### PR TITLE
Show the home status line in red on error

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -160,6 +160,10 @@ a:hover {
   white-space: nowrap;
 }
 
+.home-status-row strong.is-error {
+  color: #ff9d9d;
+}
+
 .home-status-dot {
   display: inline-block;
   width: 15px;
@@ -2042,6 +2046,10 @@ a:hover {
 
 .app-shell.theme-compact .home-status-row strong {
   color: var(--ol-success);
+}
+
+.app-shell.theme-compact .home-status-row strong.is-error {
+  color: var(--ol-danger);
 }
 
 .app-shell.theme-compact .home-status-dot {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -3496,6 +3496,9 @@ function applyStatusPill(pill: HTMLElement, status: string, tone: StatusTone) {
 
 function updateHomeStatus(elements: AppElements, status: string, tone: StatusTone) {
   elements.homeStatusText.textContent = tone === "ready" ? "Ready" : tone === "error" ? "Error" : status.replace(/\.$/, "");
+  // The text color defaults to the success green; only an error overrides it,
+  // so Ready and in-progress statuses keep their familiar look.
+  elements.homeStatusText.classList.toggle("is-error", tone === "error");
   elements.homeStatusDot.className = `home-status-dot ${tone}`;
 }
 


### PR DESCRIPTION
## Summary

The "Status:" line above the tool grid hardcoded the success green (`#35e05f` / `var(--ol-success)`) for its text in both themes, so an error read as a green "Status: Error" while only the dot turned red. Reported by Mehran during the step-4 smoke test. `updateHomeStatus` now toggles an `is-error` class on the text; base and compact themes color it with their danger red. Ready and in-progress statuses keep their green, as requested.

## Test plan

- [x] typecheck / 250 tests / build — green
- [ ] Photoshop: trigger any error (e.g. Generate with no prompt) → "Status: Error" text is red; after a successful action → "Status: Ready" is still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)