### PR TITLE
Cover the real temporary file names in the sweep tests

### DIFF
--- a/tests/utils/temporaryFileCleanup.test.ts
+++ b/tests/utils/temporaryFileCleanup.test.ts
@@ -5,19 +5,32 @@ import {
 } from "../../src/utils/temporaryFileCleanup";
 
 describe("temporary file sweep eligibility", () => {
-  it("matches every real OpenLayer temporary file name pattern", () => {
-    // From fileUtils.createLayerName() + saveBlobToTemporaryFile() call sites.
-    expect(isSweepableTemporaryFileName("OpenLayer_Generated_20260716_2010.png")).toBe(true);
-    expect(isSweepableTemporaryFileName("OpenLayer_Inpaint_20260716_2010.png")).toBe(true);
-    expect(isSweepableTemporaryFileName("OpenLayer_Source_20260716_2010.png")).toBe(true);
-    expect(isSweepableTemporaryFileName("OpenLayer_Canvas_20260716_2010.png")).toBe(true);
-    expect(isSweepableTemporaryFileName("OpenLayer_Live_20260716_2010.png")).toBe(true);
-    // From importImageAlignedToSelectionWithLayerMask's mask file.
+  // Every createLayerName() prefix that reaches saveBlobToTemporaryFile, whether
+  // the name is built inside the adapter or passed down from a panel handler.
+  it.each([
+    "OpenLayer_Generated_20260716_2010.png",
+    "OpenLayer_Img2Img_20260716_2010.png",
+    "OpenLayer_Inpaint_20260716_2010.png",
+    "OpenLayer_Outpaint_20260716_2010.png",
+    "OpenLayer_Sketch_20260716_2010.png",
+    "OpenLayer_Upscale_20260716_2010.png",
+    "OpenLayer_Live_20260716_2010.png"
+  ])("sweeps the import temporary file %s", (name) => {
+    expect(isSweepableTemporaryFileName(name)).toBe(true);
+  });
+
+  it("sweeps the exact-mask import's double-underscore mask file", () => {
     expect(isSweepableTemporaryFileName("__OpenLayer_InpaintMask_1737054000000_ab12cd.png")).toBe(true);
-    // From saveInpaintDebugBlobsToTemporaryFiles.
-    expect(isSweepableTemporaryFileName("OpenLayer_Inpaint_Debug_20260716_2010_source.png")).toBe(true);
-    expect(isSweepableTemporaryFileName("OpenLayer_Inpaint_Debug_20260716_2010_mask.png")).toBe(true);
-    expect(isSweepableTemporaryFileName("OpenLayer_Inpaint_Debug_20260716_2010_raw-result.png")).toBe(true);
+  });
+
+  // These outlive their generation on purpose, so the startup sweep is the only
+  // thing that ever removes them.
+  it.each([
+    "OpenLayer_Inpaint_Debug_20260716_2010_source.png",
+    "OpenLayer_Inpaint_Debug_20260716_2010_mask.png",
+    "OpenLayer_Inpaint_Debug_20260716_2010_raw-result.png"
+  ])("sweeps the Inpaint debug copy %s", (name) => {
+    expect(isSweepableTemporaryFileName(name)).toBe(true);
   });
 
   it("does not match a file that only happens to contain the word OpenLayer", () => {


### PR DESCRIPTION
## Summary

Test-only follow-up to #9, found while verifying the sweep against a real Photoshop UXP temporary folder.

The sweep eligibility test claimed to enumerate every real OpenLayer temporary file name, but it was written from memory rather than from the call sites. It asserted `OpenLayer_Source` and `OpenLayer_Canvas` — which name blobs uploaded to ComfyUI and never reach `saveBlobToTemporaryFile` — and missed four prefixes that do: `Img2Img`, `Outpaint`, `Sketch`, `Upscale`.

**No behavior was wrong**: the pattern is a prefix wildcard (`/^_{0,2}OpenLayer_.*\.png$/i`) and already matched all of them. Verified directly against the real UXP temp folder holding **44 accumulated PNGs** from before #9 landed — the pattern matches all 44, missing none. This replaces the invented names with every `createLayerName` prefix that actually reaches a temporary file, so a future prefix the pattern *wouldn't* match fails a test here instead of silently accumulating.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 34 files / 233 tests passing (up from 223)
- [x] `npm run build` — production build succeeds
- [x] Real regex extracted from source and run against all 44 real temp files: 44 matched, 0 missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)