### PR TITLE
Phase B1: Inpaint workflow stabilization and readiness integrity

### DIFF
--- a/src/comfy/inpaintValidation.ts
+++ b/src/comfy/inpaintValidation.ts
@@ -1,6 +1,6 @@
 import { WorkflowPreset } from "./types";
 
-export type FluxFillInpaintSourceValidationInput = {
+export type FluxFillInpaintSourceInfo = {
   presetId: WorkflowPreset | string;
   hasSourceImage: boolean;
   hasMaskImage: boolean;
@@ -11,54 +11,13 @@ export type FluxFillInpaintSourceValidationInput = {
   hasSelectionContextBounds: boolean;
 };
 
-export type FluxFillInpaintDebugInput = FluxFillInpaintSourceValidationInput & {
+export type FluxFillInpaintDebugInput = FluxFillInpaintSourceInfo & {
   selectedFluxModelName?: string;
   t5TextEncoderName?: string;
   t5FallbackName?: string;
   clipLName?: string;
   vaeName?: string;
 };
-
-export function validateFluxFillInpaintSource(input: FluxFillInpaintSourceValidationInput) {
-  if (input.presetId !== "inpaint-flux-fill-basic") {
-    return [];
-  }
-
-  const problems: string[] = [];
-
-  if (!input.hasSourceImage) {
-    problems.push("Capture a Photoshop selection source before running Flux Fill.");
-  }
-
-  if (!input.hasMaskImage) {
-    problems.push("Capture a Photoshop selection mask before running Flux Fill.");
-  }
-
-  if (!input.hasSelectionContextBounds) {
-    problems.push("Flux Fill needs the captured selection context bounds before generation.");
-  }
-
-  if (!hasKnownDimensions(input.sourceWidth, input.sourceHeight)) {
-    problems.push("Flux Fill needs known source image dimensions before generation.");
-  }
-
-  if (!hasKnownDimensions(input.maskWidth, input.maskHeight)) {
-    problems.push("Flux Fill needs known mask image dimensions before generation.");
-  }
-
-  if (
-    hasKnownDimensions(input.sourceWidth, input.sourceHeight) &&
-    hasKnownDimensions(input.maskWidth, input.maskHeight) &&
-    (Math.round(Number(input.sourceWidth)) !== Math.round(Number(input.maskWidth)) ||
-      Math.round(Number(input.sourceHeight)) !== Math.round(Number(input.maskHeight)))
-  ) {
-    problems.push(
-      `Flux Fill source and mask must match. Source is ${Math.round(Number(input.sourceWidth))} x ${Math.round(Number(input.sourceHeight))}, mask is ${Math.round(Number(input.maskWidth))} x ${Math.round(Number(input.maskHeight))}.`
-    );
-  }
-
-  return problems;
-}
 
 export function createFluxFillInpaintDebugSummary(input: FluxFillInpaintDebugInput) {
   if (input.presetId !== "inpaint-flux-fill-basic") {

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -18,7 +18,16 @@ import {
   PhotoshopDocumentIdentity,
   validateDocumentImportContext
 } from "./documentContext";
-import { formatCleanupFailures, isMaskSandwichTopmost, runCleanupTasks } from "./photoshopTransaction";
+import {
+  CleanupTask,
+  formatCleanupFailures,
+  ImportFinalizationAction,
+  ImportRecoveryAction,
+  isMaskSandwichTopmost,
+  planImportFinalization,
+  planImportRecovery,
+  runCleanupTasks
+} from "./photoshopTransaction";
 
 type PhotoshopModule = {
   app: {
@@ -567,95 +576,123 @@ export async function importImageAlignedToSelectionWithLayerMask(
           }
         }
 
-        const cleanupFailures = await runCleanupTasks([
-          ...(temporaryMaskLayerId === undefined ? [] : [{
+        // planImportFinalization owns which steps run and in what order; the
+        // handlers below own how each one talks to Photoshop. Keeping the order
+        // in one pure, tested place is what stops a future edit here from
+        // silently changing the transaction's guarantees.
+        const finalizationHandlers: Record<ImportFinalizationAction, CleanupTask> = {
+          "delete-temporary-mask-layer": {
             label: "remove temporary mask layer",
             run: async () => {
               await deleteLayerById(photoshop, temporaryMaskLayerId!, false);
               temporaryMaskLayerId = undefined;
             }
-          }]),
-          ...(temporaryBlackLayerId === undefined ? [] : [{
+          },
+          "delete-temporary-black-layer": {
             label: "remove temporary black backing layer",
             run: async () => {
               await deleteLayerById(photoshop, temporaryBlackLayerId!, false);
               temporaryBlackLayerId = undefined;
             }
-          }]),
-          ...(operationError && resultLayerId !== undefined ? [{
+          },
+          "delete-result-layer": {
             label: "remove partially imported result layer",
             run: async () => {
               await deleteLayerById(photoshop, resultLayerId!, false);
               resultLayerId = undefined;
             }
-          }] : []),
-          {
+          },
+          "restore-selection": {
             label: "restore the artist's selection",
             run: async () => {
               await restoreSelectionSnapshot(photoshop, transactionDocument, selectionSnapshot);
               selectionRestored = true;
             }
           },
-          ...(selectionSnapshot.channel ? [{
+          "delete-selection-snapshot-channel": {
             label: "remove selection snapshot channel",
             run: async () => {
               if (!selectionRestored) throw new Error("Selection was not restored; snapshot channel retained for recovery.");
               await removeSelectionSnapshotChannel(selectionSnapshot);
               selectionSnapshotRemoved = true;
             }
-          }] : []),
-          {
+          },
+          "restore-channel-targeting": {
             label: "restore channel targeting",
             run: () => restoreActiveChannels(transactionDocument, selectionSnapshot)
           },
-          ...(!operationError && resultLayerId !== undefined ? [{
+          "select-result-layer": {
             label: "activate imported result layer",
             run: () => selectLayerById(photoshop, resultLayerId!, false)
-          }] : []),
-          ...(operationError && previousLayerId !== undefined ? [{
+          },
+          "restore-previous-layer": {
             label: "restore previously active layer",
-            run: () => selectLayerById(photoshop, previousLayerId, false)
-          }] : [])
-        ]);
+            run: () => selectLayerById(photoshop, previousLayerId!, false)
+          }
+        };
+
+        const cleanupFailures = await runCleanupTasks(
+          planImportFinalization(
+            {
+              resultLayerCreated: resultLayerId !== undefined,
+              temporaryMaskLayerCreated: temporaryMaskLayerId !== undefined,
+              temporaryBlackLayerCreated: temporaryBlackLayerId !== undefined,
+              selectionSnapshotChannelCreated: Boolean(selectionSnapshot.channel),
+              previousLayerAvailable: previousLayerId !== undefined
+            },
+            operationError ? "failure" : "success"
+          ).map((action) => finalizationHandlers[action])
+        );
 
         let recoveryFailures: Awaited<ReturnType<typeof runCleanupTasks>> = [];
         if (cleanupFailures.length > 0) {
-          recoveryFailures = await runCleanupTasks([
-            ...(temporaryMaskLayerId === undefined ? [] : [{
+          const recoveryHandlers: Record<ImportRecoveryAction, CleanupTask> = {
+            "retry-delete-temporary-mask-layer": {
               label: "retry temporary mask layer removal",
               run: () => deleteLayerById(photoshop, temporaryMaskLayerId!, false)
-            }]),
-            ...(temporaryBlackLayerId === undefined ? [] : [{
+            },
+            "retry-delete-temporary-black-layer": {
               label: "retry temporary black layer removal",
               run: () => deleteLayerById(photoshop, temporaryBlackLayerId!, false)
-            }]),
-            ...(resultLayerId === undefined ? [] : [{
+            },
+            "roll-back-result-layer": {
               label: "roll back imported result layer",
               run: () => deleteLayerById(photoshop, resultLayerId!, false)
-            }]),
-            ...(!selectionRestored ? [{
+            },
+            "retry-restore-selection": {
               label: "retry artist selection restoration",
               run: async () => {
                 await restoreSelectionSnapshot(photoshop, transactionDocument, selectionSnapshot);
                 selectionRestored = true;
               }
-            }] : []),
-            ...(selectionSnapshot.channel && !selectionSnapshotRemoved ? [{
+            },
+            "delete-selection-snapshot-channel": {
               label: "remove selection snapshot channel after rollback",
               run: async () => {
                 if (!selectionRestored) throw new Error("Selection restoration still failed; snapshot channel retained.");
                 await removeSelectionSnapshotChannel(selectionSnapshot);
               }
-            }] : []),
-            {
+            },
+            "restore-channel-targeting": {
               label: "restore channel targeting after rollback",
               run: () => restoreActiveChannels(transactionDocument, selectionSnapshot)
             },
-            ...(previousLayerId === undefined ? [] : [{
+            "restore-previous-layer": {
               label: "restore previously active layer after rollback",
-              run: () => selectLayerById(photoshop, previousLayerId, false)
-            }])
-          ]);
+              run: () => selectLayerById(photoshop, previousLayerId!, false)
+            }
+          };
+
+          recoveryFailures = await runCleanupTasks(
+            planImportRecovery({
+              temporaryMaskLayerPresent: temporaryMaskLayerId !== undefined,
+              temporaryBlackLayerPresent: temporaryBlackLayerId !== undefined,
+              resultLayerPresent: resultLayerId !== undefined,
+              selectionRestored,
+              selectionSnapshotChannelPresent: Boolean(selectionSnapshot.channel) && !selectionSnapshotRemoved,
+              previousLayerAvailable: previousLayerId !== undefined
+            }).map((action) => recoveryHandlers[action])
+          );
           if (!operationError) {
             throw new Error(`Photoshop could not safely finalize the import. ${formatCleanupFailures([...cleanupFailures, ...recoveryFailures])}`);
           }

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -18,7 +18,7 @@ import {
   PhotoshopDocumentIdentity,
   validateDocumentImportContext
 } from "./documentContext";
-import { formatCleanupFailures, runCleanupTasks } from "./photoshopTransaction";
+import { formatCleanupFailures, isMaskSandwichTopmost, runCleanupTasks } from "./photoshopTransaction";
 
 type PhotoshopModule = {
   app: {
@@ -42,6 +42,9 @@ type PhotoshopDocument = {
   name?: string;
   width?: number;
   height?: number;
+  // Top-level layers, topmost first. Used to build the mask sandwich above the
+  // whole stack so the composite selection cannot read the artist's artwork.
+  layers?: PhotoshopLayer[];
   activeLayers?: PhotoshopLayer[];
   activeChannels?: PhotoshopChannel[];
   channels?: { getByName: (name: string) => PhotoshopChannel };
@@ -527,6 +530,13 @@ export async function importImageAlignedToSelectionWithLayerMask(
           await alignActiveLayerToBounds(photoshop, bounds);
 
           options.onProgress?.("Applying the exact saved selection mask...");
+          // The mask sandwich must sit above every other layer. The selection below
+          // is read from the RGB composite, so any visible layer left above the
+          // sandwich would contaminate it: confirmed in Photoshop on 2026-07-16,
+          // where a visible layer above a non-topmost active layer replaced the
+          // saved mask with that layer's luminance. Building the sandwich on top of
+          // the stack makes the composite depend only on OpenLayer's own layers.
+          await selectTopmostLayer(photoshop);
           temporaryBlackLayerId = await createTemporaryMaskLayer(photoshop);
           await selectEntireCanvas(photoshop);
           await fillActiveSelection(photoshop, "black");
@@ -538,8 +548,10 @@ export async function importImageAlignedToSelectionWithLayerMask(
           // This PNG is fully opaque, so Photoshop reports its complete captured
           // context bounds rather than trimming to the white mask pixels.
           await alignActiveLayerToBounds(photoshop, bounds);
-          // The opaque grayscale mask sits above a temporary full-canvas black layer,
-          // making the document composite an exact selection source with black outside.
+          await assertMaskSandwichIsTopmost(temporaryMaskLayerId, temporaryBlackLayerId);
+          // The opaque grayscale mask sits above a temporary full-canvas black layer
+          // at the top of the stack, making the document composite an exact selection
+          // source with black outside the saved mask.
           await loadSelectionFromCompositeChannel(photoshop);
           await selectLayerById(photoshop, resultLayerId, false);
           await createLayerMaskFromActiveSelection(photoshop);
@@ -947,6 +959,36 @@ async function captureSelectionMaskSourceImage(
 
   if (!capturedMask) throw new Error("Photoshop did not return the captured selection mask.");
   return capturedMask;
+}
+
+// Photoshop creates a new layer directly above the active one, so activating the
+// topmost layer first is what places the mask sandwich above the whole stack.
+// This reuses the same select-by-ID primitive the rest of the import already
+// relies on rather than introducing an arrange/reorder descriptor.
+async function selectTopmostLayer(photoshop: PhotoshopModule) {
+  const topmostLayerId = getActiveDocument().layers?.[0]?.id;
+
+  if (typeof topmostLayerId !== "number") {
+    throw new Error(
+      "Photoshop did not expose the topmost layer, so OpenLayer cannot build the saved mask above the layer stack."
+    );
+  }
+
+  await selectLayerById(photoshop, topmostLayerId, false);
+  return topmostLayerId;
+}
+
+// Fails the import rather than letting a contaminated composite become a layer
+// mask. The sandwich is only a valid selection source while the opaque mask sits
+// directly above the full-canvas black backing at the very top of the document.
+async function assertMaskSandwichIsTopmost(maskLayerId: number, blackLayerId: number) {
+  const topLevelLayerIds = (getActiveDocument().layers ?? []).map((layer) => layer.id);
+
+  if (!isMaskSandwichTopmost(topLevelLayerIds, { maskLayerId, blackLayerId })) {
+    throw new Error(
+      "Photoshop did not keep OpenLayer's temporary mask layers at the top of the document, so the saved selection mask could not be applied exactly."
+    );
+  }
 }
 
 async function createTemporaryMaskLayer(photoshop: PhotoshopModule) {

--- a/src/photoshop/photoshopTransaction.ts
+++ b/src/photoshop/photoshopTransaction.ts
@@ -20,6 +20,22 @@ export type CleanupTask = Readonly<{
   run: () => Promise<void>;
 }>;
 
+export type MaskSandwichLayers = Readonly<{
+  maskLayerId: number;
+  blackLayerId: number;
+}>;
+
+// The exact-mask import reads its selection from the RGB composite, which is only
+// a faithful copy of the saved mask while the opaque mask layer sits directly on
+// top of the full-canvas black backing at the very top of the document. Any other
+// order means a visible artwork layer is contributing to the composite.
+export function isMaskSandwichTopmost(
+  topLevelLayerIds: readonly (number | undefined)[],
+  sandwich: MaskSandwichLayers
+) {
+  return topLevelLayerIds[0] === sandwich.maskLayerId && topLevelLayerIds[1] === sandwich.blackLayerId;
+}
+
 export type CleanupFailure = Readonly<{ label: string; message: string }>;
 
 export function planImportFinalization(

--- a/src/photoshop/photoshopTransaction.ts
+++ b/src/photoshop/photoshopTransaction.ts
@@ -12,8 +12,33 @@ export type ImportFinalizationAction =
   | "delete-result-layer"
   | "restore-selection"
   | "delete-selection-snapshot-channel"
+  | "restore-channel-targeting"
   | "select-result-layer"
   | "restore-previous-layer";
+
+// The second pass, run only when finalization itself failed. It abandons the
+// import regardless of how the operation went: a result layer that cannot be
+// finalized safely must not be left behind, and the snapshot channel is retained
+// until the selection is actually back.
+export type ImportRecoveryAction =
+  | "retry-delete-temporary-mask-layer"
+  | "retry-delete-temporary-black-layer"
+  | "roll-back-result-layer"
+  | "retry-restore-selection"
+  | "delete-selection-snapshot-channel"
+  | "restore-channel-targeting"
+  | "restore-previous-layer";
+
+// Describes what survived the first pass, so the retry only touches what is
+// still there.
+export type ImportRecoveryState = Readonly<{
+  temporaryMaskLayerPresent: boolean;
+  temporaryBlackLayerPresent: boolean;
+  resultLayerPresent: boolean;
+  selectionRestored: boolean;
+  selectionSnapshotChannelPresent: boolean;
+  previousLayerAvailable: boolean;
+}>;
 
 export type CleanupTask = Readonly<{
   label: string;
@@ -48,8 +73,21 @@ export function planImportFinalization(
   if (outcome === "failure" && state.resultLayerCreated) actions.push("delete-result-layer");
   actions.push("restore-selection");
   if (state.selectionSnapshotChannelCreated) actions.push("delete-selection-snapshot-channel");
+  actions.push("restore-channel-targeting");
   if (outcome === "success" && state.resultLayerCreated) actions.push("select-result-layer");
   if (outcome === "failure" && state.previousLayerAvailable) actions.push("restore-previous-layer");
+  return actions;
+}
+
+export function planImportRecovery(state: ImportRecoveryState): ImportRecoveryAction[] {
+  const actions: ImportRecoveryAction[] = [];
+  if (state.temporaryMaskLayerPresent) actions.push("retry-delete-temporary-mask-layer");
+  if (state.temporaryBlackLayerPresent) actions.push("retry-delete-temporary-black-layer");
+  if (state.resultLayerPresent) actions.push("roll-back-result-layer");
+  if (!state.selectionRestored) actions.push("retry-restore-selection");
+  if (state.selectionSnapshotChannelPresent) actions.push("delete-selection-snapshot-channel");
+  actions.push("restore-channel-targeting");
+  if (state.previousLayerAvailable) actions.push("restore-previous-layer");
   return actions;
 }
 

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -4,10 +4,7 @@ import {
   formatHardwareReport,
   HardwareRecommendationReport
 } from "../comfy/hardwareAdvisor";
-import {
-  createFluxFillInpaintDebugSummary,
-  validateFluxFillInpaintSource
-} from "../comfy/inpaintValidation";
+import { createFluxFillInpaintDebugSummary } from "../comfy/inpaintValidation";
 import { createFluxFillEmbeddedMaskSource } from "../comfy/fluxFillMaskBridge";
 import { formatFluxFillReferenceDefaults } from "../comfy/fluxFillDefaults";
 import {
@@ -22,6 +19,12 @@ import {
   validateGenerationCommit
 } from "./generationIntegrity";
 import { createObjectUrlRegistry, ObjectUrlRegistry } from "./objectUrlRegistry";
+import {
+  evaluateInpaintReadiness,
+  formatInpaintReadinessDiagnostic,
+  getInpaintReadinessStatusLabel,
+  InpaintReadiness
+} from "./inpaintReadiness";
 import {
   formatInpaintOutputDiagnostics,
   ImageDimensions,
@@ -2894,46 +2897,78 @@ export function renderApp(rootElement: HTMLElement) {
     }
   }
 
+  // One readiness gate for the whole panel: it names the single thing to fix and
+  // reports it the same way whichever prerequisite is missing. Generate passes
+  // the workflow context an artist needs to interpret the block; import has no
+  // workflow, so it passes none.
+  function reportInpaintNotReady(
+    readiness: Extract<InpaintReadiness, { ok: false }>,
+    workflowContext = ""
+  ) {
+    setInpaintError(elements, readiness.message);
+    setInpaintStatus(elements, getInpaintReadinessStatusLabel(readiness.reason), "error");
+    setInpaintDiagnostics(
+      elements,
+      [formatInpaintReadinessDiagnostic(readiness), workflowContext].filter(Boolean).join(" ")
+    );
+  }
+
+  function createInpaintWorkflowContext() {
+    const preset = resolveInpaintPreset(readSelectValue(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW));
+
+    if (!preset) {
+      return "";
+    }
+
+    return createWorkflowDiagnostics(preset, readSelectValue(elements.inpaintCheckpoint), {
+      selection: Boolean(inpaintSource),
+      "selection-mask": Boolean(inpaintSource?.mask)
+    });
+  }
+
+  function resolveInpaintPreset(presetId: string) {
+    try {
+      return getWorkflowPreset(presetId);
+    } catch {
+      return null;
+    }
+  }
+
   async function handleGenerateInpaint() {
     setInpaintDiagnostics(elements, `Inpaint generate pressed at ${new Date().toLocaleTimeString()}.`);
 
-    if (!inpaintSource) {
-      setInpaintError(elements, "Make a Photoshop selection, then click Capture Selection before generating Inpaint.");
-      setInpaintStatus(elements, "Selection required.", "error");
-      setInpaintDiagnostics(
-        elements,
-        createWorkflowDiagnostics(
-          getWorkflowPreset(readSelectValue(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW)),
-          readSelectValue(elements.inpaintCheckpoint),
-          {
-            selection: false,
-            "selection-mask": false
-          }
-        )
-      );
+    const presetId = readSelectValue(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW);
+    // Evaluated before the client exists, so a missing selection or prompt is
+    // reported instantly instead of behind a ComfyUI round trip.
+    const localReadiness = evaluateInpaintReadiness({
+      mode: "generate",
+      source: inpaintSource,
+      preset: resolveInpaintPreset(presetId),
+      presetId,
+      checkpointName: readSelectValue(elements.inpaintCheckpoint),
+      prompt: elements.inpaintPrompt.value
+    });
+
+    if (!localReadiness.ok) {
+      reportInpaintNotReady(localReadiness, createInpaintWorkflowContext());
       return;
     }
 
-    if (!elements.inpaintPrompt.value.trim()) {
-      setInpaintError(elements, getErrorMessage(createOpenLayerError("PROMPT_REQUIRED", "Enter a prompt before generating Inpaint.")));
-      setInpaintStatus(elements, "Prompt required.", "error");
-      return;
-    }
+    // Snapshot the capture the moment it passes the gate. Everything downstream
+    // reads this frozen copy, so a selection captured while ComfyUI is still
+    // generating cannot pair a new source with this run's result.
+    const submittedSource = createInpaintSourceSnapshot(inpaintSource!);
+    const submittedMask = submittedSource.mask;
 
-    if (!inpaintSource.mask) {
-      setInpaintError(elements, inpaintSource.maskMessage || "Capture Selection did not produce a mask image.");
-      setInpaintStatus(elements, "Mask required.", "error");
-      setInpaintDiagnostics(
-        elements,
-        createWorkflowDiagnostics(
-          getWorkflowPreset(readSelectValue(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW)),
-          readSelectValue(elements.inpaintCheckpoint),
-          {
-            selection: true,
-            "selection-mask": false
-          }
-        )
-      );
+    // Readiness already proved the mask is present; this keeps the compiler
+    // honest without a non-null assertion on every use below.
+    if (!submittedMask) {
+      reportInpaintNotReady({
+        ok: false,
+        reason: "mask-missing",
+        message: "Capture Selection did not produce a mask image.",
+        warnings: []
+      }, createInpaintWorkflowContext());
       return;
     }
 
@@ -2947,8 +2982,7 @@ export function renderApp(rootElement: HTMLElement) {
     let activeRun: ActiveGeneration | null = null;
 
     try {
-      const workflowPreset = readSelectValue(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW);
-      const preset = getWorkflowPreset(workflowPreset);
+      const preset = getWorkflowPreset(presetId);
       const checkpointName = readSelectValue(elements.inpaintCheckpoint);
       const { settings, warnings } = validateImageToImageSettings({
         steps: elements.inpaintSteps.value,
@@ -2959,50 +2993,28 @@ export function renderApp(rootElement: HTMLElement) {
       const client = new ComfyClient(elements.serverUrl.value);
       const fluxDebugSummary = createFluxFillInpaintDebugSummary({
         presetId: preset.id,
-        hasSourceImage: Boolean(inpaintSource),
-        hasMaskImage: Boolean(inpaintSource.mask),
-        sourceWidth: inpaintSource.width,
-        sourceHeight: inpaintSource.height,
-        maskWidth: inpaintSource.mask.width,
-        maskHeight: inpaintSource.mask.height,
-        hasSelectionContextBounds: Boolean(inpaintSource.selection.contextBounds),
+        hasSourceImage: true,
+        hasMaskImage: true,
+        sourceWidth: submittedSource.width,
+        sourceHeight: submittedSource.height,
+        maskWidth: submittedMask.width,
+        maskHeight: submittedMask.height,
+        hasSelectionContextBounds: Boolean(submittedSource.selection.contextBounds),
         selectedFluxModelName: checkpointName
       });
-      const fluxSourceProblems = validateFluxFillInpaintSource({
-        presetId: preset.id,
-        hasSourceImage: Boolean(inpaintSource),
-        hasMaskImage: Boolean(inpaintSource.mask),
-        sourceWidth: inpaintSource.width,
-        sourceHeight: inpaintSource.height,
-        maskWidth: inpaintSource.mask.width,
-        maskHeight: inpaintSource.mask.height,
-        hasSelectionContextBounds: Boolean(inpaintSource.selection.contextBounds)
-      });
-
-      if (fluxSourceProblems.length > 0) {
-        throw createOpenLayerError(
-          "INPAINT_SOURCE_INVALID",
-          fluxSourceProblems[0],
-          fluxSourceProblems.join(" ")
-        );
-      }
 
       applyValidatedInpaintSettings(elements, settings);
       const workflowDiagnostics = warnings.length > 0
         ? warnings.join(" ")
         : createWorkflowDiagnostics(preset, checkpointName, {
-          selection: Boolean(inpaintSource),
-          "selection-mask": Boolean(inpaintSource?.mask)
+          selection: true,
+          "selection-mask": true
         });
       setInpaintDiagnostics(
         elements,
         [workflowDiagnostics, fluxDebugSummary].filter(Boolean).join(" ")
       );
       await client.checkOnline();
-
-      if (!checkpointName) {
-        throw createOpenLayerError("CHECKPOINT_REQUIRED", "Choose a ComfyUI checkpoint before generating Inpaint.");
-      }
 
       const compatibility = getCheckpointCompatibility(checkpointName, preset);
 
@@ -3021,12 +3033,22 @@ export function renderApp(rootElement: HTMLElement) {
 
       setInpaintStatus(elements, "Checking selected checkpoint...", "idle");
       setInpaintProgressPreview(elements, "Checking selected checkpoint...");
+      // Re-run the contract now that the server can answer which models it has.
+      // This replaces the ad hoc hasModelForPreset check with the same rule set
+      // the local gate used, so both report failures identically.
+      const serverReadiness = evaluateInpaintReadiness({
+        mode: "generate",
+        source: submittedSource,
+        preset,
+        presetId: preset.id,
+        checkpointName,
+        prompt: elements.inpaintPrompt.value,
+        installedModelNames: await client.getModelNamesForPreset(preset)
+      });
 
-      if (!(await client.hasModelForPreset(checkpointName, preset))) {
-        throw createOpenLayerError(
-          "CHECKPOINT_REQUIRED",
-          `The ${preset.modelSource.label.toLowerCase()} "${checkpointName}" was not found in ComfyUI. Click Check ComfyUI and choose an available model.`
-        );
+      if (!serverReadiness.ok) {
+        reportInpaintNotReady(serverReadiness, workflowDiagnostics);
+        return;
       }
 
       setInpaintStatus(elements, "Checking Inpaint nodes...", "idle");
@@ -3035,16 +3057,16 @@ export function renderApp(rootElement: HTMLElement) {
 
       setInpaintStatus(elements, "Uploading source and mask to ComfyUI...", "idle");
       setInpaintProgressPreview(elements, "Uploading source and mask...");
-      let sourceUploadBlob = inpaintSource.blob;
-      let sourceUploadFilename = inpaintSource.filename;
-      let maskUploadBlob = inpaintSource.mask.blob;
-      let maskUploadFilename = inpaintSource.mask.filename;
+      let sourceUploadBlob = submittedSource.blob;
+      let sourceUploadFilename = submittedSource.filename;
+      let maskUploadBlob = submittedMask.blob;
+      let maskUploadFilename = submittedMask.filename;
       let fluxEmbeddedMaskMessage = "";
 
       if (preset.id === "inpaint-flux-fill-basic") {
         setInpaintStatus(elements, "Preparing Flux Fill masked source...", "idle");
         setInpaintProgressPreview(elements, "Embedding mask into Flux Fill source...");
-        const embeddedSource = await createFluxFillEmbeddedMaskSource(inpaintSource.blob, inpaintSource.mask.blob);
+        const embeddedSource = await createFluxFillEmbeddedMaskSource(submittedSource.blob, submittedMask.blob);
         sourceUploadBlob = embeddedSource.blob;
         sourceUploadFilename = embeddedSource.filename;
         maskUploadBlob = embeddedSource.blob;
@@ -3068,8 +3090,8 @@ export function renderApp(rootElement: HTMLElement) {
         cfg: settings.cfg,
         seed: settings.seed,
         denoise: settings.denoise,
-        width: Math.round(inpaintSource.width),
-        height: Math.round(inpaintSource.height),
+        width: Math.round(submittedSource.width),
+        height: Math.round(submittedSource.height),
         requiredModelSelections
       });
 
@@ -3131,26 +3153,21 @@ export function renderApp(rootElement: HTMLElement) {
         await client.retrieveFirstOutputImage(promptId, history, {
           preferredNodeId: getSaveImageNodeId(buildResult.preset)
         }),
-        inpaintSource.originatingDocument
+        submittedSource.originatingDocument
       );
       ensureGenerationCanCommit(activeRun);
-      const generatedImportContext = createInpaintImportContext(
-        createInpaintSourceSnapshot(inpaintSource),
-        generatedResult
-      );
+      const generatedImportContext = createInpaintImportContext(submittedSource, generatedResult);
       const resultDimensions = await readImageDimensionsFromBlob(generatedResult.blob);
       const inpaintOutputDiagnostics = formatInpaintOutputDiagnostics({
         presetId: buildResult.preset.id,
         sourceDimensions: {
-          width: inpaintSource.width,
-          height: inpaintSource.height
+          width: submittedSource.width,
+          height: submittedSource.height
         },
-        maskDimensions: inpaintSource.mask
-          ? {
-            width: inpaintSource.mask.width,
-            height: inpaintSource.mask.height
-          }
-          : null,
+        maskDimensions: {
+          width: submittedMask.width,
+          height: submittedMask.height
+        },
         resultDimensions,
         importMode: "aligned-context-fallback",
         maskPolarity: "white-repaints"
@@ -3159,8 +3176,8 @@ export function renderApp(rootElement: HTMLElement) {
 
       try {
         const debugFiles = await saveInpaintDebugBlobsToTemporaryFiles({
-          sourceBlob: inpaintSource.blob,
-          maskBlob: inpaintSource.mask.blob,
+          sourceBlob: submittedSource.blob,
+          maskBlob: submittedMask.blob,
           resultBlob: generatedResult.blob
         });
         debugExportMessage = ` Debug copies saved in the UXP temporary folder: ${debugFiles.join(", ")}.`;
@@ -3179,10 +3196,10 @@ export function renderApp(rootElement: HTMLElement) {
         toolType: "inpaint",
         seed: buildResult.seed,
         sizeLabel: "Inpaint",
-        dimensions: `${inpaintSource.width} x ${inpaintSource.height}`,
-        sourceMode: getInpaintSourceModeLabel(inpaintSource.sourceMode),
-        sourceBounds: createMetadataBounds(inpaintSource.selection.bounds),
-        contextBounds: createMetadataBounds(inpaintSource.selection.contextBounds),
+        dimensions: `${submittedSource.width} x ${submittedSource.height}`,
+        sourceMode: getInpaintSourceModeLabel(submittedSource.sourceMode),
+        sourceBounds: createMetadataBounds(submittedSource.selection.bounds),
+        contextBounds: createMetadataBounds(submittedSource.selection.contextBounds),
         inpaintImportContext: generatedImportContext,
         experimental: true,
         diagnosticsSummary: [
@@ -3190,19 +3207,17 @@ export function renderApp(rootElement: HTMLElement) {
           formatInpaintOutpaintDebugContract({
             toolType: "inpaint",
             presetId: buildResult.preset.id,
-            sourceMode: getInpaintSourceModeLabel(inpaintSource.sourceMode),
+            sourceMode: getInpaintSourceModeLabel(submittedSource.sourceMode),
             sourceDimensions: {
-              width: inpaintSource.width,
-              height: inpaintSource.height
+              width: submittedSource.width,
+              height: submittedSource.height
             },
-            maskDimensions: inpaintSource.mask
-              ? {
-                width: inpaintSource.mask.width,
-                height: inpaintSource.mask.height
-              }
-              : null,
+            maskDimensions: {
+              width: submittedMask.width,
+              height: submittedMask.height
+            },
             maskPolarity: "white-repaints",
-            contextBounds: createMetadataBounds(inpaintSource.selection.contextBounds),
+            contextBounds: createMetadataBounds(submittedSource.selection.contextBounds),
             outputKind: "selection context",
             importMode: "Photoshop layer mask with aligned fallback"
           })
@@ -3250,9 +3265,28 @@ export function renderApp(rootElement: HTMLElement) {
 
     const importSource = importContext.source;
     const importResultImage = importContext.result;
+    // The result carries the exact capture it was generated from, so import
+    // readiness re-checks that saved pair rather than whatever is on screen now.
+    const importReadiness = evaluateInpaintReadiness({
+      mode: "import",
+      source: importSource,
+      resultDimensions: await readImageDimensionsFromBlob(importResultImage.blob)
+    });
 
-    if (!importSource.mask) {
-      setInpaintError(elements, "The saved selection mask for this Inpaint result is unavailable. Generate the result again from a captured selection.");
+    if (!importReadiness.ok) {
+      reportInpaintNotReady(importReadiness);
+      return;
+    }
+
+    const importMask = importSource.mask;
+
+    if (!importMask) {
+      reportInpaintNotReady({
+        ok: false,
+        reason: "mask-missing",
+        message: "The saved selection mask for this Inpaint result is unavailable. Generate the result again from a captured selection.",
+        warnings: []
+      });
       return;
     }
 
@@ -3269,15 +3303,11 @@ export function renderApp(rootElement: HTMLElement) {
         height: importSource.height
       };
       const maskDimensions = {
-        width: importSource.mask.width,
-        height: importSource.mask.height
+        width: importMask.width,
+        height: importMask.height
       };
-      const resultDimensions = await readImageDimensionsFromBlob(importResultImage.blob);
+      const resultDimensions = { width: importSource.width, height: importSource.height };
       let importMode: InpaintImportMode = "aligned-context-fallback";
-
-      if (!resultDimensions || !dimensionsMatchForUi(resultDimensions, sourceDimensions)) {
-        throw new Error("The generated Inpaint result dimensions do not match the saved source context. Generate this result again before importing.");
-      }
 
       setInpaintDiagnostics(
         elements,
@@ -3294,9 +3324,9 @@ export function renderApp(rootElement: HTMLElement) {
         originatingDocument: importResultImage.originatingDocument,
         bounds: importSource.selection.contextBounds,
         mask: {
-          blob: importSource.mask.blob,
-          width: importSource.mask.width,
-          height: importSource.mask.height
+          blob: importMask.blob,
+          width: importMask.width,
+          height: importMask.height
         },
         sourceDimensions,
         resultDimensions,
@@ -6129,10 +6159,6 @@ function createSourceCaptureMessage(source: ExportedSourceImage, suffix = "") {
 function createSourceMetaText(source: ExportedSourceImage) {
   const size = `${Math.round(source.width)} x ${Math.round(source.height)}`;
   return `${size} | ${formatSourceCaptureLabel(source)} source`;
-}
-
-function dimensionsMatchForUi(first: ImageDimensions, second: ImageDimensions) {
-  return Math.round(first.width) === Math.round(second.width) && Math.round(first.height) === Math.round(second.height);
 }
 
 function getSaveImageNodeId(preset: WorkflowPresetDefinition) {

--- a/src/ui/inpaintReadiness.ts
+++ b/src/ui/inpaintReadiness.ts
@@ -57,6 +57,10 @@ export type InpaintReadinessInput = Readonly<{
   checkpointName?: string;
   prompt?: string;
   compatibilityContext?: WorkflowCompatibilityContext;
+  // The model names the ComfyUI server actually offers for this preset's model
+  // source. Omitted when the list could not be read, because an unreachable or
+  // unlisted server must not block generation on a guess.
+  installedModelNames?: readonly string[];
   // Flux Fill embeds the mask in the source PNG's alpha channel instead of
   // uploading a separate mask image.
   maskBridgeAvailable?: boolean;
@@ -195,7 +199,7 @@ function evaluateWorkflowReadiness(
   // requiredModels, so a freely chosen checkpoint is never compared against the
   // server there. A stale dropdown or a deleted model would otherwise reach the
   // upload before ComfyUI rejected it.
-  const installedModelNames = getSelectableModelNames(input, preset);
+  const installedModelNames = input.installedModelNames ?? [];
 
   if (installedModelNames.length > 0 && !installedModelNames.includes(checkpointName)) {
     return blocked(
@@ -290,30 +294,6 @@ function blocked(
   technicalMessage?: string
 ): InpaintReadiness {
   return { ok: false, reason, message, technicalMessage, warnings: [...warnings] };
-}
-
-// Only the bucket the preset actually selects from, and only when it was
-// enumerated successfully: an unreachable or unlisted server must not block
-// generation on a guess.
-function getSelectableModelNames(input: InpaintReadinessInput, preset: WorkflowPresetDefinition) {
-  const inventory = input.compatibilityContext?.availableModels;
-
-  if (!inventory) {
-    return [];
-  }
-
-  switch (preset.modelSource.kind) {
-    case "checkpoint":
-      return inventory.checkpoints ?? [];
-    case "diffusion-model-stack":
-      return inventory.diffusionModels ?? [];
-    case "upscale":
-      return inventory.upscaleModels ?? [];
-    case "vision-language":
-      return inventory.visionLanguageModels ?? [];
-    default:
-      return [];
-  }
 }
 
 function sameDimensions(left: PixelDimensions, right: PixelDimensions) {

--- a/src/ui/inpaintReadiness.ts
+++ b/src/ui/inpaintReadiness.ts
@@ -1,0 +1,354 @@
+import type { SelectedRegionSourceImage } from "../photoshop/photoshopAdapter";
+import type { PixelDimensions } from "../photoshop/exactInpaintMask";
+import type { NormalizedSelectionBounds } from "../photoshop/selectionUtils";
+import type { WorkflowPresetDefinition } from "../comfy/types";
+import {
+  evaluateWorkflowCompatibility,
+  WorkflowCompatibilityContext
+} from "../comfy/workflowCompatibility";
+
+// ComfyUI's VAE rounds image dimensions down to multiples of 8. A context that is
+// not a multiple of 8 comes back smaller than it was captured, which silently
+// breaks the translate-only aligned import, so it is a readiness failure rather
+// than a warning. Mirrors INPAINT_CONTEXT_MULTIPLE in photoshopAdapter.
+const INPAINT_CONTEXT_MULTIPLE = 8;
+
+export const FLUX_FILL_PRESET_ID = "inpaint-flux-fill-basic";
+
+export type InpaintReadinessReason =
+  | "workflow-unresolved"
+  | "workflow-not-runnable"
+  | "source-missing"
+  | "origin-document-missing"
+  | "prompt-missing"
+  | "mask-missing"
+  | "mask-dimension-mismatch"
+  | "context-bounds-invalid"
+  | "context-bounds-unaligned"
+  | "source-context-mismatch"
+  | "selection-outside-context"
+  | "checkpoint-missing"
+  | "checkpoint-not-installed"
+  | "flux-fill-mask-bridge-unavailable"
+  | "result-dimension-mismatch";
+
+export type InpaintReadiness =
+  | Readonly<{ ok: true; warnings: readonly string[] }>
+  | Readonly<{
+    ok: false;
+    reason: InpaintReadinessReason;
+    message: string;
+    technicalMessage?: string;
+    warnings: readonly string[];
+  }>;
+
+// Importing a saved result replays pixels that already exist: it runs no
+// workflow, loads no checkpoint, and needs no ComfyUI node. Import readiness is
+// therefore the capture-and-geometry subset of generate readiness, plus the
+// check that the result still matches the context it was generated for.
+export type InpaintReadinessMode = "generate" | "import";
+
+export type InpaintReadinessInput = Readonly<{
+  mode: InpaintReadinessMode;
+  source: SelectedRegionSourceImage | null;
+  // Generate only.
+  preset?: WorkflowPresetDefinition | null;
+  presetId?: string;
+  checkpointName?: string;
+  prompt?: string;
+  compatibilityContext?: WorkflowCompatibilityContext;
+  // Flux Fill embeds the mask in the source PNG's alpha channel instead of
+  // uploading a separate mask image.
+  maskBridgeAvailable?: boolean;
+  // Import only: what ComfyUI actually returned.
+  resultDimensions?: PixelDimensions | null;
+}>;
+
+export function evaluateInpaintReadiness(input: InpaintReadinessInput): InpaintReadiness {
+  const warnings: string[] = [];
+  const isGenerate = input.mode === "generate";
+
+  if (isGenerate && !input.preset) {
+    return blocked(
+      "workflow-unresolved",
+      `OpenLayer could not resolve the “${input.presetId || "selected"}” Inpaint workflow. Choose an Inpaint workflow in the panel and try again.`,
+      warnings
+    );
+  }
+
+  const source = input.source;
+
+  if (!source || source.blob.size === 0) {
+    return blocked(
+      "source-missing",
+      "Make a Photoshop selection, then click Capture Selection before generating Inpaint.",
+      warnings
+    );
+  }
+
+  if (!source.originatingDocument) {
+    return blocked(
+      "origin-document-missing",
+      "This captured selection is not linked to a Photoshop document, so OpenLayer will not generate from it. Capture the selection again while the intended document is active.",
+      warnings
+    );
+  }
+
+  if (isGenerate && !(input.prompt ?? "").trim()) {
+    return blocked("prompt-missing", "Enter a prompt before generating Inpaint.", warnings);
+  }
+
+  if (!source.mask || source.mask.blob.size === 0) {
+    return blocked(
+      "mask-missing",
+      source.maskMessage || "Capture Selection did not produce a mask image. Capture the selection again before generating.",
+      warnings
+    );
+  }
+
+  if (!sameDimensions(source.mask, source)) {
+    return blocked(
+      "mask-dimension-mismatch",
+      "The captured mask does not match its source image, so the repainted area would land in the wrong place. Capture the selection again.",
+      warnings,
+      `Mask is ${formatDimensions(source.mask)}; source is ${formatDimensions(source)}.`
+    );
+  }
+
+  const contextBounds = source.selection?.contextBounds;
+
+  if (!contextBounds || !isVisibleBounds(contextBounds)) {
+    return blocked(
+      "context-bounds-invalid",
+      "The captured selection context is missing or empty. Make a visible selection and capture it again.",
+      warnings
+    );
+  }
+
+  if (!isAlignedToMultiple(contextBounds)) {
+    return blocked(
+      "context-bounds-unaligned",
+      "The captured selection context cannot be generated at its exact size, so the result would not line up with your selection. Capture the selection again.",
+      warnings,
+      `Context ${formatDimensions(contextBounds)} is not a multiple of ${INPAINT_CONTEXT_MULTIPLE}; ComfyUI would round it down and return a smaller image.`
+    );
+  }
+
+  if (!sameDimensions(source, contextBounds)) {
+    return blocked(
+      "source-context-mismatch",
+      "The captured source image does not match its selection context, so the result would not line up with your selection. Capture the selection again.",
+      warnings,
+      `Source is ${formatDimensions(source)}; context is ${formatDimensions(contextBounds)}.`
+    );
+  }
+
+  const selectionBounds = source.selection?.bounds;
+
+  if (selectionBounds && !containsBounds(contextBounds, selectionBounds)) {
+    return blocked(
+      "selection-outside-context",
+      "The captured selection sits outside its own context, so the repainted area would be clipped. Capture the selection again.",
+      warnings,
+      `Selection ${formatBounds(selectionBounds)} is not contained by context ${formatBounds(contextBounds)}.`
+    );
+  }
+
+  if (isGenerate && input.preset) {
+    const workflowReadiness = evaluateWorkflowReadiness(input, input.preset, warnings);
+
+    if (workflowReadiness) {
+      return workflowReadiness;
+    }
+  }
+
+  if (input.mode === "import" && (!input.resultDimensions || !sameDimensions(input.resultDimensions, source))) {
+    return blocked(
+      "result-dimension-mismatch",
+      "The generated Inpaint result does not match the saved source context. Generate this result again before importing.",
+      warnings,
+      `Result is ${input.resultDimensions ? formatDimensions(input.resultDimensions) : "an unreadable size"}; saved source context is ${formatDimensions(source)}.`
+    );
+  }
+
+  return { ok: true, warnings };
+}
+
+// Returns a blocked readiness, or null when the workflow side is ready. Warnings
+// are collected into the caller's list either way.
+function evaluateWorkflowReadiness(
+  input: InpaintReadinessInput,
+  preset: WorkflowPresetDefinition,
+  warnings: string[]
+): InpaintReadiness | null {
+  const checkpointName = (input.checkpointName ?? "").trim();
+
+  if (!checkpointName) {
+    return blocked(
+      "checkpoint-missing",
+      `Choose a ${preset.modelSource.label} for the ${preset.label} workflow before generating.`,
+      warnings
+    );
+  }
+
+  // evaluateWorkflowCompatibility only checks the models a preset declares in
+  // requiredModels, so a freely chosen checkpoint is never compared against the
+  // server there. A stale dropdown or a deleted model would otherwise reach the
+  // upload before ComfyUI rejected it.
+  const installedModelNames = getSelectableModelNames(input, preset);
+
+  if (installedModelNames.length > 0 && !installedModelNames.includes(checkpointName)) {
+    return blocked(
+      "checkpoint-not-installed",
+      `“${checkpointName}” is not installed in ComfyUI. Choose an installed ${preset.modelSource.label} for the ${preset.label} workflow.`,
+      warnings,
+      `Installed options: ${installedModelNames.join(", ")}.`
+    );
+  }
+
+  if (preset.id === FLUX_FILL_PRESET_ID && input.maskBridgeAvailable === false) {
+    return blocked(
+      "flux-fill-mask-bridge-unavailable",
+      "OpenLayer could not embed the Photoshop mask into the Flux Fill source image, so Flux Fill would repaint the wrong area. Capture the selection again.",
+      warnings,
+      "inpaint-flux-fill-basic uploads one PNG whose alpha channel carries the mask for the LoadImage mask output."
+    );
+  }
+
+  const compatibility = evaluateWorkflowCompatibility(preset, {
+    ...input.compatibilityContext,
+    selectedModelName: input.compatibilityContext?.selectedModelName ?? checkpointName,
+    photoshopInputs: {
+      ...input.compatibilityContext?.photoshopInputs,
+      selection: true,
+      "selection-mask": true
+    }
+  });
+
+  for (const issue of compatibility.issues) {
+    if (issue.level === "warning" || issue.level === "experimental") {
+      warnings.push(issue.artistMessage);
+    }
+  }
+
+  if (!compatibility.canRun) {
+    const blockingIssue =
+      compatibility.issues.find((issue) => issue.level === "unsupported") ??
+      compatibility.issues.find((issue) => issue.level === "setup-required");
+
+    return blocked(
+      "workflow-not-runnable",
+      blockingIssue?.artistMessage ?? `The ${preset.label} workflow is not ready to run in this ComfyUI setup.`,
+      warnings,
+      [blockingIssue?.code, blockingIssue?.technicalMessage, compatibility.recommendedAction]
+        .filter(Boolean)
+        .join(" ") || undefined
+    );
+  }
+
+  return null;
+}
+
+// Short status-line label per reason, so a blocked run keeps naming the one thing
+// the artist has to fix rather than collapsing to a generic "not ready".
+const READINESS_STATUS_LABELS: Record<InpaintReadinessReason, string> = {
+  "workflow-unresolved": "Workflow required.",
+  "workflow-not-runnable": "Setup required.",
+  "source-missing": "Selection required.",
+  "origin-document-missing": "Document required.",
+  "prompt-missing": "Prompt required.",
+  "mask-missing": "Mask required.",
+  "mask-dimension-mismatch": "Recapture required.",
+  "context-bounds-invalid": "Selection required.",
+  "context-bounds-unaligned": "Recapture required.",
+  "source-context-mismatch": "Recapture required.",
+  "selection-outside-context": "Recapture required.",
+  "checkpoint-missing": "Checkpoint required.",
+  "checkpoint-not-installed": "Checkpoint required.",
+  "flux-fill-mask-bridge-unavailable": "Mask required.",
+  "result-dimension-mismatch": "Regenerate required."
+};
+
+export function getInpaintReadinessStatusLabel(reason: InpaintReadinessReason) {
+  return READINESS_STATUS_LABELS[reason];
+}
+
+export function formatInpaintReadinessDiagnostic(readiness: InpaintReadiness) {
+  if (readiness.ok) {
+    return readiness.warnings.join(" ");
+  }
+
+  return [`Inpaint blocked (${readiness.reason}).`, readiness.technicalMessage, ...readiness.warnings]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function blocked(
+  reason: InpaintReadinessReason,
+  message: string,
+  warnings: readonly string[],
+  technicalMessage?: string
+): InpaintReadiness {
+  return { ok: false, reason, message, technicalMessage, warnings: [...warnings] };
+}
+
+// Only the bucket the preset actually selects from, and only when it was
+// enumerated successfully: an unreachable or unlisted server must not block
+// generation on a guess.
+function getSelectableModelNames(input: InpaintReadinessInput, preset: WorkflowPresetDefinition) {
+  const inventory = input.compatibilityContext?.availableModels;
+
+  if (!inventory) {
+    return [];
+  }
+
+  switch (preset.modelSource.kind) {
+    case "checkpoint":
+      return inventory.checkpoints ?? [];
+    case "diffusion-model-stack":
+      return inventory.diffusionModels ?? [];
+    case "upscale":
+      return inventory.upscaleModels ?? [];
+    case "vision-language":
+      return inventory.visionLanguageModels ?? [];
+    default:
+      return [];
+  }
+}
+
+function sameDimensions(left: PixelDimensions, right: PixelDimensions) {
+  return Math.round(left.width) === Math.round(right.width) && Math.round(left.height) === Math.round(right.height);
+}
+
+function isVisibleBounds(bounds: NormalizedSelectionBounds) {
+  return [bounds.left, bounds.top, bounds.right, bounds.bottom].every((value) => Number.isFinite(value)) &&
+    bounds.right > bounds.left &&
+    bounds.bottom > bounds.top &&
+    isPositiveInteger(bounds.width) &&
+    isPositiveInteger(bounds.height) &&
+    bounds.width === bounds.right - bounds.left &&
+    bounds.height === bounds.bottom - bounds.top;
+}
+
+function isAlignedToMultiple(bounds: NormalizedSelectionBounds) {
+  return bounds.width % INPAINT_CONTEXT_MULTIPLE === 0 && bounds.height % INPAINT_CONTEXT_MULTIPLE === 0;
+}
+
+function containsBounds(outer: NormalizedSelectionBounds, inner: NormalizedSelectionBounds) {
+  return inner.left >= outer.left &&
+    inner.top >= outer.top &&
+    inner.right <= outer.right &&
+    inner.bottom <= outer.bottom;
+}
+
+function isPositiveInteger(value: number) {
+  return Number.isInteger(value) && value > 0;
+}
+
+function formatDimensions(dimensions: PixelDimensions) {
+  return `${Math.round(dimensions.width)} x ${Math.round(dimensions.height)}`;
+}
+
+function formatBounds(bounds: NormalizedSelectionBounds) {
+  return `${formatDimensions(bounds)} at ${bounds.left}, ${bounds.top}`;
+}

--- a/tests/comfy/inpaintValidation.test.ts
+++ b/tests/comfy/inpaintValidation.test.ts
@@ -1,40 +1,7 @@
 import { describe, expect, it } from "vitest";
-import {
-  createFluxFillInpaintDebugSummary,
-  validateFluxFillInpaintSource
-} from "../../src/comfy/inpaintValidation";
+import { createFluxFillInpaintDebugSummary } from "../../src/comfy/inpaintValidation";
 
 describe("inpaint validation", () => {
-  it("allows matching Flux Fill source and mask dimensions", () => {
-    const problems = validateFluxFillInpaintSource({
-      presetId: "inpaint-flux-fill-basic",
-      hasSourceImage: true,
-      hasMaskImage: true,
-      sourceWidth: 768,
-      sourceHeight: 512,
-      maskWidth: 768,
-      maskHeight: 512,
-      hasSelectionContextBounds: true
-    });
-
-    expect(problems).toEqual([]);
-  });
-
-  it("blocks Flux Fill when source and mask dimensions differ", () => {
-    const problems = validateFluxFillInpaintSource({
-      presetId: "inpaint-flux-fill-basic",
-      hasSourceImage: true,
-      hasMaskImage: true,
-      sourceWidth: 768,
-      sourceHeight: 512,
-      maskWidth: 512,
-      maskHeight: 512,
-      hasSelectionContextBounds: true
-    });
-
-    expect(problems.join(" ")).toContain("Source is 768 x 512, mask is 512 x 512");
-  });
-
   it("creates a compact Flux Fill debug summary", () => {
     const summary = createFluxFillInpaintDebugSummary({
       presetId: "inpaint-flux-fill-basic",

--- a/tests/photoshop/photoshopTransaction.test.ts
+++ b/tests/photoshop/photoshopTransaction.test.ts
@@ -3,6 +3,7 @@ import {
   formatCleanupFailures,
   isMaskSandwichTopmost,
   planImportFinalization,
+  planImportRecovery,
   runCleanupTasks
 } from "../../src/photoshop/photoshopTransaction";
 
@@ -15,25 +16,35 @@ const completeState = {
 };
 
 describe("Photoshop import transaction finalization", () => {
-  it("restores selection and leaves the imported result active after success", () => {
+  it("restores selection and channels and leaves the imported result active after success", () => {
     expect(planImportFinalization(completeState, "success")).toEqual([
       "delete-temporary-mask-layer",
       "delete-temporary-black-layer",
       "restore-selection",
       "delete-selection-snapshot-channel",
+      "restore-channel-targeting",
       "select-result-layer"
     ]);
   });
 
-  it("removes the result and restores selection and previous layer after failure", () => {
+  it("removes the result and restores selection, channels, and previous layer after failure", () => {
     expect(planImportFinalization(completeState, "failure")).toEqual([
       "delete-temporary-mask-layer",
       "delete-temporary-black-layer",
       "delete-result-layer",
       "restore-selection",
       "delete-selection-snapshot-channel",
+      "restore-channel-targeting",
       "restore-previous-layer"
     ]);
+  });
+
+  it("restores the selection before dropping the channel that holds it", () => {
+    const actions = planImportFinalization(completeState, "success");
+
+    expect(actions.indexOf("restore-selection")).toBeLessThan(
+      actions.indexOf("delete-selection-snapshot-channel")
+    );
   });
 
   it("restores a no-selection state without requiring a snapshot channel", () => {
@@ -49,8 +60,13 @@ describe("Photoshop import transaction finalization", () => {
       "delete-temporary-black-layer",
       "delete-result-layer",
       "restore-selection",
+      "restore-channel-targeting",
       "restore-previous-layer"
     ]);
+  });
+
+  it("never deletes the imported result on the success path", () => {
+    expect(planImportFinalization(completeState, "success")).not.toContain("delete-result-layer");
   });
 
   it("attempts every cleanup task and aggregates multiple failures", async () => {
@@ -63,6 +79,50 @@ describe("Photoshop import transaction finalization", () => {
 
     expect(attempted).toEqual(["mask", "result", "selection"]);
     expect(formatCleanupFailures(failures)).toBe("mask: mask failed; result: result failed");
+  });
+});
+
+describe("Photoshop import transaction recovery", () => {
+  const survivingState = {
+    temporaryMaskLayerPresent: true,
+    temporaryBlackLayerPresent: true,
+    resultLayerPresent: true,
+    selectionRestored: false,
+    selectionSnapshotChannelPresent: true,
+    previousLayerAvailable: true
+  };
+
+  it("abandons the import and restores the host when finalization failed", () => {
+    expect(planImportRecovery(survivingState)).toEqual([
+      "retry-delete-temporary-mask-layer",
+      "retry-delete-temporary-black-layer",
+      "roll-back-result-layer",
+      "retry-restore-selection",
+      "delete-selection-snapshot-channel",
+      "restore-channel-targeting",
+      "restore-previous-layer"
+    ]);
+  });
+
+  it("only retries what the first pass left behind", () => {
+    expect(planImportRecovery({
+      temporaryMaskLayerPresent: false,
+      temporaryBlackLayerPresent: false,
+      resultLayerPresent: false,
+      selectionRestored: true,
+      selectionSnapshotChannelPresent: false,
+      previousLayerAvailable: false
+    })).toEqual(["restore-channel-targeting"]);
+  });
+
+  it("does not retry a selection the first pass already restored", () => {
+    expect(planImportRecovery({ ...survivingState, selectionRestored: true }))
+      .not.toContain("retry-restore-selection");
+  });
+
+  it("rolls back a result layer even when the operation itself succeeded", () => {
+    // Reached only when finalization failed, so the result cannot be trusted.
+    expect(planImportRecovery(survivingState)).toContain("roll-back-result-layer");
   });
 });
 

--- a/tests/photoshop/photoshopTransaction.test.ts
+++ b/tests/photoshop/photoshopTransaction.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { formatCleanupFailures, planImportFinalization, runCleanupTasks } from "../../src/photoshop/photoshopTransaction";
+import {
+  formatCleanupFailures,
+  isMaskSandwichTopmost,
+  planImportFinalization,
+  runCleanupTasks
+} from "../../src/photoshop/photoshopTransaction";
 
 const completeState = {
   resultLayerCreated: true,
@@ -58,5 +63,36 @@ describe("Photoshop import transaction finalization", () => {
 
     expect(attempted).toEqual(["mask", "result", "selection"]);
     expect(formatCleanupFailures(failures)).toBe("mask: mask failed; result: result failed");
+  });
+});
+
+describe("exact-mask sandwich layer order", () => {
+  const sandwich = { maskLayerId: 91, blackLayerId: 90 };
+
+  it("accepts the mask directly above the black backing at the top of the stack", () => {
+    expect(isMaskSandwichTopmost([91, 90, 42, 7], sandwich)).toBe(true);
+  });
+
+  it("rejects an artwork layer left above the sandwich", () => {
+    // The 2026-07-16 Photoshop reproduction: a visible layer above the active
+    // layer contaminated the composite and replaced the saved mask.
+    expect(isMaskSandwichTopmost([42, 91, 90, 7], sandwich)).toBe(false);
+  });
+
+  it("rejects the black backing landing above the mask", () => {
+    expect(isMaskSandwichTopmost([90, 91, 42], sandwich)).toBe(false);
+  });
+
+  it("rejects an artwork layer wedged between the mask and its backing", () => {
+    expect(isMaskSandwichTopmost([91, 42, 90], sandwich)).toBe(false);
+  });
+
+  it("rejects a stack whose topmost layer IDs are unavailable", () => {
+    expect(isMaskSandwichTopmost([undefined, undefined], sandwich)).toBe(false);
+    expect(isMaskSandwichTopmost([], sandwich)).toBe(false);
+  });
+
+  it("rejects a sandwich missing its backing layer", () => {
+    expect(isMaskSandwichTopmost([91], sandwich)).toBe(false);
   });
 });

--- a/tests/ui/inpaintReadiness.test.ts
+++ b/tests/ui/inpaintReadiness.test.ts
@@ -80,11 +80,10 @@ function createAvailableNodes(preset: typeof basicPreset) {
 const readyContext: WorkflowCompatibilityContext = {
   selectedModelName: "epicrealism_naturalSinRC1VAE-inpainting.safetensors",
   selectedModelFamily: "sd1",
-  availableNodes: createAvailableNodes(basicPreset),
-  availableModels: {
-    checkpoints: ["epicrealism_naturalSinRC1VAE-inpainting.safetensors"]
-  }
+  availableNodes: createAvailableNodes(basicPreset)
 };
+
+const installedCheckpoints = ["epicrealism_naturalSinRC1VAE-inpainting.safetensors"];
 
 function evaluateBasic(overrides: Partial<InpaintReadinessInput> = {}) {
   return evaluateInpaintReadiness({
@@ -95,6 +94,7 @@ function evaluateBasic(overrides: Partial<InpaintReadinessInput> = {}) {
     checkpointName: "epicrealism_naturalSinRC1VAE-inpainting.safetensors",
     prompt: "a cat holding a mouse",
     compatibilityContext: readyContext,
+    installedModelNames: installedCheckpoints,
     ...overrides
   });
 }
@@ -264,11 +264,8 @@ describe("Inpaint readiness contract", () => {
 
   it("blocks a checkpoint the ComfyUI server does not have installed", () => {
     const readiness = evaluateBasic({
-      compatibilityContext: {
-        ...readyContext,
-        selectedModelName: "not-installed.safetensors",
-        availableModels: { checkpoints: ["something-else.safetensors"] }
-      },
+      compatibilityContext: { ...readyContext, selectedModelName: "not-installed.safetensors" },
+      installedModelNames: ["something-else.safetensors"],
       checkpointName: "not-installed.safetensors"
     });
 
@@ -277,11 +274,8 @@ describe("Inpaint readiness contract", () => {
   });
 
   it("does not guess about installed models when the server list is unavailable", () => {
-    const readiness = evaluateBasic({
-      compatibilityContext: { ...readyContext, availableModels: undefined }
-    });
-
-    expect(readiness.ok).toBe(true);
+    expect(evaluateBasic({ installedModelNames: undefined }).ok).toBe(true);
+    expect(evaluateBasic({ installedModelNames: [] }).ok).toBe(true);
   });
 
   it("blocks Flux Fill when the mask cannot be embedded into the source PNG", () => {

--- a/tests/ui/inpaintReadiness.test.ts
+++ b/tests/ui/inpaintReadiness.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateInpaintReadiness,
+  formatInpaintReadinessDiagnostic,
+  getInpaintReadinessStatusLabel,
+  InpaintReadinessInput
+} from "../../src/ui/inpaintReadiness";
+import { getWorkflowPreset } from "../../src/comfy/presetRegistry";
+import { createPhotoshopDocumentIdentity } from "../../src/photoshop/documentContext";
+import type { SelectedRegionSourceImage } from "../../src/photoshop/photoshopAdapter";
+import type { NormalizedSelectionBounds } from "../../src/photoshop/selectionUtils";
+import type { WorkflowCompatibilityContext } from "../../src/comfy/workflowCompatibility";
+
+const origin = createPhotoshopDocumentIdentity(101, "Concept.psd");
+const basicPreset = getWorkflowPreset("inpaint-basic");
+const fluxPreset = getWorkflowPreset("inpaint-flux-fill-basic");
+
+function bounds(left: number, top: number, right: number, bottom: number): NormalizedSelectionBounds {
+  return { left, top, right, bottom, width: right - left, height: bottom - top };
+}
+
+// The captured context is padded and snapped to a multiple of 8, and the source
+// PNG is captured at exactly those bounds.
+const contextBounds = bounds(100, 100, 356, 292);
+const selectionBounds = bounds(160, 150, 300, 250);
+
+function createSource(overrides: Partial<SelectedRegionSourceImage> = {}): SelectedRegionSourceImage {
+  return {
+    blob: new Blob(["source-pixels"], { type: "image/png" }),
+    filename: "OpenLayer_Inpaint_Source.png",
+    mimeType: "image/png",
+    width: contextBounds.width,
+    height: contextBounds.height,
+    sourceName: "Visible canvas from Concept.psd",
+    captureFormat: "png",
+    originatingDocument: origin,
+    selection: {
+      bounds: selectionBounds,
+      contextBounds,
+      documentName: "Concept.psd",
+      originatingDocument: origin,
+      maskAvailable: true,
+      maskMessage: "Selection mask captured as PNG/lossless source."
+    },
+    mask: {
+      blob: new Blob(["mask-pixels"], { type: "image/png" }),
+      filename: "OpenLayer_Inpaint_Mask.png",
+      mimeType: "image/png",
+      bounds: contextBounds,
+      width: contextBounds.width,
+      height: contextBounds.height,
+      captureFormat: "png",
+      originatingDocument: origin
+    },
+    maskAvailable: true,
+    maskMessage: "Selection mask captured as PNG/lossless source.",
+    sourceMode: "visible-canvas",
+    sourceWarning: "",
+    ...overrides
+  };
+}
+
+// Derived from the preset itself so the fixture cannot drift from the graph the
+// workflow actually requires.
+function createAvailableNodes(preset: typeof basicPreset) {
+  const availableNodes: Record<string, string[]> = {};
+
+  for (const node of preset.requiredNodes) {
+    availableNodes[node.classType] = [
+      ...(availableNodes[node.classType] ?? []),
+      ...node.requiredInputs
+    ];
+  }
+
+  return availableNodes;
+}
+
+// inpaint-basic is experimental, so a ready evaluation still carries warnings.
+// Everything the graph needs is present here; individual tests remove one thing.
+const readyContext: WorkflowCompatibilityContext = {
+  selectedModelName: "epicrealism_naturalSinRC1VAE-inpainting.safetensors",
+  selectedModelFamily: "sd1",
+  availableNodes: createAvailableNodes(basicPreset),
+  availableModels: {
+    checkpoints: ["epicrealism_naturalSinRC1VAE-inpainting.safetensors"]
+  }
+};
+
+function evaluateBasic(overrides: Partial<InpaintReadinessInput> = {}) {
+  return evaluateInpaintReadiness({
+    mode: "generate",
+    source: createSource(),
+    preset: basicPreset,
+    presetId: "inpaint-basic",
+    checkpointName: "epicrealism_naturalSinRC1VAE-inpainting.safetensors",
+    prompt: "a cat holding a mouse",
+    compatibilityContext: readyContext,
+    ...overrides
+  });
+}
+
+function evaluateImport(overrides: Partial<InpaintReadinessInput> = {}) {
+  return evaluateInpaintReadiness({
+    mode: "import",
+    source: createSource(),
+    resultDimensions: { width: contextBounds.width, height: contextBounds.height },
+    ...overrides
+  });
+}
+
+describe("Inpaint readiness contract", () => {
+  it("is ready when the capture, mask, context, checkpoint, and graph all line up", () => {
+    const readiness = evaluateBasic();
+
+    expect(readiness.ok).toBe(true);
+  });
+
+  it("surfaces the experimental workflow as a warning rather than a block", () => {
+    const readiness = evaluateBasic();
+
+    expect(readiness.ok).toBe(true);
+    expect(readiness.warnings.join(" ")).toMatch(/experimental/i);
+  });
+
+  it("blocks an unresolved workflow preset", () => {
+    const readiness = evaluateBasic({ preset: null, presetId: "inpaint-nonexistent" });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "workflow-unresolved" });
+  });
+
+  it("blocks before upload when no selection has been captured", () => {
+    const readiness = evaluateBasic({ source: null });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "source-missing" });
+  });
+
+  it("blocks an empty captured source blob", () => {
+    const readiness = evaluateBasic({ source: createSource({ blob: new Blob() }) });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "source-missing" });
+  });
+
+  it("blocks a source with no originating document identity", () => {
+    const readiness = evaluateBasic({
+      source: createSource({ originatingDocument: null as never })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "origin-document-missing" });
+  });
+
+  it("blocks an empty prompt", () => {
+    const readiness = evaluateBasic({ prompt: "   " });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "prompt-missing" });
+  });
+
+  it("blocks a prompt that was never entered", () => {
+    const readiness = evaluateBasic({ prompt: undefined });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "prompt-missing" });
+  });
+
+  it("blocks a missing mask", () => {
+    const readiness = evaluateBasic({ source: createSource({ mask: undefined }) });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "mask-missing" });
+  });
+
+  it("blocks an empty mask blob", () => {
+    const source = createSource();
+    const readiness = evaluateBasic({
+      source: createSource({ mask: { ...source.mask!, blob: new Blob() } })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "mask-missing" });
+  });
+
+  it("blocks a mask that does not match its source", () => {
+    const source = createSource();
+    const readiness = evaluateBasic({
+      source: createSource({ mask: { ...source.mask!, width: 128 } })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "mask-dimension-mismatch" });
+    expect((readiness as { technicalMessage: string }).technicalMessage).toContain("128");
+  });
+
+  it("blocks an empty selection context", () => {
+    const source = createSource();
+    const readiness = evaluateBasic({
+      source: createSource({
+        selection: { ...source.selection, contextBounds: bounds(100, 100, 100, 100) }
+      })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "context-bounds-invalid" });
+  });
+
+  it("blocks a context whose width is not a multiple of 8, which ComfyUI would round down", () => {
+    const source = createSource();
+    const unaligned = bounds(100, 100, 355, 292);
+    const readiness = evaluateBasic({
+      source: createSource({
+        width: unaligned.width,
+        height: unaligned.height,
+        selection: { ...source.selection, contextBounds: unaligned },
+        mask: { ...source.mask!, width: unaligned.width, height: unaligned.height }
+      })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "context-bounds-unaligned" });
+    expect((readiness as { technicalMessage: string }).technicalMessage).toMatch(/multiple of 8/);
+  });
+
+  it("blocks a source image that does not match its captured context", () => {
+    const readiness = evaluateBasic({
+      source: createSource({ width: 128, mask: createSource().mask, height: contextBounds.height })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "mask-dimension-mismatch" });
+  });
+
+  it("blocks when source and mask agree but neither matches the context bounds", () => {
+    const source = createSource();
+    const readiness = evaluateBasic({
+      source: createSource({
+        width: 128,
+        height: 96,
+        mask: { ...source.mask!, width: 128, height: 96 }
+      })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "source-context-mismatch" });
+  });
+
+  it("blocks a selection that escapes its own context", () => {
+    const source = createSource();
+    const readiness = evaluateBasic({
+      source: createSource({
+        selection: { ...source.selection, bounds: bounds(10, 10, 60, 60) }
+      })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "selection-outside-context" });
+  });
+
+  it("blocks when no checkpoint is selected", () => {
+    const readiness = evaluateBasic({ checkpointName: "  " });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "checkpoint-missing" });
+  });
+
+  it("blocks when a required ComfyUI node is missing", () => {
+    const readiness = evaluateBasic({
+      compatibilityContext: {
+        ...readyContext,
+        availableNodes: { LoadImage: ["image"] }
+      }
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "workflow-not-runnable" });
+    expect(readiness.ok === false && readiness.message).toBeTruthy();
+  });
+
+  it("blocks a checkpoint the ComfyUI server does not have installed", () => {
+    const readiness = evaluateBasic({
+      compatibilityContext: {
+        ...readyContext,
+        selectedModelName: "not-installed.safetensors",
+        availableModels: { checkpoints: ["something-else.safetensors"] }
+      },
+      checkpointName: "not-installed.safetensors"
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "checkpoint-not-installed" });
+    expect((readiness as { technicalMessage: string }).technicalMessage).toContain("something-else.safetensors");
+  });
+
+  it("does not guess about installed models when the server list is unavailable", () => {
+    const readiness = evaluateBasic({
+      compatibilityContext: { ...readyContext, availableModels: undefined }
+    });
+
+    expect(readiness.ok).toBe(true);
+  });
+
+  it("blocks Flux Fill when the mask cannot be embedded into the source PNG", () => {
+    const readiness = evaluateInpaintReadiness({
+      mode: "generate",
+      source: createSource(),
+      preset: fluxPreset,
+      presetId: "inpaint-flux-fill-basic",
+      checkpointName: "flux1-fill-dev.safetensors",
+      prompt: "a cat holding a mouse",
+      maskBridgeAvailable: false
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "flux-fill-mask-bridge-unavailable" });
+  });
+
+  it("does not apply the Flux Fill mask bridge rule to other Inpaint workflows", () => {
+    const readiness = evaluateBasic({ maskBridgeAvailable: false });
+
+    expect(readiness.ok).toBe(true);
+  });
+
+  it("blocks an import whose result does not match the saved source context", () => {
+    const readiness = evaluateImport({
+      resultDimensions: { width: 128, height: 96 }
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "result-dimension-mismatch" });
+  });
+
+  it("blocks an import whose result dimensions could not be read", () => {
+    const readiness = evaluateImport({ resultDimensions: null });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "result-dimension-mismatch" });
+  });
+
+  it("allows an import whose result matches the saved source context", () => {
+    const readiness = evaluateImport({
+      resultDimensions: { width: contextBounds.width, height: contextBounds.height }
+    });
+
+    expect(readiness.ok).toBe(true);
+  });
+
+  it("does not ask an import for a workflow, checkpoint, or prompt it never uses", () => {
+    // Importing replays saved pixels, so a missing checkpoint or an unrunnable
+    // graph must not block it: only the capture geometry and the result matter.
+    const readiness = evaluateImport({
+      preset: null,
+      presetId: "",
+      checkpointName: "",
+      prompt: ""
+    });
+
+    expect(readiness.ok).toBe(true);
+  });
+
+  it("still blocks an import whose saved capture is inconsistent", () => {
+    const source = createSource();
+    const readiness = evaluateImport({
+      source: createSource({ mask: { ...source.mask!, width: 128 } })
+    });
+
+    expect(readiness).toMatchObject({ ok: false, reason: "mask-dimension-mismatch" });
+  });
+
+  it("names the one thing to fix in the status line for every reason", () => {
+    expect(getInpaintReadinessStatusLabel("source-missing")).toBe("Selection required.");
+    expect(getInpaintReadinessStatusLabel("prompt-missing")).toBe("Prompt required.");
+    expect(getInpaintReadinessStatusLabel("mask-missing")).toBe("Mask required.");
+    expect(getInpaintReadinessStatusLabel("checkpoint-not-installed")).toBe("Checkpoint required.");
+    expect(getInpaintReadinessStatusLabel("result-dimension-mismatch")).toBe("Regenerate required.");
+  });
+
+  it("reports the blocking reason and technical detail in one diagnostic line", () => {
+    const readiness = evaluateImport({ resultDimensions: { width: 128, height: 96 } });
+
+    const diagnostic = formatInpaintReadinessDiagnostic(readiness);
+    expect(diagnostic).toContain("result-dimension-mismatch");
+    expect(diagnostic).toContain("128 x 96");
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix exact-mask contamination from layers above the active layer** — the exact-mask Inpaint import previously read its selection from the RGB composite channel, which any visible layer above the active layer could contaminate. This was the confirmed defect flagged during the PR #7 audit. **Host-verified in Photoshop on 2026-07-16/17: with a visible layer above a non-topmost active layer, the mask now matches the saved selection exactly.** The sandwich (temporary black backing + opaque mask layer) is now built above the entire layer stack instead of just above the result layer, with a new `isMaskSandwichTopmost` check that fails the import into the existing rollback rather than risk a contaminated mask.
- **Add an explicit Inpaint readiness contract** — `src/ui/inpaintReadiness.ts` states the full set of Inpaint prerequisites (source, mask, document origin, prompt, geometry, checkpoint availability, Flux Fill mask bridge, workflow runnability, result-dimension match) as pure, unit-tested logic, with distinct `generate` and `import` modes since import runs no workflow and needs no checkpoint.
- **Gate Inpaint on the readiness contract and snapshot at submission** — both `handleGenerateInpaint` and `handleImportInpaint` now evaluate readiness before any upload or prompt submission, and the inpaint source is snapshotted into an immutable copy the moment it passes the gate, closing a gap where a re-captured selection during a long generation could have paired a new source with an old result.
- **Drive the import transaction from its tested finalization plan** — `planImportFinalization` had no caller; the adapter's real cleanup had already drifted from it (missing a channel-targeting restore step, and a whole untested recovery pass). The adapter now consumes the plan (plus a new `planImportRecovery` for the second pass) so the execution order is the same thing the tests assert.

Remaining tracked follow-ups (not in this PR): temporary PNGs (source/mask/debug copies) are never deleted; panel close doesn't cancel an in-flight generation poll loop; the mask alpha ≤ 8 feather tail is silently clipped to 0; `App.ts` is still a single large file pending the planned decomposition.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` (Vitest) — 32 files / 209 tests passing
- [x] `npm run build` — production build succeeds
- [x] Manual Photoshop verification (2026-07-16/17, Mehran): mask shape, feathering, holes, and disconnected regions all correct; contamination from a visible layer above a non-topmost active layer is fixed; previously-working topmost-active-layer case still works; readiness status messages verified for missing selection/prompt/checkpoint; import from history with the workflow dropdown changed still succeeds; rollback restores selection and active layer with no leftover `__OpenLayer_*` layers/channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)