### PR TITLE
Fix live preview flicker: reuse one img element per generation

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1510,8 +1510,11 @@ a:hover {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 165px;
-  max-height: 260px;
+  /* A fixed height, not min/max, keeps the panel the same size whether it is
+     showing the empty message or an image, whatever that image's aspect
+     ratio: without this the box grows and shrinks between generations,
+     reading as a flicker even though no element is being rebuilt. */
+  height: 260px;
   overflow: hidden;
   border: 1px solid #4c4c4c;
   border-radius: 8px;
@@ -1584,8 +1587,7 @@ a:hover {
 }
 
 .img2img-result-panel .preview-panel {
-  min-height: 140px;
-  max-height: 210px;
+  height: 210px;
 }
 
 .img2img-result-panel .preview-panel img {
@@ -1815,8 +1817,7 @@ a:hover {
   }
 
   .preview-panel {
-    min-height: 150px;
-    max-height: 230px;
+    height: 230px;
   }
 
   .preview-panel img {
@@ -1824,8 +1825,7 @@ a:hover {
   }
 
   .img2img-result-panel .preview-panel {
-    min-height: 130px;
-    max-height: 190px;
+    height: 190px;
   }
 
   .img2img-result-panel .preview-panel img {
@@ -2341,8 +2341,7 @@ a:hover {
 }
 
 .app-shell.theme-compact .preview-panel {
-  min-height: 132px;
-  max-height: 220px;
+  height: 220px;
   border-color: var(--ol-line);
 }
 
@@ -2874,8 +2873,7 @@ a:hover {
 }
 
 .app-shell.theme-compact .preview-panel {
-  min-height: 112px;
-  max-height: 175px;
+  height: 175px;
   border-radius: 5px;
 }
 
@@ -3290,8 +3288,7 @@ a:hover {
 
 .app-shell.theme-compact .preview-panel {
   width: 100%;
-  min-height: 112px;
-  max-height: 170px;
+  height: 170px;
   min-width: 0;
   border-radius: 4px;
 }
@@ -3516,10 +3513,6 @@ a:hover {
 .app-shell.theme-compact .status-bar {
   min-height: 26px;
   padding: 3px 6px;
-}
-
-.app-shell.theme-compact .preview-panel {
-  min-height: 104px;
 }
 
 .app-shell.theme-classic {
@@ -3790,8 +3783,7 @@ a:hover {
 }
 
 .app-shell.theme-compact .preview-panel {
-  min-height: 96px;
-  max-height: 150px;
+  height: 150px;
 }
 
 .app-shell.theme-compact .preview-panel img {
@@ -4648,8 +4640,7 @@ a:hover {
 .app-shell.theme-compact .preview-panel {
   box-sizing: border-box;
   width: 100%;
-  min-height: 118px;
-  max-height: 320px;
+  height: 320px;
   border: 1px solid var(--ol-border);
   border-radius: var(--ol-radius);
   background: #262626;
@@ -6381,8 +6372,7 @@ a:hover {
 }
 
 .app-shell.theme-compact .preview-panel {
-  min-height: 112px !important;
-  max-height: 210px !important;
+  height: 210px !important;
   border: 1px solid var(--ol-border-soft) !important;
   border-radius: 6px !important;
   background: rgba(255, 255, 255, 0.035) !important;

--- a/src/ui/previewState.ts
+++ b/src/ui/previewState.ts
@@ -105,11 +105,18 @@ export function createResultPreviewPanel(options: {
   const resultUrl = createOwnedObjectUrl(options.urls);
   const liveUrl = createOwnedObjectUrl(options.urls);
   let hasResult = false;
+  // One persistent element for the live ComfyUI frames. The WebSocket delivers
+  // many frames per second, so rebuilding the img each frame (as this did
+  // before) flickered between sampler steps; swapping src on a reused element
+  // does not. Reset to null whenever the panel leaves live-image mode, so the
+  // next live frame re-appends a fresh img. Mirrors updateLivePreview in App.ts.
+  let liveImage: HTMLImageElement | null = null;
 
   return {
     showResult(blob) {
       resultUrl.release();
       liveUrl.release();
+      liveImage = null;
       hasResult = Boolean(blob);
 
       if (!blob) {
@@ -123,10 +130,20 @@ export function createResultPreviewPanel(options: {
       if (hasResult) return;
 
       if (blob) {
-        renderPreviewImage(options.panel, liveUrl.createFrom(blob), options.liveAlt);
+        if (!liveImage) {
+          options.panel.innerHTML = "";
+          liveImage = document.createElement("img");
+          liveImage.alt = options.liveAlt;
+          options.panel.append(liveImage);
+        }
+
+        // createFrom revokes the previous frame's URL before returning the new
+        // one, keeping exactly one live URL alive across the whole sequence.
+        liveImage.src = liveUrl.createFrom(blob);
         return;
       }
 
+      liveImage = null;
       liveUrl.release();
       renderPreviewMessage(options.panel, "preview-empty", message);
     },

--- a/tests/ui/previewState.test.ts
+++ b/tests/ui/previewState.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createObjectUrlRegistry } from "../../src/ui/objectUrlRegistry";
-import { createOwnedObjectUrl } from "../../src/ui/previewState";
+import { createOwnedObjectUrl, createResultPreviewPanel } from "../../src/ui/previewState";
 
 function createRegistry() {
   let sequence = 0;
@@ -10,6 +10,38 @@ function createRegistry() {
     revokeObjectURL
   });
   return { registry, revokeObjectURL };
+}
+
+// The result-preview panel touches the DOM (createElement/append), which the
+// node test env does not provide. A minimal stub lets us assert the element
+// reuse that eliminates the flicker, plus the URL ownership around it, without
+// pulling in jsdom.
+type FakeElement = { tagName: string; alt: string; src: string; innerHTML: string };
+
+function installFakeDom() {
+  const created: FakeElement[] = [];
+  const previousDocument = (globalThis as { document?: unknown }).document;
+  (globalThis as { document?: unknown }).document = {
+    createElement: (tagName: string) => {
+      const element: FakeElement = { tagName, alt: "", src: "", innerHTML: "" };
+      created.push(element);
+      return element;
+    }
+  };
+
+  const panel = {
+    innerHTML: "",
+    children: [] as FakeElement[],
+    append(child: FakeElement) {
+      this.children.push(child);
+    }
+  };
+
+  const restore = () => {
+    (globalThis as { document?: unknown }).document = previousDocument;
+  };
+
+  return { created, panel, restore };
 }
 
 describe("owned object URL slot", () => {
@@ -72,5 +104,92 @@ describe("owned object URL slot", () => {
     slot.release();
 
     expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("result preview live frames", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createPanel() {
+    const { created, panel, restore } = installFakeDom();
+    const { registry, revokeObjectURL } = createRegistry();
+    const preview = createResultPreviewPanel({
+      urls: registry,
+      panel: panel as unknown as HTMLElement,
+      emptyText: "No result yet",
+      resultAlt: "Result",
+      liveAlt: "Live preview"
+    });
+    return { created, panel, restore, registry, revokeObjectURL, preview };
+  }
+
+  it("reuses one img element across consecutive live frames instead of rebuilding it", () => {
+    const { created, panel, restore, preview } = createPanel();
+
+    try {
+      preview.showProgress("frame", new Blob(["1"]));
+      preview.showProgress("frame", new Blob(["2"]));
+      preview.showProgress("frame", new Blob(["3"]));
+
+      // The flicker fix: a single <img> is created and kept, not one per frame.
+      const images = created.filter((element) => element.tagName === "img");
+      expect(images).toHaveLength(1);
+      expect(panel.children).toEqual(images);
+      expect(images[0].src).toBe("blob:3");
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps exactly one live URL alive across frames and revokes each prior one", () => {
+    const { restore, registry, revokeObjectURL, preview } = createPanel();
+
+    try {
+      preview.showProgress("frame", new Blob(["1"]));
+      preview.showProgress("frame", new Blob(["2"]));
+      preview.showProgress("frame", new Blob(["3"]));
+
+      // Two prior frames revoked, newest still alive.
+      expect(revokeObjectURL.mock.calls.map(([url]) => url)).toEqual(["blob:1", "blob:2"]);
+      expect(registry.activeCount()).toBe(1);
+
+      preview.releaseLivePreviewUrl();
+      expect(registry.activeCount()).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("re-appends a fresh img after the panel drops to a message and back to frames", () => {
+    const { created, restore, preview } = createPanel();
+
+    try {
+      preview.showProgress("frame", new Blob(["1"]));
+      preview.showProgress("waiting...");
+      preview.showProgress("frame", new Blob(["2"]));
+
+      // Leaving live-image mode resets the persistent element, so the second
+      // run gets its own img rather than reviving a detached one.
+      expect(created.filter((element) => element.tagName === "img")).toHaveLength(2);
+    } finally {
+      restore();
+    }
+  });
+
+  it("ignores live frames once a final result is shown", () => {
+    const { created, restore, registry, preview } = createPanel();
+
+    try {
+      preview.showResult(new Blob(["result"]));
+      const before = registry.activeCount();
+      preview.showProgress("frame", new Blob(["late"]));
+
+      expect(created.filter((element) => element.tagName === "img")).toHaveLength(1);
+      expect(registry.activeCount()).toBe(before);
+    } finally {
+      restore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Two commits addressing the "preview flicker" report, both landing here since they're the same user-visible complaint with two distinct causes.

**1. Element rebuild (original fix).** The result preview rebuilt its `<img>` from scratch on every live ComfyUI WebSocket frame. Now keeps one persistent `<img>` and swaps `.src`, mirroring the pattern `updateLivePreview` already uses for Live Painting. Object-URL ownership unchanged.

**2. Panel resizing (found during Mehran's smoke test — the real cause of what he was seeing).** Mehran clarified the visible effect wasn't per-frame jank but the panel box itself resizing between the empty "No result yet" state and a result image. Root cause: every `.preview-panel` rule — the base theme, **seven separate declarations of the same selector in the active compact theme** (accumulated technical debt, one with `!important`), plus the img2img/520px-media-query variants — sized the box with `min-height`/`max-height` instead of a fixed height. The box grew or shrank to fit whatever was showing, reading as a resize/flicker regardless of the element-reuse fix. Every one of those declarations now sets a single fixed `height` (keeping each theme's original max value, so nothing changes size vs. before — it just stops moving). One now-fully-dead `min-height: 104px` declaration (silently overridden by the later `!important` block) removed for clarity.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 254 tests, all green
- [x] `npm run build` — green
- [ ] Photoshop: run a generation with live preview — panel stays the same size from idle → live frames → final result, no visible resize or blink in either theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)