### PR TITLE
v0.6 step 4: extract the generation pipeline into a run-owning controller

### DIFF
--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -10,15 +10,14 @@ import { formatFluxFillReferenceDefaults } from "../comfy/fluxFillDefaults";
 import {
   formatCancelDiagnostic,
   formatCancelResultDiagnostic,
-  createGenerationCancelledError,
   isGenerationCancelledError
 } from "../comfy/generationCancel";
-import {
-  canPublishGenerationUpdate,
-  shouldFinalizeActiveRun,
-  validateGenerationCommit
-} from "./generationIntegrity";
 import { createObjectUrlRegistry, ObjectUrlRegistry } from "./objectUrlRegistry";
+import {
+  createGenerationController,
+  GenerationPipelineUi,
+  GenerationRunHandle
+} from "./generationController";
 import {
   BUSY_DISABLED_ACTIONS,
   BUSY_DISABLED_FIELDS,
@@ -212,15 +211,6 @@ type AppGeneratedImageResult = DocumentContextBound<GeneratedImageResult>;
 type AppInpaintImportContext = InpaintImportContext<SelectedRegionSourceImage, AppGeneratedImageResult>;
 type LiveGeneratedImageResult = DocumentContextBound<{ blob: Blob }>;
 
-type ActiveGeneration = {
-  runId: number;
-  toolType: HistoryToolType;
-  client: ComfyClient;
-  promptId?: string;
-  watcher: ReturnType<ComfyClient["watchProgress"]> | null;
-  isCancelled: boolean;
-};
-
 const statusProgressTimers = new WeakMap<HTMLElement, number>();
 // Remembers the last real step percentage per progress bar so percent-less
 // status updates (e.g. the history poll tick) cannot reset a determinate bar
@@ -248,8 +238,6 @@ export function renderApp(rootElement: HTMLElement) {
   let upscaleImportAutomatically = false;
   let isNegativePromptOpen = false;
   let allowExperimentalCheckpoints = false;
-  let activeGeneration: ActiveGeneration | null = null;
-  let generationRunSequence = 0;
   let livePaintingSession: LivePaintingSession | null = null;
   let livePreviewImage: HTMLImageElement | null = null;
   let livePreviewObjectUrl = "";
@@ -367,16 +355,36 @@ export function renderApp(rootElement: HTMLElement) {
     imageAlt: "Captured Photoshop source for Prompt from Layer"
   });
   const inpaintMaskUrl = createOwnedObjectUrl(objectUrls);
+  const generation = createGenerationController({
+    onRunStarted: () => setCancelGenerationVisible(elements, true),
+    onRunFinished: (toolType) => {
+      releaseGenerationLivePreview(toolType);
+      setCancelGenerationVisible(elements, false);
+    }
+  });
+
+  // Adapts one tool's reporting surfaces to the pipeline's hooks. The
+  // controller gates every call on run currency before it reaches these.
+  function createPipelineUi(toolType: HistoryToolType, stepProgressElement: HTMLElement): GenerationPipelineUi {
+    const toolUi = generationToolUi[toolType];
+
+    return {
+      status: (message, tone) => toolUi.status(elements, message, tone),
+      progressPreview: (message, blob) => toolUi.progress?.(elements, message, blob),
+      stepProgress: (value, max) => applyDeterminateProgress(stepProgressElement, value, max),
+      diagnostics: (message) => toolUi.diagnostics(elements, message),
+      cancelled: (promptId) => showGenerationCancelled(toolType, promptId)
+    };
+  }
   let resourceObserver: MutationObserver | null = null;
   let resourcesDisposed = false;
   const disposeAppResources = () => {
     if (resourcesDisposed) return;
     resourcesDisposed = true;
-    // isCancelled must be set before closing the watcher: pollUntilComplete only
+    // Cancelling before the watcher closes matters: pollUntilComplete only
     // checks isCancelled() between polls, so closing the watcher alone leaves an
     // in-flight poll loop running against ComfyUI after the panel is gone.
-    if (activeGeneration) activeGeneration.isCancelled = true;
-    activeGeneration?.watcher?.close();
+    generation.disposeActive();
     livePaintingSession?.stop("Live session stopped because the OpenLayer panel closed.");
     for (const progressElement of [
       elements.statusProgress,
@@ -883,31 +891,6 @@ export function renderApp(rootElement: HTMLElement) {
     );
   }
 
-  function beginActiveGeneration(toolType: HistoryToolType, client: ComfyClient, promptId: string): ActiveGeneration {
-    const activeRun: ActiveGeneration = {
-      runId: ++generationRunSequence,
-      toolType,
-      client,
-      promptId,
-      watcher: null,
-      isCancelled: false
-    };
-
-    activeGeneration = activeRun;
-    setCancelGenerationVisible(elements, true);
-    return activeRun;
-  }
-
-  function finishActiveGeneration(activeRun: ActiveGeneration | null) {
-    activeRun?.watcher?.close();
-
-    if (activeRun && shouldFinalizeActiveRun(activeRun, activeGeneration)) {
-      releaseGenerationLivePreview(activeRun.toolType);
-      activeGeneration = null;
-      setCancelGenerationVisible(elements, false);
-    }
-  }
-
   function releaseGenerationLivePreview(toolType: HistoryToolType) {
     switch (toolType) {
       case "image-to-image": imageResultPanel.releaseLivePreviewUrl(); return;
@@ -918,16 +901,6 @@ export function renderApp(rootElement: HTMLElement) {
       case "text-to-image": resultPanel.releaseLivePreviewUrl(); return;
       case "prompt-from-layer": return;
     }
-  }
-
-  function ensureGenerationCanCommit(activeRun: ActiveGeneration | null) {
-    if (!activeRun) throw createGenerationCancelledError();
-    const validation = validateGenerationCommit(activeRun, activeGeneration);
-    if (!validation.ok) throw createGenerationCancelledError();
-  }
-
-  function publishGenerationUpdate(activeRun: ActiveGeneration | null, update: () => void) {
-    if (activeRun && canPublishGenerationUpdate(activeRun, activeGeneration)) update();
   }
 
   // One row per tool: how each generation surface reports status, diagnostics,
@@ -972,32 +945,29 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleCancelGeneration() {
-    const generation = activeGeneration;
+    const active = generation.cancelActive();
 
-    if (!generation) {
+    if (!active) {
       setDiagnostics(elements, "No active generation to cancel.");
       return;
     }
 
-    generation.isCancelled = true;
-    generation.watcher?.close();
-    generation.watcher = null;
-    setGenerationToolStatus(generation.toolType, "Cancelling generation...", "idle");
-    setGenerationToolProgress(generation.toolType, "Cancelling generation...");
+    setGenerationToolStatus(active.toolType, "Cancelling generation...", "idle");
+    setGenerationToolProgress(active.toolType, "Cancelling generation...");
     setCancelGenerationVisible(elements, false);
 
     try {
-      const cancelResult = await generation.client.cancelPrompt(generation.promptId);
-      if (shouldFinalizeActiveRun(generation, activeGeneration)) {
+      const cancelResult = await active.client.cancelPrompt(active.promptId);
+      if (active.isCurrent()) {
         setGenerationToolDiagnostics(
-          generation.toolType,
-          formatCancelResultDiagnostic(cancelResult, generation.promptId)
+          active.toolType,
+          formatCancelResultDiagnostic(cancelResult, active.promptId)
         );
       }
     } catch (caughtError) {
-      if (shouldFinalizeActiveRun(generation, activeGeneration)) {
+      if (active.isCurrent()) {
         setGenerationToolDiagnostics(
-          generation.toolType,
+          active.toolType,
           `Cancel requested locally. ComfyUI interrupt may already be complete or unavailable. ${getTechnicalErrorDetails(caughtError)}`
         );
       }
@@ -1019,8 +989,6 @@ export function renderApp(rootElement: HTMLElement) {
     syncBusy();
     setStatus(elements, "Preparing workflow...", "idle");
     setProgressPreview(elements, "Preparing workflow...");
-    let progressWatcher: ReturnType<ComfyClient["watchProgress"]> | null = null;
-    let activeRun: ActiveGeneration | null = null;
 
     try {
       const originatingDocument = getActiveDocumentIdentity();
@@ -1073,75 +1041,43 @@ export function renderApp(rootElement: HTMLElement) {
         seed: settings.seed
       });
 
-      setStatus(elements, "Submitting prompt to ComfyUI...", "idle");
-      setProgressPreview(elements, "Submitting prompt to ComfyUI...");
-      const promptId = await client.submitPrompt(buildResult.workflow);
-      activeRun = beginActiveGeneration("text-to-image", client, promptId);
-      let hasLivePreview = false;
-      progressWatcher = client.watchProgress(promptId, {
-        onStatus: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setProgressPreview(elements, message);
-          }
-        },
-        onProgress: (value, max) => publishGenerationUpdate(activeRun, () => applyDeterminateProgress(elements.statusProgress, value, max)),
-        onPreviewBlob: (blob) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          hasLivePreview = true;
-          setProgressPreview(elements, "Live ComfyUI preview...", blob);
-        },
-        onError: (message) => publishGenerationUpdate(activeRun, () => setDiagnostics(elements, message))
-      });
-      activeRun.watcher = progressWatcher;
-
-      setStatus(elements, "Generating image...", "idle");
-      setProgressPreview(elements, "Generating image...");
-      const history = await client.pollUntilComplete(
-        promptId,
-        {
-          onTick: (message) => {
-            if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-            setStatus(elements, message, "idle");
-
-            if (!hasLivePreview) {
-              setProgressPreview(elements, message);
-          }
-        },
-        isCancelled: () => Boolean(activeRun?.isCancelled)
-      }
-      );
-      progressWatcher?.close();
-      progressWatcher = null;
-      activeRun.watcher = null;
-
-      setStatus(elements, "Retrieving image...", "idle");
-      setProgressPreview(elements, "Retrieving final image...");
-      const generatedResult = bindDocumentContext(
-        await client.retrieveFirstOutputImage(promptId, history, {
-          preferredNodeId: getSaveImageNodeId(buildResult.preset)
-        }),
-        originatingDocument
-      );
-      ensureGenerationCanCommit(activeRun);
-      setResult(generatedResult);
-      addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
-        prompt: elements.prompt.value,
-        negativePrompt: elements.negativePrompt.value,
-        checkpointName,
-        modelName: checkpointName,
-        workflowPreset: buildResult.preset.id,
+      const generatedResult = await generation.runPipeline({
         toolType: "text-to-image",
-        seed: buildResult.seed,
-        sizeLabel: `${settings.width} x ${settings.height}`,
-        dimensions: `${settings.width} x ${settings.height}`,
-        sourceMode: "Prompt only",
-        experimental: buildResult.preset.status === "experimental"
+        client,
+        workflow: buildResult.workflow,
+        preferredNodeId: getSaveImageNodeId(buildResult.preset),
+        originatingDocument: originatingDocument,
+        ui: createPipelineUi("text-to-image", elements.statusProgress),
+        messages: {
+          submitStatus: "Submitting prompt to ComfyUI...",
+          submitPreview: "Submitting prompt to ComfyUI...",
+          generateStatus: "Generating image...",
+          generatePreview: "Generating image...",
+          retrieveStatus: "Retrieving image...",
+          retrievePreview: "Retrieving final image...",
+          livePreview: "Live ComfyUI preview..."
+        },
+        commit: (generatedResult) => {
+        setResult(generatedResult);
+        addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
+          prompt: elements.prompt.value,
+          negativePrompt: elements.negativePrompt.value,
+          checkpointName,
+          modelName: checkpointName,
+          workflowPreset: buildResult.preset.id,
+          toolType: "text-to-image",
+          seed: buildResult.seed,
+          sizeLabel: `${settings.width} x ${settings.height}`,
+          dimensions: `${settings.width} x ${settings.height}`,
+          sourceMode: "Prompt only",
+          experimental: buildResult.preset.status === "experimental"
+        });
+        }
       });
-      finishActiveGeneration(activeRun);
-      activeRun = null;
+
+      if (!generatedResult) {
+        return;
+      }
 
       if (importAutomatically) {
         setStatus(elements, "Generation complete. Auto-importing...", "idle");
@@ -1156,7 +1092,7 @@ export function renderApp(rootElement: HTMLElement) {
       updateSettingsReport(elements);
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {
-        if (!activeRun || shouldFinalizeActiveRun(activeRun, activeGeneration)) showGenerationCancelled("text-to-image", activeRun?.promptId);
+        showGenerationCancelled("text-to-image");
         return;
       }
 
@@ -1164,8 +1100,6 @@ export function renderApp(rootElement: HTMLElement) {
       setError(elements, getErrorMessage(caughtError));
       setDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
-      progressWatcher?.close();
-      finishActiveGeneration(activeRun);
       isBusy = false;
       syncBusy();
     }
@@ -1441,8 +1375,6 @@ export function renderApp(rootElement: HTMLElement) {
     syncBusy();
     setImageStatus(elements, "Preparing Image to Image workflow...", "idle");
     setImageProgressPreview(elements, "Preparing Image to Image workflow...");
-    let progressWatcher: ReturnType<ComfyClient["watchProgress"]> | null = null;
-    let activeRun: ActiveGeneration | null = null;
 
     try {
       const workflowPreset = readSelectValue(elements.imgWorkflow, DEFAULT_IMAGE_WORKFLOW);
@@ -1509,72 +1441,46 @@ export function renderApp(rootElement: HTMLElement) {
         denoise: settings.denoise
       });
 
-      setImageStatus(elements, "Submitting Image to Image prompt...", "idle");
-      setImageProgressPreview(elements, "Submitting prompt to ComfyUI...");
-      const promptId = await client.submitPrompt(buildResult.workflow);
-      activeRun = beginActiveGeneration("image-to-image", client, promptId);
-      let hasLivePreview = false;
-      progressWatcher = client.watchProgress(promptId, {
-        onStatus: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setImageStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setImageProgressPreview(elements, message);
-          }
-        },
-        onProgress: (value, max) => publishGenerationUpdate(activeRun, () => applyDeterminateProgress(elements.imgStatusProgress, value, max)),
-        onPreviewBlob: (blob) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          hasLivePreview = true;
-          setImageProgressPreview(elements, "Live ComfyUI preview...", blob);
-        },
-        onError: (message) => publishGenerationUpdate(activeRun, () => setImageDiagnostics(elements, message))
-      });
-      activeRun.watcher = progressWatcher;
-
-      setImageStatus(elements, "Generating Image to Image result...", "idle");
-      setImageProgressPreview(elements, "Generating image...");
-      const history = await client.pollUntilComplete(promptId, {
-        onTick: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setImageStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setImageProgressPreview(elements, message);
-          }
-        },
-        isCancelled: () => Boolean(activeRun?.isCancelled)
-      });
-      progressWatcher?.close();
-      progressWatcher = null;
-      activeRun.watcher = null;
-
-      setImageStatus(elements, "Retrieving Image to Image result...", "idle");
-      setImageProgressPreview(elements, "Retrieving final image...");
-      const generatedResult = bindDocumentContext(
-        await client.retrieveFirstOutputImage(promptId, history, {
-          preferredNodeId: getSaveImageNodeId(buildResult.preset)
-        }),
-        imageSource.originatingDocument
-      );
-      ensureGenerationCanCommit(activeRun);
-      setImageResult(generatedResult);
-      addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
-        prompt: elements.imgPrompt.value,
-        negativePrompt: elements.imgNegativePrompt.value,
-        checkpointName,
-        modelName: checkpointName,
-        workflowPreset: buildResult.preset.id,
+      // The commit closure runs after awaits; a const keeps the null-checked
+      // source from the top of the handler rather than re-reading mutable state.
+      const capturedSource = imageSource;
+      const generatedResult = await generation.runPipeline({
         toolType: "image-to-image",
-        seed: buildResult.seed,
-        sizeLabel: "Image to Image",
-        dimensions: `${imageSource.width} x ${imageSource.height}`,
-        sourceMode: imageSource.sourceName,
-        experimental: buildResult.preset.status === "experimental"
+        client,
+        workflow: buildResult.workflow,
+        preferredNodeId: getSaveImageNodeId(buildResult.preset),
+        originatingDocument: capturedSource.originatingDocument,
+        ui: createPipelineUi("image-to-image", elements.imgStatusProgress),
+        messages: {
+          submitStatus: "Submitting Image to Image prompt...",
+          submitPreview: "Submitting prompt to ComfyUI...",
+          generateStatus: "Generating Image to Image result...",
+          generatePreview: "Generating image...",
+          retrieveStatus: "Retrieving Image to Image result...",
+          retrievePreview: "Retrieving final image...",
+          livePreview: "Live ComfyUI preview..."
+        },
+        commit: (generatedResult) => {
+        setImageResult(generatedResult);
+        addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
+          prompt: elements.imgPrompt.value,
+          negativePrompt: elements.imgNegativePrompt.value,
+          checkpointName,
+          modelName: checkpointName,
+          workflowPreset: buildResult.preset.id,
+          toolType: "image-to-image",
+          seed: buildResult.seed,
+          sizeLabel: "Image to Image",
+          dimensions: `${capturedSource.width} x ${capturedSource.height}`,
+          sourceMode: capturedSource.sourceName,
+          experimental: buildResult.preset.status === "experimental"
+        });
+        }
       });
-      finishActiveGeneration(activeRun);
-      activeRun = null;
+
+      if (!generatedResult) {
+        return;
+      }
       setImageStatus(elements, "Image to Image generation complete.", "ready");
       setImageDiagnostics(
         elements,
@@ -1588,7 +1494,7 @@ export function renderApp(rootElement: HTMLElement) {
       }
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {
-        if (!activeRun || shouldFinalizeActiveRun(activeRun, activeGeneration)) showGenerationCancelled("image-to-image", activeRun?.promptId);
+        showGenerationCancelled("image-to-image");
         return;
       }
 
@@ -1597,8 +1503,6 @@ export function renderApp(rootElement: HTMLElement) {
       console.error("[OpenLayer] Image to Image generation failed", getTechnicalErrorDetails(caughtError));
       setImageDiagnostics(elements, getImageToImageFailureHint(caughtError));
     } finally {
-      progressWatcher?.close();
-      finishActiveGeneration(activeRun);
       isBusy = false;
       syncBusy();
     }
@@ -1729,8 +1633,6 @@ export function renderApp(rootElement: HTMLElement) {
     syncBusy();
     setUpscaleStatus(elements, "Preparing Upscale workflow...", "idle");
     setUpscaleProgressPreview(elements, "Preparing Upscale workflow...");
-    let progressWatcher: ReturnType<ComfyClient["watchProgress"]> | null = null;
-    let activeRun: ActiveGeneration | null = null;
 
     try {
       const workflowPreset = readSelectValue(elements.upscaleWorkflow, DEFAULT_UPSCALE_WORKFLOW);
@@ -1764,71 +1666,45 @@ export function renderApp(rootElement: HTMLElement) {
         modelName
       });
 
-      setUpscaleStatus(elements, "Submitting Upscale prompt...", "idle");
-      setUpscaleProgressPreview(elements, "Submitting prompt to ComfyUI...");
-      const promptId = await client.submitPrompt(buildResult.workflow);
-      activeRun = beginActiveGeneration("upscale", client, promptId);
-      let hasLivePreview = false;
-      progressWatcher = client.watchProgress(promptId, {
-        onStatus: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setUpscaleStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setUpscaleProgressPreview(elements, message);
-          }
-        },
-        onProgress: (value, max) => publishGenerationUpdate(activeRun, () => applyDeterminateProgress(elements.upscaleStatusProgress, value, max)),
-        onPreviewBlob: (blob) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          hasLivePreview = true;
-          setUpscaleProgressPreview(elements, "Live ComfyUI preview...", blob);
-        },
-        onError: (message) => publishGenerationUpdate(activeRun, () => setUpscaleDiagnostics(elements, message))
-      });
-      activeRun.watcher = progressWatcher;
-
-      setUpscaleStatus(elements, "Upscaling image...", "idle");
-      setUpscaleProgressPreview(elements, "Upscaling image...");
-      const history = await client.pollUntilComplete(promptId, {
-        onTick: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setUpscaleStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setUpscaleProgressPreview(elements, message);
-          }
-        },
-        isCancelled: () => Boolean(activeRun?.isCancelled)
-      });
-      progressWatcher?.close();
-      progressWatcher = null;
-      activeRun.watcher = null;
-
-      setUpscaleStatus(elements, "Retrieving Upscale result...", "idle");
-      setUpscaleProgressPreview(elements, "Retrieving final image...");
-      const generatedResult = bindDocumentContext(
-        await client.retrieveFirstOutputImage(promptId, history, {
-          preferredNodeId: getSaveImageNodeId(buildResult.preset)
-        }),
-        upscaleSource.originatingDocument
-      );
-      ensureGenerationCanCommit(activeRun);
-      setUpscaleResult(generatedResult);
-      addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
-        prompt: `Upscale ${upscaleSource.sourceName}`,
-        checkpointName: modelName,
-        modelName,
-        workflowPreset: buildResult.preset.id,
+      // The commit closure runs after awaits; a const keeps the null-checked
+      // source from the top of the handler rather than re-reading mutable state.
+      const capturedSource = upscaleSource;
+      const generatedResult = await generation.runPipeline({
         toolType: "upscale",
-        seed: 0,
-        sizeLabel: "Upscale",
-        dimensions: `${upscaleSource.width} x ${upscaleSource.height} source`,
-        sourceMode: upscaleSource.sourceName,
-        experimental: buildResult.preset.status === "experimental"
+        client,
+        workflow: buildResult.workflow,
+        preferredNodeId: getSaveImageNodeId(buildResult.preset),
+        originatingDocument: capturedSource.originatingDocument,
+        ui: createPipelineUi("upscale", elements.upscaleStatusProgress),
+        messages: {
+          submitStatus: "Submitting Upscale prompt...",
+          submitPreview: "Submitting prompt to ComfyUI...",
+          generateStatus: "Upscaling image...",
+          generatePreview: "Upscaling image...",
+          retrieveStatus: "Retrieving Upscale result...",
+          retrievePreview: "Retrieving final image...",
+          livePreview: "Live ComfyUI preview..."
+        },
+        commit: (generatedResult) => {
+        setUpscaleResult(generatedResult);
+        addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
+          prompt: `Upscale ${capturedSource.sourceName}`,
+          checkpointName: modelName,
+          modelName,
+          workflowPreset: buildResult.preset.id,
+          toolType: "upscale",
+          seed: 0,
+          sizeLabel: "Upscale",
+          dimensions: `${capturedSource.width} x ${capturedSource.height} source`,
+          sourceMode: capturedSource.sourceName,
+          experimental: buildResult.preset.status === "experimental"
+        });
+        }
       });
-      finishActiveGeneration(activeRun);
-      activeRun = null;
+
+      if (!generatedResult) {
+        return;
+      }
       setUpscaleStatus(elements, "Upscale generation complete.", "ready");
       setUpscaleDiagnostics(
         elements,
@@ -1842,7 +1718,7 @@ export function renderApp(rootElement: HTMLElement) {
       }
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {
-        if (!activeRun || shouldFinalizeActiveRun(activeRun, activeGeneration)) showGenerationCancelled("upscale", activeRun?.promptId);
+        showGenerationCancelled("upscale");
         return;
       }
 
@@ -1851,8 +1727,6 @@ export function renderApp(rootElement: HTMLElement) {
       console.error("[OpenLayer] Upscale generation failed", getTechnicalErrorDetails(caughtError));
       setUpscaleDiagnostics(elements, getUpscaleFailureHint(caughtError));
     } finally {
-      progressWatcher?.close();
-      finishActiveGeneration(activeRun);
       isBusy = false;
       syncBusy();
     }
@@ -1992,8 +1866,6 @@ export function renderApp(rootElement: HTMLElement) {
     syncBusy();
     setOutpaintStatus(elements, "Preparing Outpaint workflow...", "idle");
     setOutpaintProgressPreview(elements, "Preparing Outpaint workflow...");
-    let progressWatcher: ReturnType<ComfyClient["watchProgress"]> | null = null;
-    let activeRun: ActiveGeneration | null = null;
 
     try {
       const workflowPreset = readSelectValue(elements.outpaintWorkflow, DEFAULT_OUTPAINT_WORKFLOW);
@@ -2059,82 +1931,56 @@ export function renderApp(rootElement: HTMLElement) {
         requiredModelSelections
       });
 
-      setOutpaintStatus(elements, "Submitting Outpaint prompt...", "idle");
-      setOutpaintProgressPreview(elements, "Submitting prompt to ComfyUI...");
-      const promptId = await client.submitPrompt(buildResult.workflow);
-      activeRun = beginActiveGeneration("outpaint", client, promptId);
-      let hasLivePreview = false;
-      progressWatcher = client.watchProgress(promptId, {
-        onStatus: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setOutpaintStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setOutpaintProgressPreview(elements, message);
-          }
-        },
-        onProgress: (value, max) => publishGenerationUpdate(activeRun, () => applyDeterminateProgress(elements.outpaintStatusProgress, value, max)),
-        onPreviewBlob: (blob) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          hasLivePreview = true;
-          setOutpaintProgressPreview(elements, "Live ComfyUI Outpaint preview...", blob);
-        },
-        onError: (message) => publishGenerationUpdate(activeRun, () => setOutpaintDiagnostics(elements, message))
-      });
-      activeRun.watcher = progressWatcher;
-
-      setOutpaintStatus(elements, "Generating Outpaint result...", "idle");
-      setOutpaintProgressPreview(elements, "Generating outpaint...");
-      const history = await client.pollUntilComplete(promptId, {
-        onTick: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setOutpaintStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setOutpaintProgressPreview(elements, message);
-          }
-        },
-        isCancelled: () => Boolean(activeRun?.isCancelled)
-      });
-      progressWatcher?.close();
-      progressWatcher = null;
-      activeRun.watcher = null;
-
-      setOutpaintStatus(elements, "Retrieving Outpaint result...", "idle");
-      setOutpaintProgressPreview(elements, "Retrieving final image...");
-      const generatedResult = bindDocumentContext(
-        await client.retrieveFirstOutputImage(promptId, history, {
-          preferredNodeId: getSaveImageNodeId(buildResult.preset)
-        }),
-        outpaintSource.originatingDocument
-      );
-      ensureGenerationCanCommit(activeRun);
-      setOutpaintResult(generatedResult);
-      addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
-        prompt: elements.outpaintPrompt.value,
-        checkpointName,
-        modelName: checkpointName,
-        workflowPreset: buildResult.preset.id,
+      // The commit closure runs after awaits; a const keeps the null-checked
+      // source from the top of the handler rather than re-reading mutable state.
+      const capturedSource = outpaintSource;
+      const generatedResult = await generation.runPipeline({
         toolType: "outpaint",
-        seed: buildResult.seed,
-        sizeLabel: "Outpaint",
-        dimensions: `${outpaintSource.width} x ${outpaintSource.height}`,
-        sourceMode: outpaintSource.sourceName,
-        experimental: true,
-        diagnosticsSummary: formatInpaintOutpaintDebugContract({
+        client,
+        workflow: buildResult.workflow,
+        preferredNodeId: getSaveImageNodeId(buildResult.preset),
+        originatingDocument: capturedSource.originatingDocument,
+        ui: createPipelineUi("outpaint", elements.outpaintStatusProgress),
+        messages: {
+          submitStatus: "Submitting Outpaint prompt...",
+          submitPreview: "Submitting prompt to ComfyUI...",
+          generateStatus: "Generating Outpaint result...",
+          generatePreview: "Generating outpaint...",
+          retrieveStatus: "Retrieving Outpaint result...",
+          retrievePreview: "Retrieving final image...",
+          livePreview: "Live ComfyUI Outpaint preview..."
+        },
+        commit: (generatedResult) => {
+        setOutpaintResult(generatedResult);
+        addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
+          prompt: elements.outpaintPrompt.value,
+          checkpointName,
+          modelName: checkpointName,
+          workflowPreset: buildResult.preset.id,
           toolType: "outpaint",
-          presetId: buildResult.preset.id,
-          sourceMode: outpaintSource.sourceName,
-          sourceDimensions: {
-            width: outpaintSource.width,
-            height: outpaintSource.height
-          },
-          outputKind: "expanded canvas",
-          importMode: "new layer"
-        })
+          seed: buildResult.seed,
+          sizeLabel: "Outpaint",
+          dimensions: `${capturedSource.width} x ${capturedSource.height}`,
+          sourceMode: capturedSource.sourceName,
+          experimental: true,
+          diagnosticsSummary: formatInpaintOutpaintDebugContract({
+            toolType: "outpaint",
+            presetId: buildResult.preset.id,
+            sourceMode: capturedSource.sourceName,
+            sourceDimensions: {
+              width: capturedSource.width,
+              height: capturedSource.height
+            },
+            outputKind: "expanded canvas",
+            importMode: "new layer"
+          })
+        });
+        }
       });
-      finishActiveGeneration(activeRun);
-      activeRun = null;
+
+      if (!generatedResult) {
+        return;
+      }
       setOutpaintStatus(elements, "Outpaint generation complete.", "ready");
       setOutpaintDiagnostics(
         elements,
@@ -2142,7 +1988,7 @@ export function renderApp(rootElement: HTMLElement) {
       );
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {
-        if (!activeRun || shouldFinalizeActiveRun(activeRun, activeGeneration)) showGenerationCancelled("outpaint", activeRun?.promptId);
+        showGenerationCancelled("outpaint");
         return;
       }
 
@@ -2151,8 +1997,6 @@ export function renderApp(rootElement: HTMLElement) {
       console.error("[OpenLayer] Outpaint generation failed", getTechnicalErrorDetails(caughtError));
       setOutpaintDiagnostics(elements, getOutpaintFailureHint(caughtError));
     } finally {
-      progressWatcher?.close();
-      finishActiveGeneration(activeRun);
       isBusy = false;
       syncBusy();
     }
@@ -2284,8 +2128,6 @@ export function renderApp(rootElement: HTMLElement) {
     syncBusy();
     setSketchStatus(elements, "Preparing LINECN workflow...", "idle");
     setSketchProgressPreview(elements, "Preparing LINECN workflow...");
-    let progressWatcher: ReturnType<ComfyClient["watchProgress"]> | null = null;
-    let activeRun: ActiveGeneration | null = null;
 
     try {
       const workflowPreset = readSelectValue(elements.sketchWorkflow, DEFAULT_SKETCH_WORKFLOW);
@@ -2355,72 +2197,46 @@ export function renderApp(rootElement: HTMLElement) {
         controlStrength: settings.controlStrength
       });
 
-      setSketchStatus(elements, "Submitting Sketch to Image prompt...", "idle");
-      setSketchProgressPreview(elements, "Submitting prompt to ComfyUI...");
-      const promptId = await client.submitPrompt(buildResult.workflow);
-      activeRun = beginActiveGeneration("sketch-to-image", client, promptId);
-      let hasLivePreview = false;
-      progressWatcher = client.watchProgress(promptId, {
-        onStatus: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setSketchStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setSketchProgressPreview(elements, message);
-          }
-        },
-        onProgress: (value, max) => publishGenerationUpdate(activeRun, () => applyDeterminateProgress(elements.sketchStatusProgress, value, max)),
-        onPreviewBlob: (blob) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          hasLivePreview = true;
-          setSketchProgressPreview(elements, "Live ComfyUI preview...", blob);
-        },
-        onError: (message) => publishGenerationUpdate(activeRun, () => setSketchDiagnostics(elements, message))
-      });
-      activeRun.watcher = progressWatcher;
-
-      setSketchStatus(elements, "Generating Sketch to Image result...", "idle");
-      setSketchProgressPreview(elements, "Generating image...");
-      const history = await client.pollUntilComplete(promptId, {
-        onTick: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setSketchStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setSketchProgressPreview(elements, message);
-          }
-        },
-        isCancelled: () => Boolean(activeRun?.isCancelled)
-      });
-      progressWatcher?.close();
-      progressWatcher = null;
-      activeRun.watcher = null;
-
-      setSketchStatus(elements, "Retrieving Sketch to Image result...", "idle");
-      setSketchProgressPreview(elements, "Retrieving final image...");
-      const generatedResult = bindDocumentContext(
-        await client.retrieveFirstOutputImage(promptId, history, {
-          preferredNodeId: getSaveImageNodeId(buildResult.preset)
-        }),
-        sketchSource.originatingDocument
-      );
-      ensureGenerationCanCommit(activeRun);
-      setSketchResult(generatedResult);
-      addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
-        prompt: elements.sketchPrompt.value,
-        negativePrompt: elements.sketchNegativePrompt.value,
-        checkpointName,
-        modelName: checkpointName,
-        workflowPreset: buildResult.preset.id,
+      // The commit closure runs after awaits; a const keeps the null-checked
+      // source from the top of the handler rather than re-reading mutable state.
+      const capturedSource = sketchSource;
+      const generatedResult = await generation.runPipeline({
         toolType: "sketch-to-image",
-        seed: buildResult.seed,
-        sizeLabel: "Sketch to Image",
-        dimensions: `${sketchSource.width} x ${sketchSource.height}`,
-        sourceMode: sketchSource.sourceName,
-        experimental: buildResult.preset.status === "experimental"
+        client,
+        workflow: buildResult.workflow,
+        preferredNodeId: getSaveImageNodeId(buildResult.preset),
+        originatingDocument: capturedSource.originatingDocument,
+        ui: createPipelineUi("sketch-to-image", elements.sketchStatusProgress),
+        messages: {
+          submitStatus: "Submitting Sketch to Image prompt...",
+          submitPreview: "Submitting prompt to ComfyUI...",
+          generateStatus: "Generating Sketch to Image result...",
+          generatePreview: "Generating image...",
+          retrieveStatus: "Retrieving Sketch to Image result...",
+          retrievePreview: "Retrieving final image...",
+          livePreview: "Live ComfyUI preview..."
+        },
+        commit: (generatedResult) => {
+        setSketchResult(generatedResult);
+        addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
+          prompt: elements.sketchPrompt.value,
+          negativePrompt: elements.sketchNegativePrompt.value,
+          checkpointName,
+          modelName: checkpointName,
+          workflowPreset: buildResult.preset.id,
+          toolType: "sketch-to-image",
+          seed: buildResult.seed,
+          sizeLabel: "Sketch to Image",
+          dimensions: `${capturedSource.width} x ${capturedSource.height}`,
+          sourceMode: capturedSource.sourceName,
+          experimental: buildResult.preset.status === "experimental"
+        });
+        }
       });
-      finishActiveGeneration(activeRun);
-      activeRun = null;
+
+      if (!generatedResult) {
+        return;
+      }
       setSketchStatus(elements, "Sketch to Image generation complete.", "ready");
       setSketchDiagnostics(
         elements,
@@ -2428,7 +2244,7 @@ export function renderApp(rootElement: HTMLElement) {
       );
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {
-        if (!activeRun || shouldFinalizeActiveRun(activeRun, activeGeneration)) showGenerationCancelled("sketch-to-image", activeRun?.promptId);
+        showGenerationCancelled("sketch-to-image");
         return;
       }
 
@@ -2437,8 +2253,6 @@ export function renderApp(rootElement: HTMLElement) {
       console.error("[OpenLayer] Sketch to Image generation failed", getTechnicalErrorDetails(caughtError));
       setSketchDiagnostics(elements, getSketchFailureHint(caughtError));
     } finally {
-      progressWatcher?.close();
-      finishActiveGeneration(activeRun);
       isBusy = false;
       syncBusy();
     }
@@ -2607,8 +2421,6 @@ export function renderApp(rootElement: HTMLElement) {
     syncBusy();
     setInpaintStatus(elements, "Preparing Inpaint workflow...", "idle");
     setInpaintProgressPreview(elements, "Preparing Inpaint workflow...");
-    let progressWatcher: ReturnType<ComfyClient["watchProgress"]> | null = null;
-    let activeRun: ActiveGeneration | null = null;
 
     try {
       const preset = getWorkflowPreset(presetId);
@@ -2735,125 +2547,97 @@ export function renderApp(rootElement: HTMLElement) {
         );
       }
 
-      setInpaintStatus(elements, "Submitting Inpaint prompt...", "idle");
-      setInpaintProgressPreview(elements, "Submitting prompt to ComfyUI...");
-      const promptId = await client.submitPrompt(buildResult.workflow);
-      activeRun = beginActiveGeneration("inpaint", client, promptId);
-      let hasLivePreview = false;
-      progressWatcher = client.watchProgress(promptId, {
-        onStatus: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setInpaintStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setInpaintProgressPreview(elements, message);
-          }
-        },
-        onProgress: (value, max) => publishGenerationUpdate(activeRun, () => applyDeterminateProgress(elements.inpaintStatusProgress, value, max)),
-        onPreviewBlob: (blob) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          hasLivePreview = true;
-          setInpaintProgressPreview(elements, "Live ComfyUI preview...", blob);
-        },
-        onError: (message) => publishGenerationUpdate(activeRun, () => setInpaintDiagnostics(elements, message))
-      });
-      activeRun.watcher = progressWatcher;
-
-      setInpaintStatus(elements, "Generating Inpaint result...", "idle");
-      setInpaintProgressPreview(elements, "Generating image...");
-      const history = await client.pollUntilComplete(promptId, {
-        onTick: (message) => {
-          if (!activeRun || !canPublishGenerationUpdate(activeRun, activeGeneration)) return;
-          setInpaintStatus(elements, message, "idle");
-
-          if (!hasLivePreview) {
-            setInpaintProgressPreview(elements, message);
-          }
-        },
-        isCancelled: () => Boolean(activeRun?.isCancelled)
-      });
-      progressWatcher?.close();
-      progressWatcher = null;
-      activeRun.watcher = null;
-
-      setInpaintStatus(elements, "Retrieving Inpaint result...", "idle");
-      setInpaintProgressPreview(elements, "Retrieving final image...");
-      const generatedResult = bindDocumentContext(
-        await client.retrieveFirstOutputImage(promptId, history, {
-          preferredNodeId: getSaveImageNodeId(buildResult.preset)
-        }),
-        submittedSource.originatingDocument
-      );
-      ensureGenerationCanCommit(activeRun);
-      const generatedImportContext = createInpaintImportContext(submittedSource, generatedResult);
-      const resultDimensions = await readImageDimensionsFromBlob(generatedResult.blob);
-      const inpaintOutputDiagnostics = formatInpaintOutputDiagnostics({
-        presetId: buildResult.preset.id,
-        sourceDimensions: {
-          width: submittedSource.width,
-          height: submittedSource.height
-        },
-        maskDimensions: {
-          width: submittedMask.width,
-          height: submittedMask.height
-        },
-        resultDimensions,
-        importMode: "aligned-context-fallback",
-        maskPolarity: "white-repaints"
-      });
+      let inpaintOutputDiagnostics = "";
       let debugExportMessage = "";
-
-      try {
-        const debugFiles = await saveInpaintDebugBlobsToTemporaryFiles({
-          sourceBlob: submittedSource.blob,
-          maskBlob: submittedMask.blob,
-          resultBlob: generatedResult.blob
-        });
-        debugExportMessage = ` Debug copies saved in the UXP temporary folder: ${debugFiles.join(", ")}.`;
-      } catch (debugError) {
-        debugExportMessage = ` Debug copy export unavailable: ${getErrorMessage(debugError)}.`;
-      }
-
-      activeInpaintImportContext = generatedImportContext;
-      setInpaintResult(generatedResult);
-      addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
-        prompt: elements.inpaintPrompt.value,
-        negativePrompt: elements.inpaintNegativePrompt.value,
-        checkpointName,
-        modelName: checkpointName,
-        workflowPreset: buildResult.preset.id,
+      const generatedResult = await generation.runPipeline({
         toolType: "inpaint",
-        seed: buildResult.seed,
-        sizeLabel: "Inpaint",
-        dimensions: `${submittedSource.width} x ${submittedSource.height}`,
-        sourceMode: getInpaintSourceModeLabel(submittedSource.sourceMode),
-        sourceBounds: createMetadataBounds(submittedSource.selection.bounds),
-        contextBounds: createMetadataBounds(submittedSource.selection.contextBounds),
-        inpaintImportContext: generatedImportContext,
-        experimental: true,
-        diagnosticsSummary: [
-          inpaintOutputDiagnostics,
-          formatInpaintOutpaintDebugContract({
-            toolType: "inpaint",
-            presetId: buildResult.preset.id,
-            sourceMode: getInpaintSourceModeLabel(submittedSource.sourceMode),
-            sourceDimensions: {
-              width: submittedSource.width,
-              height: submittedSource.height
-            },
-            maskDimensions: {
-              width: submittedMask.width,
-              height: submittedMask.height
-            },
-            maskPolarity: "white-repaints",
-            contextBounds: createMetadataBounds(submittedSource.selection.contextBounds),
-            outputKind: "selection context",
-            importMode: "Photoshop layer mask with aligned fallback"
-          })
-        ].filter(Boolean).join(" ")
+        client,
+        workflow: buildResult.workflow,
+        preferredNodeId: getSaveImageNodeId(buildResult.preset),
+        originatingDocument: submittedSource.originatingDocument,
+        ui: createPipelineUi("inpaint", elements.inpaintStatusProgress),
+        messages: {
+          submitStatus: "Submitting Inpaint prompt...",
+          submitPreview: "Submitting prompt to ComfyUI...",
+          generateStatus: "Generating Inpaint result...",
+          generatePreview: "Generating image...",
+          retrieveStatus: "Retrieving Inpaint result...",
+          retrievePreview: "Retrieving final image...",
+          livePreview: "Live ComfyUI preview..."
+        },
+        commit: async (generatedResult) => {
+        const generatedImportContext = createInpaintImportContext(submittedSource, generatedResult);
+        const resultDimensions = await readImageDimensionsFromBlob(generatedResult.blob);
+        inpaintOutputDiagnostics = formatInpaintOutputDiagnostics({
+          presetId: buildResult.preset.id,
+          sourceDimensions: {
+            width: submittedSource.width,
+            height: submittedSource.height
+          },
+          maskDimensions: {
+            width: submittedMask.width,
+            height: submittedMask.height
+          },
+          resultDimensions,
+          importMode: "aligned-context-fallback",
+          maskPolarity: "white-repaints"
+        });
+
+        try {
+          const debugFiles = await saveInpaintDebugBlobsToTemporaryFiles({
+            sourceBlob: submittedSource.blob,
+            maskBlob: submittedMask.blob,
+            resultBlob: generatedResult.blob
+          });
+          debugExportMessage = ` Debug copies saved in the UXP temporary folder: ${debugFiles.join(", ")}.`;
+        } catch (debugError) {
+          debugExportMessage = ` Debug copy export unavailable: ${getErrorMessage(debugError)}.`;
+        }
+
+        activeInpaintImportContext = generatedImportContext;
+        setInpaintResult(generatedResult);
+        addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
+          prompt: elements.inpaintPrompt.value,
+          negativePrompt: elements.inpaintNegativePrompt.value,
+          checkpointName,
+          modelName: checkpointName,
+          workflowPreset: buildResult.preset.id,
+          toolType: "inpaint",
+          seed: buildResult.seed,
+          sizeLabel: "Inpaint",
+          dimensions: `${submittedSource.width} x ${submittedSource.height}`,
+          sourceMode: getInpaintSourceModeLabel(submittedSource.sourceMode),
+          sourceBounds: createMetadataBounds(submittedSource.selection.bounds),
+          contextBounds: createMetadataBounds(submittedSource.selection.contextBounds),
+          inpaintImportContext: generatedImportContext,
+          experimental: true,
+          diagnosticsSummary: [
+            inpaintOutputDiagnostics,
+            formatInpaintOutpaintDebugContract({
+              toolType: "inpaint",
+              presetId: buildResult.preset.id,
+              sourceMode: getInpaintSourceModeLabel(submittedSource.sourceMode),
+              sourceDimensions: {
+                width: submittedSource.width,
+                height: submittedSource.height
+              },
+              maskDimensions: {
+                width: submittedMask.width,
+                height: submittedMask.height
+              },
+              maskPolarity: "white-repaints",
+              contextBounds: createMetadataBounds(submittedSource.selection.contextBounds),
+              outputKind: "selection context",
+              importMode: "Photoshop layer mask with aligned fallback"
+            })
+          ].filter(Boolean).join(" ")
+        });
+        }
       });
-      finishActiveGeneration(activeRun);
-      activeRun = null;
+
+      if (!generatedResult) {
+        return;
+      }
       setInpaintStatus(elements, "Inpaint generation complete.", "ready");
       setInpaintDiagnostics(
         elements,
@@ -2867,7 +2651,7 @@ export function renderApp(rootElement: HTMLElement) {
       );
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {
-        if (!activeRun || shouldFinalizeActiveRun(activeRun, activeGeneration)) showGenerationCancelled("inpaint", activeRun?.promptId);
+        showGenerationCancelled("inpaint");
         return;
       }
 
@@ -2876,8 +2660,6 @@ export function renderApp(rootElement: HTMLElement) {
       console.error("[OpenLayer] Inpaint generation failed", getTechnicalErrorDetails(caughtError));
       setInpaintDiagnostics(elements, getInpaintFailureHint(caughtError));
     } finally {
-      progressWatcher?.close();
-      finishActiveGeneration(activeRun);
       isBusy = false;
       syncBusy();
     }
@@ -3068,7 +2850,7 @@ export function renderApp(rootElement: HTMLElement) {
     setPromptLayerDiagnostics(elements, `Task: ${task}. Num beams: ${numBeams}.`);
     isBusy = true;
     syncBusy();
-    let activeRun: ActiveGeneration | null = null;
+    let run: GenerationRunHandle | null = null;
 
     try {
       await client.validatePresetSetup(preset);
@@ -3089,20 +2871,21 @@ export function renderApp(rootElement: HTMLElement) {
       );
 
       const promptId = await client.submitPrompt(workflowResult.workflow);
-      activeRun = beginActiveGeneration("prompt-from-layer", client, promptId);
+      run = generation.begin("prompt-from-layer", client, promptId);
+      const startedRun = run;
       const historyItem = await client.pollUntilTextComplete(promptId, {
         preferredNodeId: textOutputNodeId,
-        onTick: (message) => publishGenerationUpdate(activeRun, () => setPromptLayerStatus(elements, message, "idle")),
-        isCancelled: () => Boolean(activeRun?.isCancelled)
+        onTick: (message) => startedRun.publish(() => setPromptLayerStatus(elements, message, "idle")),
+        isCancelled: () => startedRun.isRunCancelled()
       });
       const generatedText = await client.retrieveFirstOutputText(promptId, historyItem, {
         preferredNodeId: textOutputNodeId
       });
-      ensureGenerationCanCommit(activeRun);
+      run.assertCanCommit();
 
       elements.promptLayerGeneratedText.value = generatedText;
-      finishActiveGeneration(activeRun);
-      activeRun = null;
+      run.finish();
+      run = null;
       setPromptLayerStatus(elements, "Prompt text generated.", "ready");
       setPromptLayerDiagnostics(
         elements,
@@ -3110,7 +2893,7 @@ export function renderApp(rootElement: HTMLElement) {
       );
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {
-        if (!activeRun || shouldFinalizeActiveRun(activeRun, activeGeneration)) showGenerationCancelled("prompt-from-layer", activeRun?.promptId);
+        if (!run || run.isCurrent()) showGenerationCancelled("prompt-from-layer", run?.promptId);
         return;
       }
 
@@ -3118,7 +2901,7 @@ export function renderApp(rootElement: HTMLElement) {
       setPromptLayerError(elements, getErrorMessage(caughtError));
       setPromptLayerDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
-      finishActiveGeneration(activeRun);
+      run?.finish();
       isBusy = false;
       syncBusy();
     }

--- a/src/ui/generationController.ts
+++ b/src/ui/generationController.ts
@@ -1,0 +1,275 @@
+import {
+  canPublishGenerationUpdate,
+  shouldFinalizeActiveRun,
+  validateGenerationCommit
+} from "./generationIntegrity";
+import {
+  createGenerationCancelledError,
+  GenerationCancelResult,
+  isGenerationCancelledError
+} from "../comfy/generationCancel";
+import { bindDocumentContext, DocumentContextBound, PhotoshopDocumentIdentity } from "../photoshop/documentContext";
+import type { HistoryToolType } from "./historyMetadata";
+
+export type GenerationProgressWatcher = { close: () => void };
+
+// The structural subset of ComfyClient the pipeline drives. Kept structural so
+// the run/cancel/stale semantics are testable against a scripted fake client.
+export type GenerationClient<THistory, TImage> = {
+  submitPrompt(workflow: object): Promise<string>;
+  watchProgress(promptId: string, callbacks: {
+    onStatus: (message: string) => void;
+    onProgress: (value: number, max: number) => void;
+    onPreviewBlob: (blob: Blob) => void;
+    onError: (message: string) => void;
+  }): GenerationProgressWatcher | null;
+  pollUntilComplete(promptId: string, options: {
+    onTick: (message: string) => void;
+    isCancelled: () => boolean;
+  }): Promise<THistory>;
+  retrieveFirstOutputImage(promptId: string, history: THistory, options: {
+    preferredNodeId?: string;
+  }): Promise<TImage>;
+};
+
+export type CancellableGenerationClient = {
+  cancelPrompt(promptId?: string): Promise<GenerationCancelResult>;
+};
+
+export type GenerationStatusTone = "idle" | "ready" | "error";
+
+// How one tool reports pipeline progress. Every callback is already gated on
+// run currency by the controller; hooks never need their own staleness checks.
+export type GenerationPipelineUi = {
+  status(message: string, tone: GenerationStatusTone): void;
+  progressPreview(message: string, blob?: Blob): void;
+  stepProgress(value: number, max: number): void;
+  diagnostics(message: string): void;
+  cancelled(promptId?: string): void;
+};
+
+export type GenerationPipelineMessages = {
+  submitStatus: string;
+  submitPreview: string;
+  generateStatus: string;
+  generatePreview: string;
+  retrieveStatus: string;
+  retrievePreview: string;
+  livePreview: string;
+};
+
+export type GenerationPipelineOptions<THistory, TImage extends object> = {
+  toolType: HistoryToolType;
+  client: GenerationClient<THistory, TImage> & CancellableGenerationClient;
+  workflow: object;
+  preferredNodeId?: string;
+  originatingDocument: PhotoshopDocumentIdentity | null;
+  ui: GenerationPipelineUi;
+  messages: GenerationPipelineMessages;
+  // Publish the committed result to tool state and history. Runs only after the
+  // commit gate passed; the run is finalized when it returns.
+  commit(result: DocumentContextBound<TImage>): void | Promise<void>;
+};
+
+export type GenerationRunHandle = {
+  readonly toolType: HistoryToolType;
+  readonly promptId: string;
+  publish(update: () => void): void;
+  isRunCancelled(): boolean;
+  setWatcher(watcher: GenerationProgressWatcher | null): void;
+  assertCanCommit(): void;
+  isCurrent(): boolean;
+  finish(): void;
+};
+
+export type ActiveGenerationSnapshot = {
+  toolType: HistoryToolType;
+  promptId: string;
+  client: CancellableGenerationClient;
+  isCurrent(): boolean;
+};
+
+export type GenerationControllerHooks = {
+  onRunStarted(toolType: HistoryToolType): void;
+  onRunFinished(toolType: HistoryToolType): void;
+};
+
+type ActiveGeneration = {
+  runId: number;
+  toolType: HistoryToolType;
+  client: CancellableGenerationClient;
+  promptId: string;
+  watcher: GenerationProgressWatcher | null;
+  isCancelled: boolean;
+};
+
+// Owns which generation run is current. Exactly one run can publish UI updates,
+// commit a result, or finalize shared state; a cancelled or superseded run's
+// callbacks fall through the gates in generationIntegrity. This is the Phase A4
+// state that previously lived as renderApp closure variables.
+export function createGenerationController(hooks: GenerationControllerHooks) {
+  let activeGeneration: ActiveGeneration | null = null;
+  let runSequence = 0;
+
+  function begin(
+    toolType: HistoryToolType,
+    client: CancellableGenerationClient,
+    promptId: string
+  ): GenerationRunHandle {
+    const run: ActiveGeneration = {
+      runId: ++runSequence,
+      toolType,
+      client,
+      promptId,
+      watcher: null,
+      isCancelled: false
+    };
+
+    activeGeneration = run;
+    hooks.onRunStarted(toolType);
+    let finished = false;
+
+    return {
+      toolType,
+      promptId,
+      publish(update) {
+        if (canPublishGenerationUpdate(run, activeGeneration)) update();
+      },
+      isRunCancelled() {
+        return run.isCancelled;
+      },
+      setWatcher(watcher) {
+        run.watcher = watcher;
+      },
+      assertCanCommit() {
+        if (!validateGenerationCommit(run, activeGeneration).ok) throw createGenerationCancelledError();
+      },
+      isCurrent() {
+        return shouldFinalizeActiveRun(run, activeGeneration);
+      },
+      finish() {
+        if (finished) return;
+        finished = true;
+        run.watcher?.close();
+        run.watcher = null;
+
+        if (shouldFinalizeActiveRun(run, activeGeneration)) {
+          activeGeneration = null;
+          hooks.onRunFinished(toolType);
+        }
+      }
+    };
+  }
+
+  return {
+    begin,
+
+    // Marks the active run cancelled and stops its progress watcher, returning
+    // what the caller needs to also interrupt ComfyUI. The run's own pipeline
+    // notices isCancelled at the next poll and unwinds through its normal path.
+    cancelActive(): ActiveGenerationSnapshot | null {
+      const generation = activeGeneration;
+      if (!generation) return null;
+
+      generation.isCancelled = true;
+      generation.watcher?.close();
+      generation.watcher = null;
+
+      return {
+        toolType: generation.toolType,
+        promptId: generation.promptId,
+        client: generation.client,
+        isCurrent: () => activeGeneration?.runId === generation.runId
+      };
+    },
+
+    // Panel teardown: stop polling without finalizing UI state that no longer
+    // exists. Mirrors the pre-refactor disposeAppResources behavior.
+    disposeActive() {
+      if (!activeGeneration) return;
+      activeGeneration.isCancelled = true;
+      activeGeneration.watcher?.close();
+      activeGeneration.watcher = null;
+    },
+
+    async runPipeline<THistory, TImage extends object>(
+      options: GenerationPipelineOptions<THistory, TImage>
+    ): Promise<DocumentContextBound<TImage> | null> {
+      let watcher: GenerationProgressWatcher | null = null;
+      let run: GenerationRunHandle | null = null;
+
+      try {
+        options.ui.status(options.messages.submitStatus, "idle");
+        options.ui.progressPreview(options.messages.submitPreview);
+        const promptId = await options.client.submitPrompt(options.workflow);
+        run = begin(options.toolType, options.client, promptId);
+        const startedRun = run;
+        let hasLivePreview = false;
+        watcher = options.client.watchProgress(promptId, {
+          onStatus: (message) => {
+            startedRun.publish(() => {
+              options.ui.status(message, "idle");
+
+              if (!hasLivePreview) {
+                options.ui.progressPreview(message);
+              }
+            });
+          },
+          onProgress: (value, max) => startedRun.publish(() => options.ui.stepProgress(value, max)),
+          onPreviewBlob: (blob) => {
+            startedRun.publish(() => {
+              hasLivePreview = true;
+              options.ui.progressPreview(options.messages.livePreview, blob);
+            });
+          },
+          onError: (message) => startedRun.publish(() => options.ui.diagnostics(message))
+        });
+        run.setWatcher(watcher);
+
+        options.ui.status(options.messages.generateStatus, "idle");
+        options.ui.progressPreview(options.messages.generatePreview);
+        const history = await options.client.pollUntilComplete(promptId, {
+          onTick: (message) => {
+            startedRun.publish(() => {
+              options.ui.status(message, "idle");
+
+              if (!hasLivePreview) {
+                options.ui.progressPreview(message);
+              }
+            });
+          },
+          isCancelled: () => startedRun.isRunCancelled()
+        });
+        watcher?.close();
+        watcher = null;
+        run.setWatcher(null);
+
+        options.ui.status(options.messages.retrieveStatus, "idle");
+        options.ui.progressPreview(options.messages.retrievePreview);
+        const generatedResult = bindDocumentContext(
+          await options.client.retrieveFirstOutputImage(promptId, history, {
+            preferredNodeId: options.preferredNodeId
+          }),
+          options.originatingDocument
+        );
+        run.assertCanCommit();
+        await options.commit(generatedResult);
+        run.finish();
+        run = null;
+        return generatedResult;
+      } catch (caughtError) {
+        if (isGenerationCancelledError(caughtError)) {
+          if (!run || run.isCurrent()) options.ui.cancelled(run?.promptId);
+          return null;
+        }
+
+        throw caughtError;
+      } finally {
+        watcher?.close();
+        run?.finish();
+      }
+    }
+  };
+}
+
+export type GenerationController = ReturnType<typeof createGenerationController>;

--- a/tests/ui/generationController.test.ts
+++ b/tests/ui/generationController.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGenerationController,
+  GenerationPipelineMessages,
+  GenerationPipelineUi
+} from "../../src/ui/generationController";
+import { createPhotoshopDocumentIdentity } from "../../src/photoshop/documentContext";
+import { isGenerationCancelledError } from "../../src/comfy/generationCancel";
+
+const origin = createPhotoshopDocumentIdentity(7, "Doc.psd");
+
+const MESSAGES: GenerationPipelineMessages = {
+  submitStatus: "Submitting...",
+  submitPreview: "Submitting preview...",
+  generateStatus: "Generating...",
+  generatePreview: "Generating preview...",
+  retrieveStatus: "Retrieving...",
+  retrievePreview: "Retrieving preview...",
+  livePreview: "Live preview..."
+};
+
+type FakeClientScript = {
+  submitPrompt?: () => Promise<string>;
+  duringPoll?: (callbacks: { onTick: (message: string) => void; isCancelled: () => boolean }) => void | Promise<void>;
+  retrieve?: () => Promise<{ blob: Blob }>;
+};
+
+function createFakeClient(script: FakeClientScript = {}) {
+  const watcher = { close: vi.fn() };
+  const client = {
+    submitPrompt: vi.fn(script.submitPrompt ?? (async () => "prompt-1")),
+    watchProgress: vi.fn(() => watcher),
+    pollUntilComplete: vi.fn(async (_promptId: string, options: { onTick: (m: string) => void; isCancelled: () => boolean }) => {
+      await script.duringPoll?.(options);
+
+      if (options.isCancelled()) {
+        const { createGenerationCancelledError } = await import("../../src/comfy/generationCancel");
+        throw createGenerationCancelledError();
+      }
+
+      return { outputs: {} };
+    }),
+    retrieveFirstOutputImage: vi.fn(script.retrieve ?? (async () => ({ blob: new Blob(["image"]) }))),
+    cancelPrompt: vi.fn(async () => "interrupted" as const)
+  };
+  return { client, watcher };
+}
+
+function createUi(): GenerationPipelineUi & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    status: (message) => calls.push(`status:${message}`),
+    progressPreview: (message, blob) => calls.push(`preview:${message}${blob ? ":blob" : ""}`),
+    stepProgress: (value, max) => calls.push(`step:${value}/${max}`),
+    diagnostics: (message) => calls.push(`diag:${message}`),
+    cancelled: (promptId) => calls.push(`cancelled:${promptId ?? "none"}`)
+  };
+}
+
+function createController() {
+  const hooks = { onRunStarted: vi.fn(), onRunFinished: vi.fn() };
+  return { controller: createGenerationController(hooks), hooks };
+}
+
+describe("generation controller pipeline", () => {
+  it("runs submit, watch, poll, retrieve, commit, finish in order and returns the bound result", async () => {
+    const { controller, hooks } = createController();
+    const { client, watcher } = createFakeClient();
+    const ui = createUi();
+    const commit = vi.fn();
+
+    const result = await controller.runPipeline({
+      toolType: "image-to-image",
+      client,
+      workflow: {},
+      preferredNodeId: "9",
+      originatingDocument: origin,
+      ui,
+      messages: MESSAGES,
+      commit
+    });
+
+    expect(result?.originatingDocument).toBe(origin);
+    expect(commit).toHaveBeenCalledWith(result);
+    expect(hooks.onRunStarted).toHaveBeenCalledWith("image-to-image");
+    expect(hooks.onRunFinished).toHaveBeenCalledWith("image-to-image");
+    expect(watcher.close).toHaveBeenCalled();
+    expect(client.retrieveFirstOutputImage.mock.calls[0][2]).toEqual({ preferredNodeId: "9" });
+    expect(ui.calls).toContain("status:Submitting...");
+    expect(ui.calls).toContain("status:Generating...");
+    expect(ui.calls).toContain("status:Retrieving...");
+  });
+
+  it("shows the cancelled state and returns null when cancelled mid-poll", async () => {
+    const { controller, hooks } = createController();
+    const { client } = createFakeClient({
+      duringPoll: () => {
+        controller.cancelActive();
+      }
+    });
+    const ui = createUi();
+    const commit = vi.fn();
+
+    const result = await controller.runPipeline({
+      toolType: "inpaint",
+      client,
+      workflow: {},
+      originatingDocument: origin,
+      ui,
+      messages: MESSAGES,
+      commit
+    });
+
+    expect(result).toBeNull();
+    expect(commit).not.toHaveBeenCalled();
+    expect(ui.calls).toContain("cancelled:prompt-1");
+    // The cancelled run is still the current one, so it finalizes shared state.
+    expect(hooks.onRunFinished).toHaveBeenCalledWith("inpaint");
+  });
+
+  it("cancelActive reports the run and stops its watcher", async () => {
+    const { controller } = createController();
+    const { client, watcher } = createFakeClient({
+      duringPoll: () => {
+        const active = controller.cancelActive();
+        expect(active?.toolType).toBe("upscale");
+        expect(active?.promptId).toBe("prompt-1");
+        expect(active?.isCurrent()).toBe(true);
+        expect(watcher.close).toHaveBeenCalled();
+      }
+    });
+
+    await controller.runPipeline({
+      toolType: "upscale",
+      client,
+      workflow: {},
+      originatingDocument: origin,
+      ui: createUi(),
+      messages: MESSAGES,
+      commit: vi.fn()
+    });
+
+    expect(controller.cancelActive()).toBeNull();
+  });
+
+  it("blocks a stale run from publishing, committing, or finalizing after a newer run begins", async () => {
+    const { controller, hooks } = createController();
+    const ui = createUi();
+    const commit = vi.fn();
+    const { client } = createFakeClient({
+      duringPoll: (options) => {
+        // A second generation starts while the first is still polling.
+        controller.begin("text-to-image", { cancelPrompt: async () => "interrupted" as const }, "prompt-2");
+        options.onTick("stale tick");
+      }
+    });
+
+    const result = await controller.runPipeline({
+      toolType: "image-to-image",
+      client,
+      workflow: {},
+      originatingDocument: origin,
+      ui,
+      messages: MESSAGES,
+      commit
+    });
+
+    // The stale tick was gated, the stale commit refused, and the newer run's
+    // shared state untouched: onRunFinished never fired for the stale tool.
+    expect(ui.calls).not.toContain("status:stale tick");
+    expect(commit).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+    expect(ui.calls).not.toContain("cancelled:prompt-1");
+    expect(hooks.onRunFinished).not.toHaveBeenCalledWith("image-to-image");
+  });
+
+  it("rethrows non-cancellation errors after closing the watcher and finalizing", async () => {
+    const { controller, hooks } = createController();
+    const { client, watcher } = createFakeClient({
+      retrieve: async () => {
+        throw new Error("retrieve exploded");
+      }
+    });
+
+    await expect(controller.runPipeline({
+      toolType: "sketch-to-image",
+      client,
+      workflow: {},
+      originatingDocument: origin,
+      ui: createUi(),
+      messages: MESSAGES,
+      commit: vi.fn()
+    })).rejects.toThrow("retrieve exploded");
+
+    expect(watcher.close).toHaveBeenCalled();
+    expect(hooks.onRunFinished).toHaveBeenCalledWith("sketch-to-image");
+  });
+
+  it("gates live preview frames and diagnostics on run currency", async () => {
+    const { controller } = createController();
+    const ui = createUi();
+    let capturedCallbacks: { onPreviewBlob: (blob: Blob) => void; onError: (message: string) => void } | null = null;
+    const watcher = { close: vi.fn() };
+    const client = {
+      submitPrompt: vi.fn(async () => "prompt-1"),
+      watchProgress: vi.fn((_promptId: string, callbacks: typeof capturedCallbacks & object) => {
+        capturedCallbacks = callbacks;
+        return watcher;
+      }),
+      pollUntilComplete: vi.fn(async () => {
+        capturedCallbacks?.onPreviewBlob(new Blob(["frame"]));
+        capturedCallbacks?.onError("transient");
+        return { outputs: {} };
+      }),
+      retrieveFirstOutputImage: vi.fn(async () => ({ blob: new Blob(["image"]) })),
+      cancelPrompt: vi.fn(async () => "interrupted" as const)
+    };
+
+    await controller.runPipeline({
+      toolType: "outpaint",
+      client,
+      workflow: {},
+      originatingDocument: origin,
+      ui,
+      messages: MESSAGES,
+      commit: vi.fn()
+    });
+
+    expect(ui.calls).toContain("preview:Live preview...:blob");
+    expect(ui.calls).toContain("diag:transient");
+
+    // After the run finished, replayed callbacks must be ignored.
+    ui.calls.length = 0;
+    capturedCallbacks!.onPreviewBlob(new Blob(["late frame"]));
+    capturedCallbacks!.onError("late error");
+    expect(ui.calls).toEqual([]);
+  });
+
+  it("run handles stay usable for the text pipeline: publish, commit gate, idempotent finish", async () => {
+    const { controller, hooks } = createController();
+    const run = controller.begin("prompt-from-layer", { cancelPrompt: async () => "interrupted" as const }, "prompt-9");
+    const published: string[] = [];
+
+    run.publish(() => published.push("tick"));
+    expect(published).toEqual(["tick"]);
+    expect(() => run.assertCanCommit()).not.toThrow();
+
+    run.finish();
+    run.finish();
+    expect(hooks.onRunFinished).toHaveBeenCalledTimes(1);
+
+    run.publish(() => published.push("late"));
+    expect(published).toEqual(["tick"]);
+    expect(() => run.assertCanCommit()).toThrow();
+
+    try {
+      run.assertCanCommit();
+    } catch (error) {
+      expect(isGenerationCancelledError(error)).toBe(true);
+    }
+  });
+
+  it("disposeActive cancels polling without finalizing UI state", async () => {
+    const { controller, hooks } = createController();
+    const ui = createUi();
+    const { client, watcher } = createFakeClient({
+      duringPoll: () => {
+        controller.disposeActive();
+      }
+    });
+
+    const result = await controller.runPipeline({
+      toolType: "text-to-image",
+      client,
+      workflow: {},
+      originatingDocument: origin,
+      ui,
+      messages: MESSAGES,
+      commit: vi.fn()
+    });
+
+    expect(result).toBeNull();
+    expect(watcher.close).toHaveBeenCalled();
+    // The pipeline's own unwind still finalizes; disposeActive itself does not.
+    expect(hooks.onRunFinished).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

The high-risk step of the App.ts decomposition, landing alone as planned. The six image-generation handlers each restated the same submit → watch → poll → retrieve → commit → finish sequence — and with it every Phase A4 guarantee (runId gating, cancellation, watcher lifecycle, stale-run refusal), consistent only by copy-paste.

- **`generationController.ts`** now owns the pipeline and the active-run state (previously `renderApp` closure variables). Every progress callback is gated on run currency through the *unchanged* `generationIntegrity` predicates — the A4 logic did not move or change, only its single caller did.
- **Handlers keep only what differs per tool**: preparation/validation, the commit block (tool state + history entry), post-success reporting, and error mapping. Status strings ride along in a per-tool messages table, byte-identical to before.
- **Cancel and teardown** go through `cancelActive`/`disposeActive`, reproducing the previous mark-cancelled-then-close-watcher order. The prompt-from-layer text pipeline keeps its shape but runs on controller run handles.
- **The A4 semantics are now executable**: 8 new tests drive a scripted fake client through cancellation mid-poll, a newer run superseding an older one, late watcher callbacks after finish, error unwind, and idempotent finalization — none of which was testable while the sequence lived in the handlers.

App.ts: 5,972 → 5,754 lines (8,149 before step 1). Zero behavior change intended.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 37 files / 250 tests (242 → 250)
- [x] `npm run build` — green
- [ ] **Photoshop smoke test (Mehran, required before merge — this touches every generation path):**
  - each of the 6 image tools: capture → generate → result lands in preview + history with correct seed/metadata → import works
  - cancel mid-generation on two different tools: progress resets, "Generation cancelled." shows, a fresh generate afterward works
  - inpaint end-to-end: mask still exact, history import context still works, debug-copy diagnostics line still appears
  - prompt-from-layer: generate text, cancel once
  - auto-import toggles (txt2img / img2img / upscale) still fire after generation
  - close panel mid-generation → reopen → no stuck state

🤖 Generated with [Claude Code](https://claude.com/claude-code)