### PR TITLE
Lock the Inpaint controls Flux Fill overrides

### DIFF
--- a/src/comfy/fluxFillDefaults.ts
+++ b/src/comfy/fluxFillDefaults.ts
@@ -16,6 +16,24 @@ const FLUX_GUIDANCE_NODE_ID = "26";
 const FLUX_SAMPLER_NODE_ID = "3";
 const FLUX_DIFFERENTIAL_DIFFUSION_NODE_ID = "39";
 
+// buildInpaintWorkflow hands this preset to applyFluxFillReferenceDefaults
+// instead of injecting the panel's steps/cfg/denoise, so those three controls
+// have no effect while it is selected. The panel disables them and says so
+// rather than letting an artist tune values that are silently discarded.
+export function presetLocksSamplerControls(presetId: string) {
+  return presetId === FLUX_FILL_PRESET_ID;
+}
+
+export function formatFluxFillLockedControlsNote() {
+  return [
+    "Steps, CFG, and Denoise are fixed by the Flux Fill reference workflow",
+    `(steps ${FLUX_FILL_REFERENCE_DEFAULTS.steps},`,
+    `guidance ${FLUX_FILL_REFERENCE_DEFAULTS.guidance},`,
+    `denoise ${FLUX_FILL_REFERENCE_DEFAULTS.denoise}).`,
+    "Choose another Inpaint workflow to set them yourself."
+  ].join(" ");
+}
+
 export function applyFluxFillReferenceDefaults(workflow: ComfyWorkflow) {
   const guidanceNode = workflow[FLUX_GUIDANCE_NODE_ID];
   const samplerNode = workflow[FLUX_SAMPLER_NODE_ID];

--- a/src/styles.css
+++ b/src/styles.css
@@ -6201,6 +6201,16 @@ a:hover {
   line-height: 18px !important;
 }
 
+/* Must sit after the !important block above, which forces background and color
+   on every compact number input and would otherwise erase the locked look. */
+.app-shell.theme-compact .input.is-reference-locked:disabled {
+  border-color: #8b6f2a !important;
+  background: #3d382d !important;
+  color: #d8bd7a !important;
+  opacity: 1 !important;
+  cursor: not-allowed !important;
+}
+
 .app-shell.theme-compact .textarea,
 .app-shell.theme-compact .compact-textarea,
 .app-shell.theme-compact .ol-textarea,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1248,6 +1248,16 @@ a:hover {
   padding: 6px 8px;
 }
 
+/* A control the selected workflow overrides: still readable, clearly not
+   editable, and distinct from the transient disabled state during a run. */
+.input.is-reference-locked {
+  border-style: dashed;
+  border-color: #5a5a5a;
+  background: #1f1f1f;
+  color: #9a9a9a;
+  cursor: not-allowed;
+}
+
 .input:focus,
 .select:focus,
 .textarea:focus {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -6,7 +6,12 @@ import {
 } from "../comfy/hardwareAdvisor";
 import { createFluxFillInpaintDebugSummary } from "../comfy/inpaintValidation";
 import { createFluxFillEmbeddedMaskSource } from "../comfy/fluxFillMaskBridge";
-import { formatFluxFillReferenceDefaults } from "../comfy/fluxFillDefaults";
+import {
+  FLUX_FILL_PRESET_ID,
+  formatFluxFillLockedControlsNote,
+  formatFluxFillReferenceDefaults,
+  presetLocksSamplerControls
+} from "../comfy/fluxFillDefaults";
 import {
   formatCancelDiagnostic,
   formatCancelResultDiagnostic,
@@ -263,6 +268,7 @@ export function renderApp(rootElement: HTMLElement) {
       upscaleResult,
       upscaleSource
     });
+    updateInpaintReferenceControlLock(elements, isBusy);
   }
 
   rootElement.innerHTML = createAppMarkup();
@@ -572,6 +578,7 @@ export function renderApp(rootElement: HTMLElement) {
   setSketchSource(null);
   setSketchResult(null);
   updateInpaintCheckpointCompatibility(elements, inpaintSource);
+  updateInpaintReferenceControlLock(elements);
   setInpaintSource(null);
   setInpaintResult(null);
   updateOutpaintCheckpointCompatibility(elements, outpaintSource);
@@ -621,6 +628,7 @@ export function renderApp(rootElement: HTMLElement) {
 
   elements.inpaintWorkflow.addEventListener("change", () => {
     applyRecommendedPresetSettings(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW, elements.inpaintSteps, elements.inpaintCfg);
+    updateInpaintReferenceControlLock(elements);
     void refreshInpaintModelOptionsForSelectedPreset(elements);
     updateInpaintCheckpointCompatibility(elements, inpaintSource);
   });
@@ -1221,6 +1229,7 @@ export function renderApp(rootElement: HTMLElement) {
       case "inpaint":
         elements.inpaintPrompt.value = entry.prompt;
         setSelectValueIfPresent(elements.inpaintWorkflow, entry.workflowPreset);
+        updateInpaintReferenceControlLock(elements);
         setSelectValueIfPresent(elements.inpaintCheckpoint, entry.modelName);
         elements.inpaintSeed.value = String(entry.seed);
         setView("inpaint");
@@ -2537,7 +2546,7 @@ export function renderApp(rootElement: HTMLElement) {
       });
 
       const fluxDefaultsMessage =
-        preset.id === "inpaint-flux-fill-basic" ? formatFluxFillReferenceDefaults() : "";
+        preset.id === FLUX_FILL_PRESET_ID ? formatFluxFillReferenceDefaults() : "";
       if (fluxDefaultsMessage) {
         setInpaintDiagnostics(
           elements,
@@ -3275,6 +3284,25 @@ function setBusy(elements: AppElements, isBusy: boolean, gates: Record<BusyGateN
   for (const { button, gate } of BUSY_GATED_ACTIONS) {
     setActionDisabled(elements[button], isBusy || !gates[gate]);
   }
+}
+
+// Flux Fill ignores the panel's steps/cfg/denoise, so those controls are
+// disabled while it is selected: still disabled during a run like every other
+// field, and still disabled afterwards for as long as Flux Fill is chosen.
+// Must be re-applied anywhere the inpaint workflow selection changes, and after
+// setBusy, which re-enables every field in its table once a run ends.
+function updateInpaintReferenceControlLock(elements: AppElements, isBusy = false) {
+  const isReferenceLocked = presetLocksSamplerControls(
+    readSelectValue(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW)
+  );
+
+  for (const input of [elements.inpaintSteps, elements.inpaintCfg, elements.inpaintDenoise]) {
+    input.disabled = isBusy || isReferenceLocked;
+    input.classList.toggle("is-reference-locked", isReferenceLocked);
+  }
+
+  elements.inpaintLockedSettingsNote.hidden = !isReferenceLocked;
+  elements.inpaintLockedSettingsNote.textContent = isReferenceLocked ? formatFluxFillLockedControlsNote() : "";
 }
 
 function setCancelGenerationVisible(elements: AppElements, isVisible: boolean) {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -849,6 +849,7 @@ export function renderApp(rootElement: HTMLElement) {
   function handleResetSettings() {
     clearOpenLayerPreferences();
     applyDefaultSettings(elements);
+    updateInpaintReferenceControlLock(elements);
     applyTheme(elements, DEFAULT_THEME);
     fillCheckpointOptions(elements, FALLBACK_CHECKPOINTS, FALLBACK_CHECKPOINTS[0]);
     updateImageCheckpointCompatibility(elements, allowExperimentalCheckpoints, imageSource);

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -857,15 +857,15 @@ export function createAppMarkup() {
           <div class="settings-grid img2img-settings-grid" aria-label="Inpaint settings">
             <div class="field">
               <span class="label">Steps</span>
-              <input class="input input-compact" id="inpaint-steps" type="number" min="1" max="150" step="1" value="${DEFAULT_INPAINT_STEPS}" />
+              <input class="input input-compact" id="inpaint-steps" type="number" min="1" max="150" step="1" value="${DEFAULT_INPAINT_STEPS}" aria-describedby="inpaint-locked-settings-note" />
             </div>
             <div class="field">
               <span class="label">CFG</span>
-              <input class="input input-compact" id="inpaint-cfg" type="number" min="1" max="30" step="0.5" value="${DEFAULT_CFG}" />
+              <input class="input input-compact" id="inpaint-cfg" type="number" min="1" max="30" step="0.5" value="${DEFAULT_CFG}" aria-describedby="inpaint-locked-settings-note" />
             </div>
             <div class="field">
               <span class="label">Denoise</span>
-              <input class="input input-compact" id="inpaint-denoise" type="number" min="0.05" max="1" step="0.05" value="${DEFAULT_INPAINT_DENOISE}" />
+              <input class="input input-compact" id="inpaint-denoise" type="number" min="0.05" max="1" step="0.05" value="${DEFAULT_INPAINT_DENOISE}" aria-describedby="inpaint-locked-settings-note" />
             </div>
             <div class="field settings-seed">
               <span class="label">Seed</span>

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -101,6 +101,7 @@ export type AppElements = {
   inpaintCfg: HTMLInputElement;
   inpaintSeed: HTMLInputElement;
   inpaintDenoise: HTMLInputElement;
+  inpaintLockedSettingsNote: HTMLElement;
   captureInpaintSelectionButton: HTMLElement;
   captureInpaintActiveLayerButton: HTMLElement;
   generateInpaintButton: HTMLElement;
@@ -871,6 +872,7 @@ export function createAppMarkup() {
               <input class="input input-compact" id="inpaint-seed" type="number" min="0" placeholder="Random" />
             </div>
           </div>
+          <span class="compatibility-note" id="inpaint-locked-settings-note" hidden></span>
           <button class="button button-primary button-generate button-wide action-control" id="generate-inpaint" data-openlayer-action="generateInpaint" type="button">Generate Inpaint</button>
           <button class="button button-wide action-control cancel-generation-button" data-openlayer-action="cancelGeneration" type="button" hidden>Cancel Generation</button>
         </section>
@@ -1321,6 +1323,7 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     inpaintCfg: getElement<HTMLInputElement>(rootElement, "inpaint-cfg"),
     inpaintSeed: getElement<HTMLInputElement>(rootElement, "inpaint-seed"),
     inpaintDenoise: getElement<HTMLInputElement>(rootElement, "inpaint-denoise"),
+    inpaintLockedSettingsNote: getElement<HTMLElement>(rootElement, "inpaint-locked-settings-note"),
     captureInpaintSelectionButton: getElement<HTMLElement>(rootElement, "capture-inpaint-selection"),
     captureInpaintActiveLayerButton: getElement<HTMLElement>(rootElement, "capture-inpaint-active-layer"),
     generateInpaintButton: getElement<HTMLElement>(rootElement, "generate-inpaint"),

--- a/tests/comfy/fluxFillDefaults.test.ts
+++ b/tests/comfy/fluxFillDefaults.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyFluxFillReferenceDefaults,
+  FLUX_FILL_PRESET_ID,
+  FLUX_FILL_REFERENCE_DEFAULTS,
+  formatFluxFillLockedControlsNote,
+  presetLocksSamplerControls
+} from "../../src/comfy/fluxFillDefaults";
+import { ComfyWorkflow } from "../../src/comfy/types";
+
+describe("presets that override the panel's sampler controls", () => {
+  it("locks the controls for the Flux Fill preset", () => {
+    expect(presetLocksSamplerControls(FLUX_FILL_PRESET_ID)).toBe(true);
+  });
+
+  it("leaves the controls editable for every other Inpaint preset", () => {
+    expect(presetLocksSamplerControls("inpaint-basic")).toBe(false);
+    expect(presetLocksSamplerControls("")).toBe(false);
+  });
+
+  // The lock exists because buildInpaintWorkflow hands this preset to
+  // applyFluxFillReferenceDefaults instead of injecting the panel's values. If
+  // that override ever stops touching steps/cfg/denoise, the lock is wrong.
+  it("stays justified: the override still replaces steps, guidance, and denoise", () => {
+    const workflow: ComfyWorkflow = {
+      "26": { class_type: "FluxGuidance", inputs: { guidance: 3.5 } },
+      "3": { class_type: "KSampler", inputs: { steps: 8, cfg: 7, denoise: 0.5 } },
+      "39": { class_type: "DifferentialDiffusion", inputs: {} }
+    };
+
+    applyFluxFillReferenceDefaults(workflow);
+
+    expect(workflow["26"].inputs.guidance).toBe(FLUX_FILL_REFERENCE_DEFAULTS.guidance);
+    expect(workflow["3"].inputs.steps).toBe(FLUX_FILL_REFERENCE_DEFAULTS.steps);
+    expect(workflow["3"].inputs.cfg).toBe(FLUX_FILL_REFERENCE_DEFAULTS.cfg);
+    expect(workflow["3"].inputs.denoise).toBe(FLUX_FILL_REFERENCE_DEFAULTS.denoise);
+  });
+
+  it("names the values the artist will actually get, straight from the defaults", () => {
+    const note = formatFluxFillLockedControlsNote();
+
+    expect(note).toContain(String(FLUX_FILL_REFERENCE_DEFAULTS.steps));
+    expect(note).toContain(String(FLUX_FILL_REFERENCE_DEFAULTS.guidance));
+    expect(note).toContain(String(FLUX_FILL_REFERENCE_DEFAULTS.denoise));
+    expect(note).toMatch(/another Inpaint workflow/i);
+  });
+});


### PR DESCRIPTION
## Summary

`buildInpaintWorkflow` hands `inpaint-flux-fill-basic` to `applyFluxFillReferenceDefaults` instead of injecting the panel's steps/CFG/denoise — so for that workflow those three controls did **nothing**. The artist could tune them and every value was silently discarded before the prompt reached ComfyUI.

The panel now disables them while Flux Fill is selected and states what will actually run (steps 20, guidance 30, denoise 1), read from `FLUX_FILL_REFERENCE_DEFAULTS` so the note can't drift from the override. Seed stays editable, since every preset including this one injects it.

**The subtle part:** the lock is re-applied at all four places the selection can change — the workflow dropdown, panel init, reusing an inpaint history entry, and **after `setBusy`**, which re-enables every field in its table once a run ends and would otherwise silently unlock the controls after each generation. Steps/CFG/denoise stay in `BUSY_DISABLED_FIELDS` so they still lock during a run for every other preset too.

Note: the UI "CFG" control maps to `FluxGuidance.guidance` (30) for this preset, not `KSampler.cfg` (1), so the note names guidance rather than showing a misleading number in the field.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 258 tests (254 → 258): predicate, note values, and a guard asserting `applyFluxFillReferenceDefaults` still replaces steps/cfg/denoise (so the lock stops being justified the moment the override changes)
- [x] `npm run build` — green
- [ ] Photoshop: select Flux Fill inpaint → Steps/CFG/Denoise appear locked (dashed, greyed) with the note; Seed still editable; run a generation → after it completes they are **still** locked; switch to `inpaint-basic` → all three editable again; reuse an inpaint history entry → lock matches that entry's workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code), implementation partly by Codex