### PR TITLE
Release v0.5.5-alpha — inpaint upload fix, queue-aware cancel, alignment & defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.5.5-alpha - 2026-07-11
+
+Correctness and trust release: working inpaint uploads, safe cancel, aligned inpaint context, and honest status copy.
+
+### Fixed
+
+- Fixed ComfyUI uploads losing their filenames in Photoshop UXP. UXP's FormData saved every upload as a file named `blob`, so the Inpaint mask upload overwrote the source upload and both LoadImage nodes read the mask. Uploads now build the multipart body manually with an explicit filename per file, and inpaint-basic composites over the real captured source again.
+- Fixed the Photoshop "Make is not currently available" alert during Inpaint Import to Layers. Photoshop's place command clears the active selection, so the layer mask import now restores a selection from the captured Inpaint bounds and falls back to aligned context import cleanly when no selection can be restored.
+- Fixed inpaint misalignment caused by ComfyUI VAE rounding: the captured inpaint context now snaps to multiples of 8 so the generated result matches the captured context size exactly.
+- Fixed multipart encoding to work without TextEncoder, which Photoshop UXP does not expose.
+
+### Added
+
+- Added per-preset recommended generation defaults. `txt2img-basic` now starts at 20 steps, and switching workflow presets applies that preset's recommended steps and CFG/guidance values.
+- Added queue-aware Cancel Generation: prompts still waiting in the ComfyUI queue are removed with a queue delete instead of interrupting whatever job is currently running, and diagnostics report whether the prompt was dequeued or interrupted.
+- Added a 16-megapixel capture guard so very large layer/canvas/mask captures fail fast with a friendly message instead of risking UXP memory failures.
+- Added the `clipboard` and `launchProcess` manifest permissions used by Copy Diagnostics, Copy Prompt, and the footer links.
+
+### Changed
+
+- ComfyUI WebSocket preview frames are now received as arraybuffer for UXP reliability. Live KSampler step previews appear in the result preview when ComfyUI is started with `--preview-method auto`.
+- The Outpaint and Sketch to Image tool cards now show the Experimental badge to match their preset status, and Z_image_Turbo warnings plus the hardware advisor no longer claim those presets are disabled.
+- Bumped plugin/package metadata to `0.5.5`.
+
+### Known limitations
+
+- Live sampler previews require ComfyUI to be started with `--preview-method auto`, and the preview panel may flicker between steps until the planned UI polish pass.
+- Capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+
 ## v0.5.3-alpha - 2026-07-05
 
 Release checkpoint for the current public alpha package and landing page.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.5.3-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows, compact Photoshop-style panel, workflow diagnostics, cancellation safety, and AI layer metadata foundation, not for production work yet.
+`v0.5.5-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows, compact Photoshop-style panel, workflow diagnostics, cancellation safety, and AI layer metadata foundation, not for production work yet.
+
+New in `v0.5.5-alpha`:
+
+- Fixed ComfyUI uploads losing filenames in UXP, which made the Inpaint mask overwrite the Inpaint source. inpaint-basic now composites over the real captured source.
+- Fixed the Photoshop "Make is not currently available" alert during Inpaint import by restoring the selection before the layer mask step.
+- Inpaint context capture now snaps to multiples of 8 so results align with the document again.
+- Cancel Generation is queue-aware: pending prompts are dequeued instead of interrupting another running job on a shared ComfyUI server.
+- Switching workflow presets applies per-preset recommended steps and CFG defaults, and `txt2img-basic` starts at 20 steps.
+- Live KSampler step previews render in the result preview when ComfyUI is started with `--preview-method auto`.
+- Very large captures fail fast at the new 16-megapixel capture limit instead of risking UXP memory failures.
 
 Included in this alpha:
 
@@ -60,15 +70,17 @@ Included in this alpha:
 
 ![OpenLayer Home dashboard](docs/assets/openlayer-v021-dashboard.png)
 
-v0.5.3-alpha tester focus:
+v0.5.5-alpha tester focus:
 
 - Confirm Text to Image, Image to Image, Z_image_Turbo, and experimental Flux1-dev fp8 Text to Image generation.
 - Confirm Prompt from Layer with the local Florence-2 PromptGen workflow.
 - Confirm Upscale with a local pixel/model upscale model such as `4x-UltraSharp.pth`.
 - Confirm Workflow Health, Cancel Generation, session History metadata, and Reuse Settings.
 - Test Flux Fill Inpaint and Flux Fill Outpaint as experimental workflows only.
+- Confirm inpaint-basic and Flux Fill Inpaint after the v0.5.5 upload filename and alignment fixes, including Import to Layers.
+- Confirm Cancel Generation on both a running prompt and a queued prompt when ComfyUI is busy.
 
-Known v0.5.3-alpha boundaries:
+Known v0.5.5-alpha boundaries:
 
 - Image to Image is an early foundation path, not a full production workflow yet.
 - Sketch to Image is limited to the first SD 1.x LINECN starter workflow.
@@ -91,7 +103,9 @@ Known v0.5.3-alpha boundaries:
 - Outpaint is experimental and currently uses `outpaint-flux-fill-basic` with `flux1-fill-dev.safetensors`, `clip_l.safetensors`, `t5xxl_fp16.safetensors` or the accepted T5 fp8 fallback, and `ae.safetensors`.
 - Upscale currently uses a simple pixel/model upscale path. It does not use prompts, latent upscale, tiled diffusion, or creative enhancement.
 - Upscale needs ComfyUI's `UpscaleModelLoader` and `ImageUpscaleWithModel` nodes plus an installed upscale model such as `4x-UltraSharp.pth` or `RealESRGAN_x4plus.pth`.
-- The v0.5.3 release checkpoint does not change ComfyUI workflow behavior, model loading, generation, import, Inpaint, Outpaint, or UI design.
+- The v0.5.5 release focuses on correctness: upload filenames, queue-aware cancel, inpaint context alignment, capture size guarding, and per-preset defaults. The UI design is unchanged.
+- Layer, canvas, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
+- Live sampler previews require ComfyUI to be started with `--preview-method auto`, and the preview panel may flicker between steps until a future UI polish pass.
 - Classic v0.4 theme preserves the older visual feel, but it does not duplicate every old layout detail.
 - SDXL, SD3, Flux, and Z_image_Turbo Sketch to Image workflows need dedicated future presets.
 - Workflow node IDs may need adjustment for custom ComfyUI workflows.
@@ -219,7 +233,7 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.5.3-alpha.zip
+packages/openlayer-v0.5.5-alpha.zip
 ```
 
 ## Loading In UXP Developer Tool
@@ -249,8 +263,10 @@ OpenLayer uses port `8190` by default so it does not interfere with another plug
 If your other plugin is already using ComfyUI on `8188`, start a second ComfyUI instance for OpenLayer on `8190`, for example:
 
 ```bash
-python main.py --listen 127.0.0.1 --port 8190
+python main.py --listen 127.0.0.1 --port 8190 --preview-method auto
 ```
+
+`--preview-method auto` is optional but recommended: it makes ComfyUI stream live KSampler step previews into the OpenLayer result preview while generating.
 
 Click `Check ComfyUI` before generating.
 
@@ -344,7 +360,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.5.3-alpha test result:
+Use this quick pass before reporting a v0.5.5-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,11 +6,11 @@
     <title>OpenLayer - Open Source Photoshop ComfyUI Plugin</title>
     <meta
       name="description"
-      content="OpenLayer v0.5.3-alpha is an open-source Photoshop UXP plugin for local ComfyUI workflows, including text-to-image, image-to-image, Z_image_Turbo, Flux txt2img testing, Prompt from Layer, Upscale, Workflow Health, Cancel Generation, History metadata, and experimental Flux Inpaint and Outpaint testing."
+      content="OpenLayer v0.5.5-alpha is an open-source Photoshop UXP plugin for local ComfyUI workflows, including text-to-image, image-to-image, Z_image_Turbo, Flux txt2img testing, Prompt from Layer, Upscale, Workflow Health, Cancel Generation, History metadata, and experimental Flux Inpaint and Outpaint testing."
     >
     <meta name="theme-color" content="#2b2b2b">
     <meta property="og:title" content="OpenLayer - Open Source Photoshop ComfyUI Plugin">
-    <meta property="og:description" content="OpenLayer v0.5.3-alpha is an open-source Photoshop UXP plugin for local ComfyUI text-to-image, image-to-image, Z_image_Turbo, Flux txt2img testing, Prompt from Layer, Upscale, diagnostics, Cancel Generation, History metadata, and experimental layer workflows.">
+    <meta property="og:description" content="OpenLayer v0.5.5-alpha is an open-source Photoshop UXP plugin for local ComfyUI text-to-image, image-to-image, Z_image_Turbo, Flux txt2img testing, Prompt from Layer, Upscale, diagnostics, Cancel Generation, History metadata, and experimental layer workflows.">
     <meta property="og:image" content="assets/openlayer-photoshop-mvp.png">
     <meta property="og:type" content="website">
     <link rel="icon" href="assets/openlayer-icon.png">
@@ -37,7 +37,7 @@
         <div class="hero-content">
           <div class="hero-mark">
             <img src="assets/openlayer-icon.png" alt="" width="72" height="72">
-            <span>Alpha v0.5.3</span>
+            <span>Alpha v0.5.5</span>
           </div>
           <h1 id="hero-title">OpenLayer - Open Source Photoshop ComfyUI Plugin</h1>
           <p class="hero-lede">
@@ -49,7 +49,7 @@
             and experimental Flux Inpaint and Outpaint testing.
           </p>
           <p class="alpha-note">
-            Current release: <strong>v0.5.3-alpha</strong>. Built for testing, not production work yet.
+            Current release: <strong>v0.5.5-alpha</strong>. Built for testing, not production work yet.
           </p>
           <div class="hero-actions">
             <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer">View on GitHub</a>
@@ -263,7 +263,7 @@ npm run build</code></pre>
           <div class="status-grid">
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.5.3-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.5.5-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
@@ -311,7 +311,7 @@ npm run build</code></pre>
             <li>Prompt from Layer requires the local Florence-2 PromptGen model plus text-output custom nodes.</li>
             <li>Outpaint is experimental and should be tested on duplicate layers first.</li>
             <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-            <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.5.3 keeps the shared metadata foundation and session-history wiring.</li>
+            <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.5.5 keeps the shared metadata foundation and session-history wiring.</li>
             <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
             <li>The browser dev server is only for UI preview. Photoshop APIs run inside UXP.</li>
             <li>Responsive panel spacing has been improved for testing, but final visual polish is still in progress.</li>
@@ -383,7 +383,7 @@ npm run build</code></pre>
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.5.3-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.5.5-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a>
       </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.5.3",
+  "version": "0.5.5",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/comfy/comfyClient.ts
+++ b/src/comfy/comfyClient.ts
@@ -26,6 +26,7 @@ import {
   GenerationCancelResult
 } from "./generationCancel";
 import { createOpenLayerError, getNestedErrorMessage } from "../utils/errors";
+import { createMultipartBoundary, createMultipartRequestBody } from "../utils/multipart";
 
 const MODEL_INVENTORY_SOURCES = {
   checkpoints: [
@@ -304,14 +305,32 @@ export class ComfyClient {
       throw createOpenLayerError("COMFY_UPLOAD_FAILED", "The source image is empty.");
     }
 
-    const formData = new FormData();
-    formData.append("image", blob, fileName);
-    formData.append("type", "input");
-    formData.append("overwrite", "true");
+    // UXP's FormData drops the filename on Blob parts, so ComfyUI saved every
+    // upload as "blob" and a second upload in the same run overwrote the first.
+    // Building the multipart body manually keeps each upload's unique filename.
+    const boundary = createMultipartBoundary();
+    const body = createMultipartRequestBody(
+      boundary,
+      [
+        {
+          name: "image",
+          filename: fileName,
+          contentType: blob.type || "image/png",
+          data: new Uint8Array(await blob.arrayBuffer())
+        }
+      ],
+      [
+        { name: "type", value: "input" },
+        { name: "overwrite", value: "true" }
+      ]
+    );
 
     const response = await fetch(`${this.serverUrl}/upload/image`, {
       method: "POST",
-      body: formData
+      headers: {
+        "Content-Type": `multipart/form-data; boundary=${boundary}`
+      },
+      body: toRequestArrayBuffer(body)
     });
 
     if (!response.ok) {
@@ -330,7 +349,7 @@ export class ComfyClient {
       throw createOpenLayerError("COMFY_UPLOAD_FAILED", "ComfyUI did not return an uploaded image name.");
     }
 
-    return uploadedName;
+    return data.subfolder ? `${data.subfolder}/${uploadedName}` : uploadedName;
   }
 
   async submitPrompt(workflow: ComfyWorkflow): Promise<string> {
@@ -953,6 +972,10 @@ function readOutputText(value: unknown): string | null {
 
 function delay(ms: number) {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function toRequestArrayBuffer(bytes: Uint8Array) {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
 async function readResponseText(response: Response) {

--- a/src/comfy/comfyClient.ts
+++ b/src/comfy/comfyClient.ts
@@ -607,7 +607,9 @@ export class ComfyClient {
 
     try {
       socket = new WebSocket(this.createWebSocketUrl());
-      socket.binaryType = "blob";
+      // UXP WebSocket binary support is most reliable with arraybuffer, and
+      // handleProgressMessage accepts both ArrayBuffer and Blob frames.
+      socket.binaryType = "arraybuffer";
     } catch (caughtError) {
       options.onError?.(
         `Could not open ComfyUI progress stream. Continuing with history polling. ${getNestedErrorMessage(caughtError)}`

--- a/src/comfy/comfyClient.ts
+++ b/src/comfy/comfyClient.ts
@@ -21,7 +21,9 @@ import {
 } from "./workflowModelRequirements";
 import {
   createComfyInterruptRequest,
-  createGenerationCancelledError
+  createComfyQueueDeleteRequest,
+  createGenerationCancelledError,
+  GenerationCancelResult
 } from "./generationCancel";
 import { createOpenLayerError, getNestedErrorMessage } from "../utils/errors";
 
@@ -378,6 +380,47 @@ export class ComfyClient {
       throw createOpenLayerError(
         "COMFY_HTTP",
         `ComfyUI interrupt failed with HTTP ${response.status}.`,
+        message
+      );
+    }
+  }
+
+  async cancelPrompt(promptId?: string): Promise<GenerationCancelResult> {
+    if (!promptId) {
+      await this.interruptGeneration();
+      return "interrupted";
+    }
+
+    let queue: ComfyQueueResponse | null = null;
+
+    try {
+      queue = await this.getQueue();
+    } catch {
+      // Queue inspection is best-effort; interrupt below still cancels a running prompt.
+    }
+
+    if (queue && findPromptIndex(queue.queue_pending, promptId) >= 0) {
+      try {
+        await this.deleteQueuedPrompt(promptId);
+        return "dequeued";
+      } catch {
+        // ComfyUI may have started the prompt between the queue read and the delete.
+      }
+    }
+
+    await this.interruptGeneration();
+    return "interrupted";
+  }
+
+  private async deleteQueuedPrompt(promptId: string) {
+    const request = createComfyQueueDeleteRequest(this.serverUrl, promptId);
+    const response = await fetch(request.url, request.init);
+
+    if (!response.ok) {
+      const message = await readResponseText(response);
+      throw createOpenLayerError(
+        "COMFY_HTTP",
+        `ComfyUI queue delete failed with HTTP ${response.status}.`,
         message
       );
     }
@@ -920,12 +963,25 @@ async function readResponseText(response: Response) {
   }
 }
 
-function findPromptIndex(entries: unknown[] | undefined, promptId: string) {
+export function findPromptIndex(entries: unknown[] | undefined, promptId: string) {
   if (!Array.isArray(entries)) {
     return -1;
   }
 
-  return entries.findIndex((entry) => JSON.stringify(entry).includes(promptId));
+  return entries.findIndex((entry) => {
+    const entryPromptId = readQueueEntryPromptId(entry);
+
+    if (entryPromptId !== null) {
+      return entryPromptId === promptId;
+    }
+
+    return JSON.stringify(entry).includes(promptId);
+  });
+}
+
+function readQueueEntryPromptId(entry: unknown) {
+  // ComfyUI queue entries are tuples shaped like [number, prompt_id, prompt, extra, outputs].
+  return Array.isArray(entry) && typeof entry[1] === "string" ? entry[1] : null;
 }
 
 type ProgressJsonMessage = {

--- a/src/comfy/generationCancel.ts
+++ b/src/comfy/generationCancel.ts
@@ -1,12 +1,28 @@
 import { createOpenLayerError, OpenLayerError } from "../utils/errors";
 
 export const COMFY_INTERRUPT_PATH = "/interrupt";
+export const COMFY_QUEUE_PATH = "/queue";
+
+export type GenerationCancelResult = "dequeued" | "interrupted";
 
 export function createComfyInterruptRequest(serverUrl: string) {
   return {
     url: `${normalizeServerUrl(serverUrl)}${COMFY_INTERRUPT_PATH}`,
     init: {
       method: "POST"
+    } as RequestInit
+  };
+}
+
+export function createComfyQueueDeleteRequest(serverUrl: string, promptId: string) {
+  return {
+    url: `${normalizeServerUrl(serverUrl)}${COMFY_QUEUE_PATH}`,
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ delete: [promptId] })
     } as RequestInit
   };
 }
@@ -27,6 +43,14 @@ export function formatCancelDiagnostic(promptId?: string) {
   return promptId
     ? `Cancel requested for ComfyUI prompt ${promptId}.`
     : "Cancel requested before ComfyUI returned a prompt ID.";
+}
+
+export function formatCancelResultDiagnostic(result: GenerationCancelResult, promptId?: string) {
+  const base = formatCancelDiagnostic(promptId);
+
+  return result === "dequeued"
+    ? `${base} The pending prompt was removed from the ComfyUI queue.`
+    : `${base} ComfyUI interrupted the running prompt.`;
 }
 
 function normalizeServerUrl(serverUrl: string) {

--- a/src/comfy/hardwareAdvisor.ts
+++ b/src/comfy/hardwareAdvisor.ts
@@ -246,7 +246,7 @@ function getZImageTurboMessage(inventory: ComfyModelInventory) {
   const hasVae = inventory.vaeModels.some((name) => name.toLowerCase().includes("ae.safetensors"));
 
   if (hasModel && hasClip && hasVae) {
-    return "Z_image_Turbo stack detected: diffusion model, qwen_3_4b CLIP, and ae.safetensors VAE are available. It still needs a dedicated OpenLayer workflow JSON before generation is enabled.";
+    return "Z_image_Turbo stack detected: diffusion model, qwen_3_4b CLIP, and ae.safetensors VAE are available. The experimental Z_image_Turbo Text to Image and Image to Image presets can use this stack.";
   }
 
   if (hasModel) {

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -666,6 +666,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     workflowFile: "workflows/api/txt2img-basic.json",
     sourceWorkflowFile: "workflows/source/txt2img-basic.workflow.json",
     status: "stable",
+    recommendedSettings: { steps: 20, cfg: 7 },
     supportedModelFamilies: ["sd1", "sdxl", "unknown"],
     experimentalModelFamilies: ["sd3", "flux", "zImage"],
     modelSource: CHECKPOINT_MODEL_SOURCE,
@@ -713,6 +714,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     workflowFile: "workflows/api/txt2img-flux1-dev-fp8.json",
     sourceWorkflowFile: "workflows/source/txt2img-flux1-dev-fp8.workflow.json",
     status: "experimental",
+    recommendedSettings: { steps: 20, cfg: 3.5 },
     supportedModelFamilies: ["flux"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "zImage", "unknown"],
     modelSource: CHECKPOINT_MODEL_SOURCE,
@@ -772,6 +774,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     workflowFile: "workflows/api/img2img-basic.json",
     sourceWorkflowFile: "workflows/source/img2img-basic.workflow.json",
     status: "stable",
+    recommendedSettings: { steps: 20, cfg: 7 },
     supportedModelFamilies: ["sd1", "sdxl", "unknown"],
     experimentalModelFamilies: ["sd3", "flux", "zImage"],
     modelSource: CHECKPOINT_MODEL_SOURCE,
@@ -902,6 +905,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     workflowFile: "workflows/api/sketch2img-linecn-basic.json",
     sourceWorkflowFile: "workflows/source/sketch2img-linecn-basic.workflow.json",
     status: "experimental",
+    recommendedSettings: { steps: 16, cfg: 7 },
     supportedModelFamilies: ["sd1"],
     experimentalModelFamilies: ["sdxl", "sd3", "flux", "zImage"],
     modelSource: CHECKPOINT_MODEL_SOURCE,
@@ -980,6 +984,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     workflowFile: "workflows/api/inpaint-basic.json",
     sourceWorkflowFile: "workflows/source/inpaint-basic.workflow.json",
     status: "experimental",
+    recommendedSettings: { steps: 16, cfg: 7 },
     supportedModelFamilies: ["sd1"],
     experimentalModelFamilies: ["sdxl", "sd3", "flux", "zImage", "unknown"],
     modelSource: CHECKPOINT_MODEL_SOURCE,
@@ -1047,6 +1052,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental Flux Fill inpainting workflow using a diffusion model stack.",
     workflowFile: "workflows/api/inpaint-flux-fill-basic.json",
     status: "experimental",
+    recommendedSettings: { steps: 20, cfg: 30 },
     supportedModelFamilies: ["flux"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "zImage", "unknown"],
     modelSource: DIFFUSION_MODEL_SOURCE,
@@ -1127,6 +1133,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     workflowFile: "workflows/api/outpaint-flux-fill-basic.json",
     sourceWorkflowFile: "workflows/source/outpaint-flux-fill-basic.workflow.json",
     status: "experimental",
+    recommendedSettings: { steps: 20, cfg: 30 },
     supportedModelFamilies: ["flux"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "zImage", "unknown"],
     modelSource: DIFFUSION_MODEL_SOURCE,
@@ -1212,6 +1219,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     workflowFile: "workflows/api/txt2img-z-image-turbo.json",
     sourceWorkflowFile: "workflows/source/txt2img-z-image-turbo.workflow.json",
     status: "experimental",
+    recommendedSettings: { steps: 8, cfg: 1 },
     supportedModelFamilies: ["zImage"],
     experimentalModelFamilies: ["unknown"],
     modelSource: DIFFUSION_MODEL_SOURCE,
@@ -1282,6 +1290,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     workflowFile: "workflows/api/img2img-z-image-turbo.json",
     sourceWorkflowFile: "workflows/source/img2img-z-image-turbo.workflow.json",
     status: "experimental",
+    recommendedSettings: { steps: 8, cfg: 1 },
     supportedModelFamilies: ["zImage"],
     experimentalModelFamilies: ["unknown"],
     modelSource: DIFFUSION_MODEL_SOURCE,
@@ -1444,6 +1453,25 @@ export function getWorkflowPreset(presetId: string): WorkflowPresetDefinition {
 
 export function isWorkflowPreset(presetId: string): presetId is WorkflowPreset {
   return WORKFLOW_PRESETS.some((preset) => preset.id === presetId);
+}
+
+export type RecommendedPresetSettings = {
+  steps: number;
+  cfg: number;
+};
+
+const FALLBACK_RECOMMENDED_PRESET_SETTINGS: RecommendedPresetSettings = {
+  steps: 20,
+  cfg: 7
+};
+
+export function getRecommendedPresetSettings(presetId: string): RecommendedPresetSettings {
+  const preset = WORKFLOW_PRESETS.find((candidate) => candidate.id === presetId);
+
+  return {
+    steps: preset?.recommendedSettings?.steps ?? FALLBACK_RECOMMENDED_PRESET_SETTINGS.steps,
+    cfg: preset?.recommendedSettings?.cfg ?? FALLBACK_RECOMMENDED_PRESET_SETTINGS.cfg
+  };
 }
 
 export function getPresetInputTarget(

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -553,7 +553,7 @@ const Z_IMAGE_TURBO_TXT2IMG_CAPABILITY: WorkflowCapability = {
     showModelSelector: true,
     modelSelectorLabel: "Z_image_Turbo model",
     primaryActionLabel: "Generate",
-    warning: "Z_image_Turbo needs a validated diffusion-model-stack workflow before generation is enabled."
+    warning: "Z_image_Turbo is experimental. Confirm the diffusion model, CLIP, and VAE stack with Check Workflow Health before relying on results."
   }
 };
 
@@ -573,7 +573,7 @@ const Z_IMAGE_TURBO_IMG2IMG_CAPABILITY: WorkflowCapability = {
     showModelSelector: true,
     modelSelectorLabel: "Z_image_Turbo model",
     primaryActionLabel: "Generate Image to Image",
-    warning: "Z_image_Turbo Image to Image needs a validated source-image workflow before generation is enabled."
+    warning: "Z_image_Turbo Image to Image is experimental. Confirm the diffusion model, CLIP, and VAE stack with Check Workflow Health before relying on results."
   }
 };
 

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -249,6 +249,11 @@ export type WorkflowRequiredModel = WorkflowModelSource & {
   setupHint?: string;
 };
 
+export type WorkflowRecommendedSettings = {
+  steps?: number;
+  cfg?: number;
+};
+
 export type WorkflowPresetDefinition = {
   id: WorkflowPreset;
   label: string;
@@ -257,6 +262,7 @@ export type WorkflowPresetDefinition = {
   workflowFile: string;
   sourceWorkflowFile?: string;
   status: "stable" | "experimental" | "todo";
+  recommendedSettings?: WorkflowRecommendedSettings;
   supportedModelFamilies: ModelFamily[];
   experimentalModelFamilies: ModelFamily[];
   modelSource: WorkflowModelSource;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.openlayer.photoshop",
   "name": "OpenLayer",
-  "version": "0.5.3",
+  "version": "0.5.5",
   "main": "index.html",
   "host": [
     {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,6 +14,11 @@
     "localFileSystem": "fullAccess",
     "network": {
       "domains": "all"
+    },
+    "clipboard": "readAndWrite",
+    "launchProcess": {
+      "schemes": ["https"],
+      "extensions": []
     }
   },
   "entrypoints": [

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -77,6 +77,19 @@ const INPAINT_CONTEXT_PADDING_RATIO = 0.75;
 // non-multiple context comes back smaller than captured and breaks the
 // translate-only aligned import.
 const INPAINT_CONTEXT_MULTIPLE = 8;
+// Uncompressed PNG capture costs about 4 bytes per pixel, so very large
+// captures can exhaust UXP panel memory before the upload even starts.
+export const MAX_CAPTURE_PIXELS = 4096 * 4096;
+
+export function assertCaptureSizeWithinLimit(width: number, height: number) {
+  if (width * height > MAX_CAPTURE_PIXELS) {
+    throw createOpenLayerError(
+      "PHOTOSHOP_EXPORT_FAILED",
+      `This capture is ${Math.round(width)} x ${Math.round(height)}, which is larger than OpenLayer's current 16-megapixel capture limit. Crop the document, use a smaller layer, or make a smaller selection, then capture again.`,
+      "Uncompressed PNG capture above 4096 x 4096 risks UXP memory failures. A downscale option is planned."
+    );
+  }
+}
 
 export type ActiveDocumentInfo = {
   name: string;
@@ -1297,6 +1310,8 @@ async function encodeSourceImageDataAsPng(imageData: PhotoshopImageData) {
     throw new Error("Photoshop returned source image data without valid dimensions.");
   }
 
+  assertCaptureSizeWithinLimit(width, height);
+
   if (componentSize !== 8) {
     throw new Error(`OpenLayer expected 8-bit source pixels, but Photoshop returned ${componentSize}-bit data.`);
   }
@@ -1366,6 +1381,8 @@ async function encodeSelectionMaskImageDataAsPng(imageData: PhotoshopImageData) 
   if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(height) || height <= 0) {
     throw new Error("Photoshop returned selection mask data without valid dimensions.");
   }
+
+  assertCaptureSizeWithinLimit(width, height);
 
   if (componentSize !== 8) {
     throw new Error(`OpenLayer expected 8-bit mask pixels, but Photoshop returned ${componentSize}-bit data.`);

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -5,7 +5,8 @@ import {
   createPaddedSelectionBounds,
   normalizeSelectionBounds,
   NormalizedSelectionBounds,
-  SelectionBounds
+  SelectionBounds,
+  snapBoundsToMultiple
 } from "./selectionUtils";
 import {
   createInpaintSourceModeWarning,
@@ -72,6 +73,10 @@ type ImportProgress = (message: string) => void;
 type BatchPlayCommand = Record<string, unknown>;
 const MIN_INPAINT_CONTEXT_PADDING = 96;
 const INPAINT_CONTEXT_PADDING_RATIO = 0.75;
+// ComfyUI VAE encoding rounds image dimensions down to multiples of 8, so a
+// non-multiple context comes back smaller than captured and breaks the
+// translate-only aligned import.
+const INPAINT_CONTEXT_MULTIPLE = 8;
 
 export type ActiveDocumentInfo = {
   name: string;
@@ -585,11 +590,15 @@ function createInpaintContextBounds(
     MIN_INPAINT_CONTEXT_PADDING,
     Math.round(Math.max(selectionBounds.width, selectionBounds.height) * INPAINT_CONTEXT_PADDING_RATIO)
   );
-
-  return createPaddedSelectionBounds(selectionBounds, {
+  const paddedBounds = createPaddedSelectionBounds(selectionBounds, {
     width: documentWidth,
     height: documentHeight
   }, adaptivePadding);
+
+  return snapBoundsToMultiple(paddedBounds, {
+    width: documentWidth,
+    height: documentHeight
+  }, INPAINT_CONTEXT_MULTIPLE);
 }
 
 async function captureSelectionMaskSourceImage(

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -125,6 +125,7 @@ export type SelectedRegionSourceImage = ExportedSourceImage & {
 export type AlignedRegionalImportOptions = {
   blob: Blob;
   bounds: SelectionBounds;
+  selectionBounds?: SelectionBounds;
   layerName?: string;
   onProgress?: ImportProgress;
 };
@@ -436,9 +437,16 @@ export async function importImageAlignedToSelectionWithLayerMask(
 
         try {
           options.onProgress?.("Applying Photoshop selection as a layer mask...");
-          await createLayerMaskFromActiveSelection(photoshop);
-          maskApplied = true;
-          maskMessage = "Imported with a Photoshop layer mask from the active selection.";
+          const maskSelectionAvailable = await ensureSelectionForLayerMask(photoshop, options.selectionBounds);
+
+          if (maskSelectionAvailable) {
+            await createLayerMaskFromActiveSelection(photoshop);
+            maskApplied = true;
+            maskMessage = "Imported with a Photoshop layer mask from the active selection.";
+          } else {
+            maskMessage =
+              "Layer mask skipped because Photoshop no longer had an active selection after placing the result. Aligned context import used.";
+          }
         } catch (caughtError) {
           maskMessage = `Layer mask import fallback used. ${getErrorMessage(caughtError)}`;
         }
@@ -969,6 +977,74 @@ async function renameActiveLayer(photoshop: PhotoshopModule, layerName: string) 
         to: {
           _obj: "layer",
           name: layerName
+        },
+        _options: {
+          dialogOptions: "dontDisplay"
+        }
+      }
+    ],
+    {}
+  );
+}
+
+async function ensureSelectionForLayerMask(
+  photoshop: PhotoshopModule,
+  fallbackBounds?: SelectionBounds
+) {
+  // Photoshop's place command clears the active selection, so the original
+  // Inpaint selection is usually gone by the time the layer mask is created.
+  if (await hasActiveSelectionBounds(photoshop)) {
+    return true;
+  }
+
+  if (!fallbackBounds) {
+    return false;
+  }
+
+  await setRectangularSelection(photoshop, normalizeSelectionBounds(fallbackBounds));
+  return hasActiveSelectionBounds(photoshop);
+}
+
+async function hasActiveSelectionBounds(photoshop: PhotoshopModule) {
+  try {
+    return Boolean(readSelectionBounds(await getSelectionDescriptor(photoshop)));
+  } catch {
+    return false;
+  }
+}
+
+async function setRectangularSelection(
+  photoshop: PhotoshopModule,
+  bounds: NormalizedSelectionBounds
+) {
+  await photoshop.action.batchPlay(
+    [
+      {
+        _obj: "set",
+        _target: [
+          {
+            _ref: "channel",
+            _property: "selection"
+          }
+        ],
+        to: {
+          _obj: "rectangle",
+          top: {
+            _unit: "pixelsUnit",
+            _value: bounds.top
+          },
+          left: {
+            _unit: "pixelsUnit",
+            _value: bounds.left
+          },
+          bottom: {
+            _unit: "pixelsUnit",
+            _value: bounds.bottom
+          },
+          right: {
+            _unit: "pixelsUnit",
+            _value: bounds.right
+          }
         },
         _options: {
           dialogOptions: "dontDisplay"

--- a/src/photoshop/selectionUtils.ts
+++ b/src/photoshop/selectionUtils.ts
@@ -73,6 +73,54 @@ export function createPaddedSelectionBounds(
   });
 }
 
+export function snapBoundsToMultiple(
+  bounds: SelectionBounds,
+  documentSize: DocumentSize,
+  multiple: number
+): NormalizedSelectionBounds {
+  const selection = normalizeSelectionBounds(bounds);
+  const documentWidth = Math.round(documentSize.width);
+  const documentHeight = Math.round(documentSize.height);
+  const normalizedMultiple = Math.max(1, Math.round(multiple));
+
+  if (
+    !isFiniteNumber(documentWidth) ||
+    !isFiniteNumber(documentHeight) ||
+    documentWidth <= 0 ||
+    documentHeight <= 0
+  ) {
+    throw new Error("Document size must contain visible pixel dimensions.");
+  }
+
+  const horizontal = snapAxisToMultiple(selection.left, selection.right, documentWidth, normalizedMultiple);
+  const vertical = snapAxisToMultiple(selection.top, selection.bottom, documentHeight, normalizedMultiple);
+
+  return normalizeSelectionBounds({
+    left: horizontal.start,
+    top: vertical.start,
+    right: horizontal.end,
+    bottom: vertical.end
+  });
+}
+
+function snapAxisToMultiple(start: number, end: number, documentLength: number, multiple: number) {
+  const size = end - start;
+  const expandedSize = Math.ceil(size / multiple) * multiple;
+  const largestFit = Math.floor(documentLength / multiple) * multiple;
+  const targetSize = Math.min(expandedSize, largestFit);
+
+  if (targetSize <= 0 || targetSize === size) {
+    return { start, end };
+  }
+
+  const nextEnd = Math.min(documentLength, start + targetSize);
+
+  return {
+    start: nextEnd - targetSize,
+    end: nextEnd
+  };
+}
+
 export function formatSelectionBounds(bounds: SelectionBounds) {
   const normalized = normalizeSelectionBounds(bounds);
   return `${normalized.width} x ${normalized.height} at ${normalized.left}, ${normalized.top}`;

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -29,7 +29,12 @@ import {
   sanitizeOpenLayerLayerMetadata
 } from "../metadata/layerMetadata";
 import { getCheckpointCompatibility } from "../comfy/modelCompatibility";
-import { getWorkflowPreset, listRunnableWorkflowPresets, listWorkflowPresets } from "../comfy/presetRegistry";
+import {
+  getRecommendedPresetSettings,
+  getWorkflowPreset,
+  listRunnableWorkflowPresets,
+  listWorkflowPresets
+} from "../comfy/presetRegistry";
 import {
   validateGenerationSettings,
   validateImageToImageSettings,
@@ -108,7 +113,7 @@ const FALLBACK_UPSCALE_MODELS = ["4x-UltraSharp.pth", "RealESRGAN_x4plus.pth"];
 const RECOMMENDED_SKETCH_CHECKPOINT = "epicrealism_naturalSinRC1VAE.safetensors";
 const DEFAULT_WIDTH = "512";
 const DEFAULT_HEIGHT = "512";
-const DEFAULT_STEPS = "4";
+const DEFAULT_STEPS = "20";
 const DEFAULT_CFG = "7";
 const DEFAULT_IMG2IMG_STEPS = "12";
 const DEFAULT_IMG2IMG_DENOISE = "0.55";
@@ -759,6 +764,7 @@ export function renderApp(rootElement: HTMLElement) {
   void loadInitialCheckpoints();
 
   elements.workflow.addEventListener("change", () => {
+    applyRecommendedPresetSettings(elements.workflow, DEFAULT_WORKFLOW, elements.steps, elements.cfg);
     void refreshTextModelOptionsForSelectedPreset(elements).then(() => updateTextCheckpointCompatibility(elements));
   });
 
@@ -767,6 +773,7 @@ export function renderApp(rootElement: HTMLElement) {
   });
 
   elements.imgWorkflow.addEventListener("change", () => {
+    applyRecommendedPresetSettings(elements.imgWorkflow, DEFAULT_IMAGE_WORKFLOW, elements.imgSteps, elements.imgCfg);
     void refreshImageModelOptionsForSelectedPreset(elements).then(() => (
       updateImageCheckpointCompatibility(elements, allowExperimentalCheckpoints, imageSource)
     ));
@@ -777,6 +784,7 @@ export function renderApp(rootElement: HTMLElement) {
   });
 
   elements.sketchWorkflow.addEventListener("change", () => {
+    applyRecommendedPresetSettings(elements.sketchWorkflow, DEFAULT_SKETCH_WORKFLOW, elements.sketchSteps, elements.sketchCfg);
     updateSketchCheckpointCompatibility(elements, sketchSource);
   });
 
@@ -785,6 +793,7 @@ export function renderApp(rootElement: HTMLElement) {
   });
 
   elements.inpaintWorkflow.addEventListener("change", () => {
+    applyRecommendedPresetSettings(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW, elements.inpaintSteps, elements.inpaintCfg);
     void refreshInpaintModelOptionsForSelectedPreset(elements);
     updateInpaintCheckpointCompatibility(elements, inpaintSource);
   });
@@ -794,6 +803,7 @@ export function renderApp(rootElement: HTMLElement) {
   });
 
   elements.outpaintWorkflow.addEventListener("change", () => {
+    applyRecommendedPresetSettings(elements.outpaintWorkflow, DEFAULT_OUTPAINT_WORKFLOW, elements.outpaintSteps, elements.outpaintGuidance);
     void refreshOutpaintModelOptionsForSelectedPreset(elements);
     updateOutpaintCheckpointCompatibility(elements, outpaintSource);
   });
@@ -6567,6 +6577,18 @@ function readSelectValue(select: HTMLSelectElement, fallback = "") {
   const optionValue = option?.value?.trim() || option?.textContent?.trim() || "";
 
   return optionValue || fallback;
+}
+
+function applyRecommendedPresetSettings(
+  workflowSelect: HTMLSelectElement,
+  defaultPresetId: string,
+  stepsInput: HTMLInputElement,
+  cfgInput: HTMLInputElement
+) {
+  const recommended = getRecommendedPresetSettings(readSelectValue(workflowSelect, defaultPresetId));
+
+  stepsInput.value = String(recommended.steps);
+  cfgInput.value = String(recommended.cfg);
 }
 
 function setSelectValueIfPresent(select: HTMLSelectElement, value: string) {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -225,7 +225,7 @@ const TOOL_CARDS: ToolCard[] = [
     title: "Outpaint",
     subtitle: "Extend canvas content beyond edges",
     icon: "expand",
-    status: "available",
+    status: "experimental",
     view: "outpaint"
   },
   {
@@ -233,7 +233,7 @@ const TOOL_CARDS: ToolCard[] = [
     title: "Sketch to Image",
     subtitle: "Guide generation with lineart",
     icon: "lineart",
-    status: "available",
+    status: "experimental",
     view: "sketch-to-image"
   },
   {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -98,7 +98,7 @@ import {
 } from "./historyMetadata";
 
 const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-const APP_VERSION = "0.5.3";
+const APP_VERSION = "0.5.5";
 const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 const HISTORY_LIMIT = 5;
 const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -3050,6 +3050,7 @@ export function renderApp(rootElement: HTMLElement) {
       const importResult = await importImageAlignedToSelectionWithLayerMask({
         blob: inpaintResult.blob,
         bounds: inpaintSource.selection.contextBounds,
+        selectionBounds: inpaintSource.selection.bounds,
         layerName,
         onProgress: (message) => {
           setInpaintStatus(elements, message, "idle");

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -12,6 +12,7 @@ import { createFluxFillEmbeddedMaskSource } from "../comfy/fluxFillMaskBridge";
 import { formatFluxFillReferenceDefaults } from "../comfy/fluxFillDefaults";
 import {
   formatCancelDiagnostic,
+  formatCancelResultDiagnostic,
   isGenerationCancelledError
 } from "../comfy/generationCancel";
 import {
@@ -1214,8 +1215,11 @@ export function renderApp(rootElement: HTMLElement) {
     setCancelGenerationVisible(elements, false);
 
     try {
-      await generation.client.interruptGeneration();
-      setGenerationToolDiagnostics(generation.toolType, formatCancelDiagnostic(generation.promptId));
+      const cancelResult = await generation.client.cancelPrompt(generation.promptId);
+      setGenerationToolDiagnostics(
+        generation.toolType,
+        formatCancelResultDiagnostic(cancelResult, generation.promptId)
+      );
     } catch (caughtError) {
       setGenerationToolDiagnostics(
         generation.toolType,

--- a/src/utils/multipart.ts
+++ b/src/utils/multipart.ts
@@ -21,12 +21,11 @@ export function createMultipartRequestBody(
   files: readonly MultipartFilePart[],
   fields: readonly MultipartField[]
 ): Uint8Array {
-  const encoder = new TextEncoder();
   const parts: Uint8Array[] = [];
 
   for (const field of fields) {
     parts.push(
-      encoder.encode(
+      encodeUtf8(
         `--${boundary}${CRLF}` +
           `Content-Disposition: form-data; name="${sanitizeMultipartToken(field.name)}"${CRLF}${CRLF}` +
           `${field.value}${CRLF}`
@@ -36,19 +35,50 @@ export function createMultipartRequestBody(
 
   for (const file of files) {
     parts.push(
-      encoder.encode(
+      encodeUtf8(
         `--${boundary}${CRLF}` +
           `Content-Disposition: form-data; name="${sanitizeMultipartToken(file.name)}"; filename="${sanitizeMultipartToken(file.filename)}"${CRLF}` +
           `Content-Type: ${sanitizeMultipartToken(file.contentType)}${CRLF}${CRLF}`
       )
     );
     parts.push(file.data);
-    parts.push(encoder.encode(CRLF));
+    parts.push(encodeUtf8(CRLF));
   }
 
-  parts.push(encoder.encode(`--${boundary}--${CRLF}`));
+  parts.push(encodeUtf8(`--${boundary}--${CRLF}`));
 
   return concatBytes(parts);
+}
+
+// Photoshop's UXP environment does not expose TextEncoder, so multipart
+// header text is UTF-8 encoded manually.
+export function encodeUtf8(text: string): Uint8Array {
+  const bytes: number[] = [];
+
+  for (const character of text) {
+    const codePoint = character.codePointAt(0) ?? 0;
+
+    if (codePoint <= 0x7f) {
+      bytes.push(codePoint);
+    } else if (codePoint <= 0x7ff) {
+      bytes.push(0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f));
+    } else if (codePoint <= 0xffff) {
+      bytes.push(
+        0xe0 | (codePoint >> 12),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f)
+      );
+    } else {
+      bytes.push(
+        0xf0 | (codePoint >> 18),
+        0x80 | ((codePoint >> 12) & 0x3f),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f)
+      );
+    }
+  }
+
+  return new Uint8Array(bytes);
 }
 
 export function sanitizeMultipartToken(value: string) {

--- a/src/utils/multipart.ts
+++ b/src/utils/multipart.ts
@@ -1,0 +1,69 @@
+const CRLF = "\r\n";
+
+export type MultipartField = {
+  name: string;
+  value: string;
+};
+
+export type MultipartFilePart = {
+  name: string;
+  filename: string;
+  contentType: string;
+  data: Uint8Array;
+};
+
+export function createMultipartBoundary() {
+  return `----OpenLayerFormBoundary${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`;
+}
+
+export function createMultipartRequestBody(
+  boundary: string,
+  files: readonly MultipartFilePart[],
+  fields: readonly MultipartField[]
+): Uint8Array {
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+
+  for (const field of fields) {
+    parts.push(
+      encoder.encode(
+        `--${boundary}${CRLF}` +
+          `Content-Disposition: form-data; name="${sanitizeMultipartToken(field.name)}"${CRLF}${CRLF}` +
+          `${field.value}${CRLF}`
+      )
+    );
+  }
+
+  for (const file of files) {
+    parts.push(
+      encoder.encode(
+        `--${boundary}${CRLF}` +
+          `Content-Disposition: form-data; name="${sanitizeMultipartToken(file.name)}"; filename="${sanitizeMultipartToken(file.filename)}"${CRLF}` +
+          `Content-Type: ${sanitizeMultipartToken(file.contentType)}${CRLF}${CRLF}`
+      )
+    );
+    parts.push(file.data);
+    parts.push(encoder.encode(CRLF));
+  }
+
+  parts.push(encoder.encode(`--${boundary}--${CRLF}`));
+
+  return concatBytes(parts);
+}
+
+export function sanitizeMultipartToken(value: string) {
+  return value.replace(/[\r\n"]/g, "_");
+}
+
+function concatBytes(parts: readonly Uint8Array[]) {
+  const length = parts.reduce((total, part) => total + part.byteLength, 0);
+  const output = new Uint8Array(length);
+  let offset = 0;
+
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.byteLength;
+  }
+
+  return output;
+}

--- a/tests/comfy/comfyClient.test.ts
+++ b/tests/comfy/comfyClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { findImageOutput, readComfyModelNameList } from "../../src/comfy/comfyClient";
+import { findImageOutput, findPromptIndex, readComfyModelNameList } from "../../src/comfy/comfyClient";
 
 describe("ComfyClient output selection", () => {
   it("uses the preferred SaveImage node instead of the first history image", () => {
@@ -48,6 +48,34 @@ describe("ComfyClient output selection", () => {
     );
 
     expect(image).toBeNull();
+  });
+});
+
+describe("ComfyClient queue prompt matching", () => {
+  it("matches queue entries by the prompt id tuple field", () => {
+    const entries = [
+      [0, "prompt-aaa", {}, {}, []],
+      [1, "prompt-bbb", {}, {}, []]
+    ];
+
+    expect(findPromptIndex(entries, "prompt-bbb")).toBe(1);
+    expect(findPromptIndex(entries, "prompt-zzz")).toBe(-1);
+  });
+
+  it("does not match a prompt id that only appears inside another entry's payload", () => {
+    const entries = [
+      [0, "prompt-aaa", { previousPromptId: "prompt-bbb" }, {}, []],
+      [1, "prompt-bbb", {}, {}, []]
+    ];
+
+    expect(findPromptIndex(entries, "prompt-bbb")).toBe(1);
+  });
+
+  it("falls back to substring matching for unknown queue entry shapes", () => {
+    const entries = [{ prompt_id: "prompt-ccc" }];
+
+    expect(findPromptIndex(entries, "prompt-ccc")).toBe(0);
+    expect(findPromptIndex(undefined, "prompt-ccc")).toBe(-1);
   });
 });
 

--- a/tests/comfy/comfyClient.test.ts
+++ b/tests/comfy/comfyClient.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { findImageOutput, findPromptIndex, readComfyModelNameList } from "../../src/comfy/comfyClient";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ComfyClient, findImageOutput, findPromptIndex, readComfyModelNameList } from "../../src/comfy/comfyClient";
 
 describe("ComfyClient output selection", () => {
   it("uses the preferred SaveImage node instead of the first history image", () => {
@@ -48,6 +48,59 @@ describe("ComfyClient output selection", () => {
     );
 
     expect(image).toBeNull();
+  });
+});
+
+describe("ComfyClient image upload", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uploads with an explicit multipart filename instead of relying on FormData", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+
+    vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+      capturedUrl = String(url);
+      capturedInit = init;
+      return new Response(JSON.stringify({ name: "OpenLayer_Inpaint_Source_20260711_0136.png" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    });
+
+    const client = new ComfyClient("http://127.0.0.1:8190");
+    const uploadedName = await client.uploadImage(
+      new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" }),
+      "OpenLayer_Inpaint_Source_20260711_0136.png"
+    );
+
+    expect(uploadedName).toBe("OpenLayer_Inpaint_Source_20260711_0136.png");
+    expect(capturedUrl).toBe("http://127.0.0.1:8190/upload/image");
+
+    const contentType = (capturedInit?.headers as Record<string, string>)["Content-Type"];
+    expect(contentType).toContain("multipart/form-data; boundary=");
+
+    const bodyText = new TextDecoder("latin1").decode(capturedInit?.body as ArrayBuffer);
+    expect(bodyText).toContain('filename="OpenLayer_Inpaint_Source_20260711_0136.png"');
+    expect(bodyText).toContain('name="overwrite"\r\n\r\ntrue');
+  });
+
+  it("prefixes the returned name with the server-reported subfolder", async () => {
+    vi.stubGlobal("fetch", async () =>
+      new Response(JSON.stringify({ name: "source.png", subfolder: "openlayer" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+
+    const client = new ComfyClient("http://127.0.0.1:8190");
+    const uploadedName = await client.uploadImage(
+      new Blob([new Uint8Array([1])], { type: "image/png" }),
+      "source.png"
+    );
+
+    expect(uploadedName).toBe("openlayer/source.png");
   });
 });
 

--- a/tests/comfy/generationCancel.test.ts
+++ b/tests/comfy/generationCancel.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   createComfyInterruptRequest,
+  createComfyQueueDeleteRequest,
   createGenerationCancelledError,
   formatCancelDiagnostic,
+  formatCancelResultDiagnostic,
   isGenerationCancelledError
 } from "../../src/comfy/generationCancel";
 
@@ -24,5 +26,24 @@ describe("generationCancel", () => {
   it("formats prompt-aware cancellation diagnostics", () => {
     expect(formatCancelDiagnostic("abc-123")).toContain("abc-123");
     expect(formatCancelDiagnostic()).toContain("before ComfyUI returned");
+  });
+
+  it("creates a ComfyUI queue delete request for a pending prompt", () => {
+    const request = createComfyQueueDeleteRequest("http://127.0.0.1:8190/", "abc-123");
+
+    expect(request.url).toBe("http://127.0.0.1:8190/queue");
+    expect(request.init.method).toBe("POST");
+    expect(request.init.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(String(request.init.body))).toEqual({ delete: ["abc-123"] });
+  });
+
+  it("formats cancel result diagnostics for dequeued and interrupted prompts", () => {
+    const dequeued = formatCancelResultDiagnostic("dequeued", "abc-123");
+    const interrupted = formatCancelResultDiagnostic("interrupted", "abc-123");
+
+    expect(dequeued).toContain("abc-123");
+    expect(dequeued).toContain("removed from the ComfyUI queue");
+    expect(interrupted).toContain("abc-123");
+    expect(interrupted).toContain("interrupted the running prompt");
   });
 });

--- a/tests/comfy/presetRegistry.test.ts
+++ b/tests/comfy/presetRegistry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getRecommendedPresetSettings,
   getWorkflowPreset,
   listRunnableWorkflowPresets,
   listWorkflowPresets,
@@ -141,6 +142,35 @@ describe("presetRegistry", () => {
     expect(preset.modelStack?.some((model) => model.modelName === "z_image_turbo_bf16.safetensors")).toBe(true);
     expect(preset.requiredModels?.some((model) => model.modelName === "qwen_3_4b.safetensors")).toBe(true);
     expect(preset.requiredNodes.some((node) => node.classType === "ModelSamplingAuraFlow")).toBe(true);
+  });
+
+  it("returns recommended generation settings within validation ranges for every runnable preset", () => {
+    for (const preset of listRunnableWorkflowPresets()) {
+      const recommended = getRecommendedPresetSettings(preset.id);
+
+      expect(Number.isInteger(recommended.steps)).toBe(true);
+      expect(recommended.steps).toBeGreaterThanOrEqual(1);
+      expect(recommended.steps).toBeLessThanOrEqual(150);
+      expect(recommended.cfg).toBeGreaterThanOrEqual(1);
+      expect(recommended.cfg).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it("returns preset-specific recommended settings for checkpoint, Flux, and turbo workflows", () => {
+    expect(getRecommendedPresetSettings("txt2img-basic")).toEqual({ steps: 20, cfg: 7 });
+    expect(getRecommendedPresetSettings("img2img-basic")).toEqual({ steps: 20, cfg: 7 });
+    expect(getRecommendedPresetSettings("txt2img-flux1-dev-fp8")).toEqual({ steps: 20, cfg: 3.5 });
+    expect(getRecommendedPresetSettings("txt2img-z-image-turbo")).toEqual({ steps: 8, cfg: 1 });
+    expect(getRecommendedPresetSettings("img2img-z-image-turbo")).toEqual({ steps: 8, cfg: 1 });
+    expect(getRecommendedPresetSettings("sketch2img-linecn-basic")).toEqual({ steps: 16, cfg: 7 });
+    expect(getRecommendedPresetSettings("inpaint-basic")).toEqual({ steps: 16, cfg: 7 });
+    expect(getRecommendedPresetSettings("inpaint-flux-fill-basic")).toEqual({ steps: 20, cfg: 30 });
+    expect(getRecommendedPresetSettings("outpaint-flux-fill-basic")).toEqual({ steps: 20, cfg: 30 });
+  });
+
+  it("falls back to safe recommended settings for unknown preset ids", () => {
+    expect(getRecommendedPresetSettings("not-a-real-preset")).toEqual({ steps: 20, cfg: 7 });
+    expect(getRecommendedPresetSettings("")).toEqual({ steps: 20, cfg: 7 });
   });
 
   it("reports missing workflow inputs with remapping guidance", () => {

--- a/tests/photoshop/captureLimit.test.ts
+++ b/tests/photoshop/captureLimit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { assertCaptureSizeWithinLimit, MAX_CAPTURE_PIXELS } from "../../src/photoshop/photoshopAdapter";
+import { OpenLayerError } from "../../src/utils/errors";
+
+describe("capture size limit", () => {
+  it("allows captures up to exactly 4096 x 4096", () => {
+    expect(() => assertCaptureSizeWithinLimit(4096, 4096)).not.toThrow();
+    expect(() => assertCaptureSizeWithinLimit(272, 328)).not.toThrow();
+    expect(MAX_CAPTURE_PIXELS).toBe(4096 * 4096);
+  });
+
+  it("rejects captures above the 16-megapixel limit with a friendly message", () => {
+    try {
+      assertCaptureSizeWithinLimit(5000, 5000);
+      throw new Error("Expected the capture size check to fail.");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OpenLayerError);
+      expect((error as OpenLayerError).code).toBe("PHOTOSHOP_EXPORT_FAILED");
+      expect((error as OpenLayerError).message).toContain("5000 x 5000");
+      expect((error as OpenLayerError).message).toContain("16-megapixel");
+    }
+  });
+
+  it("rejects wide but short captures that exceed the pixel budget", () => {
+    expect(() => assertCaptureSizeWithinLimit(20000, 1000)).toThrow("16-megapixel");
+  });
+});

--- a/tests/photoshop/selectionUtils.test.ts
+++ b/tests/photoshop/selectionUtils.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   createPaddedSelectionBounds,
   formatSelectionBounds,
-  normalizeSelectionBounds
+  normalizeSelectionBounds,
+  snapBoundsToMultiple
 } from "../../src/photoshop/selectionUtils";
 
 describe("selectionUtils", () => {
@@ -49,5 +50,111 @@ describe("selectionUtils", () => {
     expect(() => normalizeSelectionBounds({ left: 10, top: 10, right: 10, bottom: 20 })).toThrow(
       "visible rectangular area"
     );
+  });
+
+  it("snaps bounds to multiples of 8 by expanding right and bottom first", () => {
+    expect(
+      snapBoundsToMultiple(
+        { left: 10, top: 20, right: 25, bottom: 41 },
+        { width: 100, height: 120 },
+        8
+      )
+    ).toEqual({
+      left: 10,
+      top: 20,
+      right: 26,
+      bottom: 44,
+      width: 16,
+      height: 24
+    });
+  });
+
+  it("keeps bounds unchanged when they are already multiples", () => {
+    expect(
+      snapBoundsToMultiple(
+        { left: 0, top: 0, right: 64, bottom: 80 },
+        { width: 100, height: 120 },
+        8
+      )
+    ).toEqual({
+      left: 0,
+      top: 0,
+      right: 64,
+      bottom: 80,
+      width: 64,
+      height: 80
+    });
+  });
+
+  it("expands leftward and upward when the document edge blocks expansion", () => {
+    expect(
+      snapBoundsToMultiple(
+        { left: 95, top: 113, right: 100, bottom: 120 },
+        { width: 100, height: 120 },
+        8
+      )
+    ).toEqual({
+      left: 92,
+      top: 112,
+      right: 100,
+      bottom: 120,
+      width: 8,
+      height: 8
+    });
+  });
+
+  it("shrinks to the largest multiple that fits a non-multiple document", () => {
+    expect(
+      snapBoundsToMultiple(
+        { left: 0, top: 0, right: 100, bottom: 100 },
+        { width: 100, height: 100 },
+        8
+      )
+    ).toEqual({
+      left: 0,
+      top: 0,
+      right: 96,
+      bottom: 96,
+      width: 96,
+      height: 96
+    });
+  });
+
+  it("leaves bounds unchanged when the document is smaller than the multiple", () => {
+    expect(
+      snapBoundsToMultiple(
+        { left: 0, top: 0, right: 5, bottom: 6 },
+        { width: 5, height: 6 },
+        8
+      )
+    ).toEqual({
+      left: 0,
+      top: 0,
+      right: 5,
+      bottom: 6,
+      width: 5,
+      height: 6
+    });
+  });
+
+  it("always produces multiple-of-8 sizes when the document allows it", () => {
+    const documentSize = { width: 1024, height: 768 };
+    const samples = [
+      { left: 3, top: 7, right: 130, bottom: 99 },
+      { left: 500, top: 300, right: 1021, bottom: 765 },
+      { left: 0, top: 0, right: 1, bottom: 1 },
+      { left: 900, top: 700, right: 1024, bottom: 768 }
+    ];
+
+    for (const sample of samples) {
+      const snapped = snapBoundsToMultiple(sample, documentSize, 8);
+
+      expect(snapped.width % 8).toBe(0);
+      expect(snapped.height % 8).toBe(0);
+      expect(snapped.left).toBeGreaterThanOrEqual(0);
+      expect(snapped.top).toBeGreaterThanOrEqual(0);
+      expect(snapped.right).toBeLessThanOrEqual(documentSize.width);
+      expect(snapped.bottom).toBeLessThanOrEqual(documentSize.height);
+    }
   });
 });

--- a/tests/utils/multipart.test.ts
+++ b/tests/utils/multipart.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMultipartBoundary,
+  createMultipartRequestBody,
+  sanitizeMultipartToken
+} from "../../src/utils/multipart";
+
+describe("multipart", () => {
+  it("builds a multipart body with an explicit file filename and form fields", () => {
+    const boundary = "----OpenLayerTestBoundary";
+    const fileBytes = new Uint8Array([137, 80, 78, 71]);
+    const body = createMultipartRequestBody(
+      boundary,
+      [
+        {
+          name: "image",
+          filename: "OpenLayer_Inpaint_Source_20260711_0136.png",
+          contentType: "image/png",
+          data: fileBytes
+        }
+      ],
+      [
+        { name: "type", value: "input" },
+        { name: "overwrite", value: "true" }
+      ]
+    );
+    const text = new TextDecoder("latin1").decode(body);
+
+    expect(text).toContain(
+      'Content-Disposition: form-data; name="image"; filename="OpenLayer_Inpaint_Source_20260711_0136.png"'
+    );
+    expect(text).toContain("Content-Type: image/png");
+    expect(text).toContain('Content-Disposition: form-data; name="type"\r\n\r\ninput\r\n');
+    expect(text).toContain('Content-Disposition: form-data; name="overwrite"\r\n\r\ntrue\r\n');
+    expect(text.startsWith(`--${boundary}\r\n`)).toBe(true);
+    expect(text.endsWith(`--${boundary}--\r\n`)).toBe(true);
+  });
+
+  it("keeps binary file bytes intact inside the multipart body", () => {
+    const boundary = "----OpenLayerTestBoundary";
+    const fileBytes = new Uint8Array([0, 255, 13, 10, 128]);
+    const body = createMultipartRequestBody(
+      boundary,
+      [{ name: "image", filename: "a.png", contentType: "image/png", data: fileBytes }],
+      []
+    );
+
+    // latin1 maps every byte to one character, so text offsets equal byte offsets.
+    const text = new TextDecoder("latin1").decode(body);
+    const payloadStart = text.indexOf("\r\n\r\n") + 4;
+
+    expect(payloadStart).toBeGreaterThan(3);
+    expect([...body.subarray(payloadStart, payloadStart + fileBytes.length)]).toEqual([...fileBytes]);
+  });
+
+  it("sanitizes quotes and line breaks out of multipart tokens", () => {
+    expect(sanitizeMultipartToken('bad"name\r\n.png')).toBe("bad_name__.png");
+  });
+
+  it("creates unique-looking boundaries", () => {
+    const first = createMultipartBoundary();
+    const second = createMultipartBoundary();
+
+    expect(first.startsWith("----OpenLayerFormBoundary")).toBe(true);
+    expect(first).not.toBe(second);
+  });
+});

--- a/tests/utils/multipart.test.ts
+++ b/tests/utils/multipart.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createMultipartBoundary,
   createMultipartRequestBody,
+  encodeUtf8,
   sanitizeMultipartToken
 } from "../../src/utils/multipart";
 
@@ -55,6 +56,12 @@ describe("multipart", () => {
 
   it("sanitizes quotes and line breaks out of multipart tokens", () => {
     expect(sanitizeMultipartToken('bad"name\r\n.png')).toBe("bad_name__.png");
+  });
+
+  it("encodes text as UTF-8 without relying on TextEncoder", () => {
+    expect([...encodeUtf8("ab")]).toEqual([0x61, 0x62]);
+    expect([...encodeUtf8("café")]).toEqual([...new TextEncoder().encode("café")]);
+    expect([...encodeUtf8("画像🎨")]).toEqual([...new TextEncoder().encode("画像🎨")]);
   });
 
   it("creates unique-looking boundaries", () => {


### PR DESCRIPTION
# v0.5.5-alpha - 2026-07-11

Correctness and trust release: working inpaint uploads, safe cancel, aligned inpaint context, and honest status copy.

### Fixed

- Fixed ComfyUI uploads losing their filenames in Photoshop UXP. UXP's FormData saved every upload as a file named `blob`, so the Inpaint mask upload overwrote the source upload and both LoadImage nodes read the mask. Uploads now build the multipart body manually with an explicit filename per file, and inpaint-basic composites over the real captured source again.
- Fixed the Photoshop "Make is not currently available" alert during Inpaint Import to Layers. Photoshop's place command clears the active selection, so the layer mask import now restores a selection from the captured Inpaint bounds and falls back to aligned context import cleanly when no selection can be restored.
- Fixed inpaint misalignment caused by ComfyUI VAE rounding: the captured inpaint context now snaps to multiples of 8 so the generated result matches the captured context size exactly.
- Fixed multipart encoding to work without TextEncoder, which Photoshop UXP does not expose.

### Added

- Added per-preset recommended generation defaults. `txt2img-basic` now starts at 20 steps, and switching workflow presets applies that preset's recommended steps and CFG/guidance values.
- Added queue-aware Cancel Generation: prompts still waiting in the ComfyUI queue are removed with a queue delete instead of interrupting whatever job is currently running, and diagnostics report whether the prompt was dequeued or interrupted.
- Added a 16-megapixel capture guard so very large layer/canvas/mask captures fail fast with a friendly message instead of risking UXP memory failures.
- Added the `clipboard` and `launchProcess` manifest permissions used by Copy Diagnostics, Copy Prompt, and the footer links.

### Changed

- ComfyUI WebSocket preview frames are now received as arraybuffer for UXP reliability. Live KSampler step previews appear in the result preview when ComfyUI is started with `--preview-method auto`.
- The Outpaint and Sketch to Image tool cards now show the Experimental badge to match their preset status, and Z_image_Turbo warnings plus the hardware advisor no longer claim those presets are disabled.
- Bumped plugin/package metadata to `0.5.5`.

### Known limitations

- Live sampler previews require ComfyUI to be started with `--preview-method auto`, and the preview panel may flicker between steps until the planned UI polish pass.
- Capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.