### PR TITLE
Scope the busy lockout to the tool that is running

### DIFF
--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -24,8 +24,8 @@ import {
   GenerationRunHandle
 } from "./generationController";
 import {
-  BUSY_DISABLED_ACTIONS,
-  BUSY_DISABLED_FIELDS,
+  BUSY_ALWAYS_DISABLED_ACTIONS,
+  BUSY_DISABLED_FIELD_GROUPS,
   BUSY_GATED_ACTIONS,
   BusyGateName
 } from "./toolDescriptors";
@@ -225,6 +225,7 @@ const statusProgressLastPercent = new WeakMap<HTMLElement, number>();
 export function renderApp(rootElement: HTMLElement) {
   let currentView: AppView = "home";
   let isBusy = false;
+  let busyTool: HistoryToolType | null = null;
   let result: AppGeneratedImageResult | null = null;
   let imageSource: ImageSourceState | null = null;
   let imageResult: AppGeneratedImageResult | null = null;
@@ -255,7 +256,7 @@ export function renderApp(rootElement: HTMLElement) {
   const objectUrls = createObjectUrlRegistry();
 
   function syncBusy() {
-    setBusy(elements, isBusy, {
+    setBusy(elements, isBusy, busyTool, {
       result,
       imageResult,
       imageSource,
@@ -268,7 +269,7 @@ export function renderApp(rootElement: HTMLElement) {
       upscaleResult,
       upscaleSource
     });
-    updateInpaintReferenceControlLock(elements, isBusy);
+    updateInpaintReferenceControlLock(elements, isBusy && busyTool === "inpaint");
   }
 
   rootElement.innerHTML = createAppMarkup();
@@ -994,6 +995,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     setError(elements, "");
     setResult(null);
+    busyTool = "text-to-image";
     isBusy = true;
     syncBusy();
     setStatus(elements, "Preparing workflow...", "idle");
@@ -1110,6 +1112,7 @@ export function renderApp(rootElement: HTMLElement) {
       setDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -1122,7 +1125,7 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   function handleHistoryAction(action: HistoryActionName, historyId: string) {
-    if (isBusy) {
+    if (isBusy && action !== "preview") {
       setDiagnostics(elements, "Finish the current operation before using history.");
       return;
     }
@@ -1271,6 +1274,7 @@ export function renderApp(rootElement: HTMLElement) {
     }
 
     setError(elements, "");
+    busyTool = "text-to-image";
     isBusy = true;
     syncBusy();
     setStatus(elements, "Importing image into Photoshop...", "idle");
@@ -1300,6 +1304,7 @@ export function renderApp(rootElement: HTMLElement) {
       setError(elements, getErrorMessage(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -1331,6 +1336,7 @@ export function renderApp(rootElement: HTMLElement) {
     setImageDiagnostics(elements, options.progressMessage);
     setImageError(elements, "");
     setImageStatus(elements, options.statusMessage, "idle");
+    busyTool = "image-to-image";
     isBusy = true;
     syncBusy();
 
@@ -1352,6 +1358,7 @@ export function renderApp(rootElement: HTMLElement) {
       setImageDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -1381,6 +1388,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     setImageError(elements, "");
     setImageResult(null);
+    busyTool = "image-to-image";
     isBusy = true;
     syncBusy();
     setImageStatus(elements, "Preparing Image to Image workflow...", "idle");
@@ -1514,6 +1522,7 @@ export function renderApp(rootElement: HTMLElement) {
       setImageDiagnostics(elements, getImageToImageFailureHint(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -1532,6 +1541,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     setImageError(elements, "");
     if (manageBusy) {
+      busyTool = "image-to-image";
       isBusy = true;
       syncBusy();
     }
@@ -1563,6 +1573,7 @@ export function renderApp(rootElement: HTMLElement) {
     } finally {
       if (manageBusy) {
         isBusy = false;
+        busyTool = null;
         syncBusy();
       }
     }
@@ -1595,6 +1606,7 @@ export function renderApp(rootElement: HTMLElement) {
     setUpscaleDiagnostics(elements, options.progressMessage);
     setUpscaleError(elements, "");
     setUpscaleStatus(elements, options.statusMessage, "idle");
+    busyTool = "upscale";
     isBusy = true;
     syncBusy();
 
@@ -1616,6 +1628,7 @@ export function renderApp(rootElement: HTMLElement) {
       setUpscaleDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -1639,6 +1652,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     setUpscaleError(elements, "");
     setUpscaleResult(null);
+    busyTool = "upscale";
     isBusy = true;
     syncBusy();
     setUpscaleStatus(elements, "Preparing Upscale workflow...", "idle");
@@ -1738,6 +1752,7 @@ export function renderApp(rootElement: HTMLElement) {
       setUpscaleDiagnostics(elements, getUpscaleFailureHint(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -1756,6 +1771,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     setUpscaleError(elements, "");
     if (manageBusy) {
+      busyTool = "upscale";
       isBusy = true;
       syncBusy();
     }
@@ -1787,6 +1803,7 @@ export function renderApp(rootElement: HTMLElement) {
     } finally {
       if (manageBusy) {
         isBusy = false;
+        busyTool = null;
         syncBusy();
       }
     }
@@ -1819,6 +1836,7 @@ export function renderApp(rootElement: HTMLElement) {
     setOutpaintDiagnostics(elements, options.progressMessage);
     setOutpaintError(elements, "");
     setOutpaintStatus(elements, options.statusMessage, "idle");
+    busyTool = "outpaint";
     isBusy = true;
     syncBusy();
 
@@ -1840,6 +1858,7 @@ export function renderApp(rootElement: HTMLElement) {
       setOutpaintDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -1872,6 +1891,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     setOutpaintError(elements, "");
     setOutpaintResult(null);
+    busyTool = "outpaint";
     isBusy = true;
     syncBusy();
     setOutpaintStatus(elements, "Preparing Outpaint workflow...", "idle");
@@ -2008,6 +2028,7 @@ export function renderApp(rootElement: HTMLElement) {
       setOutpaintDiagnostics(elements, getOutpaintFailureHint(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2021,6 +2042,7 @@ export function renderApp(rootElement: HTMLElement) {
     }
 
     setOutpaintError(elements, "");
+    busyTool = "outpaint";
     isBusy = true;
     syncBusy();
     setOutpaintStatus(elements, "Importing Outpaint result into Photoshop...", "idle");
@@ -2050,6 +2072,7 @@ export function renderApp(rootElement: HTMLElement) {
       setOutpaintError(elements, getErrorMessage(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2081,6 +2104,7 @@ export function renderApp(rootElement: HTMLElement) {
     setSketchDiagnostics(elements, options.progressMessage);
     setSketchError(elements, "");
     setSketchStatus(elements, options.statusMessage, "idle");
+    busyTool = "sketch-to-image";
     isBusy = true;
     syncBusy();
 
@@ -2102,6 +2126,7 @@ export function renderApp(rootElement: HTMLElement) {
       setSketchDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2134,6 +2159,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     setSketchError(elements, "");
     setSketchResult(null);
+    busyTool = "sketch-to-image";
     isBusy = true;
     syncBusy();
     setSketchStatus(elements, "Preparing LINECN workflow...", "idle");
@@ -2264,6 +2290,7 @@ export function renderApp(rootElement: HTMLElement) {
       setSketchDiagnostics(elements, getSketchFailureHint(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2277,6 +2304,7 @@ export function renderApp(rootElement: HTMLElement) {
     }
 
     setSketchError(elements, "");
+    busyTool = "sketch-to-image";
     isBusy = true;
     syncBusy();
     setSketchStatus(elements, "Importing Sketch to Image result into Photoshop...", "idle");
@@ -2306,6 +2334,7 @@ export function renderApp(rootElement: HTMLElement) {
       setSketchError(elements, getErrorMessage(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2315,6 +2344,7 @@ export function renderApp(rootElement: HTMLElement) {
     setInpaintDiagnostics(elements, `Capturing Photoshop selection from ${sourceModeLabel}...`);
     setInpaintError(elements, "");
     setInpaintStatus(elements, `Capturing ${sourceModeLabel} selection...`, "idle");
+    busyTool = "inpaint";
     isBusy = true;
     syncBusy();
 
@@ -2346,6 +2376,7 @@ export function renderApp(rootElement: HTMLElement) {
       setInpaintDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2427,6 +2458,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     setInpaintError(elements, "");
     setInpaintResult(null);
+    busyTool = "inpaint";
     isBusy = true;
     syncBusy();
     setInpaintStatus(elements, "Preparing Inpaint workflow...", "idle");
@@ -2671,6 +2703,7 @@ export function renderApp(rootElement: HTMLElement) {
       setInpaintDiagnostics(elements, getInpaintFailureHint(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2712,6 +2745,7 @@ export function renderApp(rootElement: HTMLElement) {
     }
 
     setInpaintError(elements, "");
+    busyTool = "inpaint";
     isBusy = true;
     syncBusy();
     setInpaintStatus(elements, "Importing Inpaint result into Photoshop...", "idle");
@@ -2786,6 +2820,7 @@ export function renderApp(rootElement: HTMLElement) {
       setInpaintError(elements, getErrorMessage(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2817,6 +2852,7 @@ export function renderApp(rootElement: HTMLElement) {
     setPromptLayerDiagnostics(elements, options.progressMessage);
     setPromptLayerError(elements, "");
     setPromptLayerStatus(elements, options.statusMessage, "idle");
+    busyTool = "prompt-from-layer";
     isBusy = true;
     syncBusy();
 
@@ -2838,6 +2874,7 @@ export function renderApp(rootElement: HTMLElement) {
       setPromptLayerDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -2858,6 +2895,7 @@ export function renderApp(rootElement: HTMLElement) {
     setPromptLayerError(elements, "");
     setPromptLayerStatus(elements, "Uploading source to ComfyUI...", "idle");
     setPromptLayerDiagnostics(elements, `Task: ${task}. Num beams: ${numBeams}.`);
+    busyTool = "prompt-from-layer";
     isBusy = true;
     syncBusy();
     let run: GenerationRunHandle | null = null;
@@ -2913,6 +2951,7 @@ export function renderApp(rootElement: HTMLElement) {
     } finally {
       run?.finish();
       isBusy = false;
+      busyTool = null;
       syncBusy();
     }
   }
@@ -3269,12 +3308,21 @@ export function renderApp(rootElement: HTMLElement) {
 }
 
 
-function setBusy(elements: AppElements, isBusy: boolean, gates: Record<BusyGateName, unknown>) {
-  for (const fieldKey of BUSY_DISABLED_FIELDS) {
-    elements[fieldKey].disabled = isBusy;
+function setBusy(
+  elements: AppElements,
+  isBusy: boolean,
+  busyTool: HistoryToolType | null,
+  gates: Record<BusyGateName, unknown>
+) {
+  for (const [groupName, fieldKeys] of Object.entries(BUSY_DISABLED_FIELD_GROUPS)) {
+    const isGroupBusy = isBusy && (groupName === "global" || groupName === busyTool);
+
+    for (const fieldKey of fieldKeys) {
+      elements[fieldKey].disabled = isGroupBusy;
+    }
   }
 
-  for (const actionKey of BUSY_DISABLED_ACTIONS) {
+  for (const actionKey of BUSY_ALWAYS_DISABLED_ACTIONS) {
     setActionDisabled(elements[actionKey], isBusy);
   }
 
@@ -3288,8 +3336,8 @@ function setBusy(elements: AppElements, isBusy: boolean, gates: Record<BusyGateN
 }
 
 // Flux Fill ignores the panel's steps/cfg/denoise, so those controls are
-// disabled while it is selected: still disabled during a run like every other
-// field, and still disabled afterwards for as long as Flux Fill is chosen.
+// disabled while it is selected: still disabled during an Inpaint operation,
+// and still disabled afterwards for as long as Flux Fill is chosen.
 // Must be re-applied anywhere the inpaint workflow selection changes, and after
 // setBusy, which re-enables every field in its table once a run ends.
 function updateInpaintReferenceControlLock(elements: AppElements, isBusy = false) {

--- a/src/ui/toolDescriptors.ts
+++ b/src/ui/toolDescriptors.ts
@@ -1,4 +1,5 @@
 import type { AppElements } from "./appMarkup";
+import type { HistoryToolType } from "./historyMetadata";
 
 // Keys of AppElements whose element type actually carries a .disabled property,
 // so a table entry pointing at a plain HTMLElement is a compile error rather
@@ -13,64 +14,83 @@ export type ActionElementKey = {
   [K in keyof AppElements]: AppElements[K] extends HTMLElement ? K : never;
 }[keyof AppElements];
 
-// Every form field the panel locks while a generation or import is running.
-export const BUSY_DISABLED_FIELDS: readonly DisableableElementKey[] = [
-  "serverUrl",
-  "prompt",
-  "negativePrompt",
-  "workflow",
-  "checkpoint",
-  "width",
-  "height",
-  "steps",
-  "cfg",
-  "seed",
-  "imgPrompt",
-  "imgNegativePrompt",
-  "imgWorkflow",
-  "imgCheckpoint",
-  "imgSteps",
-  "imgCfg",
-  "imgSeed",
-  "imgDenoise",
-  "sketchPrompt",
-  "sketchNegativePrompt",
-  "sketchWorkflow",
-  "sketchCheckpoint",
-  "sketchSteps",
-  "sketchCfg",
-  "sketchSeed",
-  "sketchDenoise",
-  "sketchControlStrength",
-  "inpaintPrompt",
-  "inpaintNegativePrompt",
-  "inpaintWorkflow",
-  "inpaintCheckpoint",
-  "inpaintSteps",
-  "inpaintCfg",
-  "inpaintSeed",
-  "inpaintDenoise",
-  "outpaintPrompt",
-  "outpaintWorkflow",
-  "outpaintCheckpoint",
-  "outpaintSteps",
-  "outpaintGuidance",
-  "outpaintSeed",
-  "outpaintDenoise",
-  "outpaintLeft",
-  "outpaintTop",
-  "outpaintRight",
-  "outpaintBottom",
-  "outpaintFeathering",
-  "upscaleWorkflow",
-  "upscaleModel",
-  "promptLayerTask",
-  "promptLayerNumBeams",
-  "promptLayerGeneratedText"
-];
+export type BusyFieldGroupName = HistoryToolType | "global";
 
-// Action buttons that are simply unavailable while busy.
-export const BUSY_DISABLED_ACTIONS: readonly ActionElementKey[] = [
+// Form fields are locked only for the tool performing the current operation.
+// Global fields remain locked for every operation because changing them can
+// disrupt the active request.
+export const BUSY_DISABLED_FIELD_GROUPS: Readonly<
+  Record<BusyFieldGroupName, readonly DisableableElementKey[]>
+> = {
+  global: ["serverUrl"],
+  "text-to-image": [
+    "prompt",
+    "negativePrompt",
+    "workflow",
+    "checkpoint",
+    "width",
+    "height",
+    "steps",
+    "cfg",
+    "seed"
+  ],
+  "image-to-image": [
+    "imgPrompt",
+    "imgNegativePrompt",
+    "imgWorkflow",
+    "imgCheckpoint",
+    "imgSteps",
+    "imgCfg",
+    "imgSeed",
+    "imgDenoise"
+  ],
+  "sketch-to-image": [
+    "sketchPrompt",
+    "sketchNegativePrompt",
+    "sketchWorkflow",
+    "sketchCheckpoint",
+    "sketchSteps",
+    "sketchCfg",
+    "sketchSeed",
+    "sketchDenoise",
+    "sketchControlStrength"
+  ],
+  inpaint: [
+    "inpaintPrompt",
+    "inpaintNegativePrompt",
+    "inpaintWorkflow",
+    "inpaintCheckpoint",
+    "inpaintSteps",
+    "inpaintCfg",
+    "inpaintSeed",
+    "inpaintDenoise"
+  ],
+  outpaint: [
+    "outpaintPrompt",
+    "outpaintWorkflow",
+    "outpaintCheckpoint",
+    "outpaintSteps",
+    "outpaintGuidance",
+    "outpaintSeed",
+    "outpaintDenoise",
+    "outpaintLeft",
+    "outpaintTop",
+    "outpaintRight",
+    "outpaintBottom",
+    "outpaintFeathering"
+  ],
+  upscale: ["upscaleWorkflow", "upscaleModel"],
+  "prompt-from-layer": [
+    "promptLayerTask",
+    "promptLayerNumBeams",
+    "promptLayerGeneratedText"
+  ]
+};
+
+// Actions that are unavailable during every operation. The two primary
+// buttons here join the gated Generate buttons below to preserve the
+// generation controller's single-active-run contract.
+export const BUSY_ALWAYS_DISABLED_ACTIONS: readonly ActionElementKey[] = [
   "checkButton",
   "findPortButton",
   "detectHardwareButton",
@@ -78,11 +98,19 @@ export const BUSY_DISABLED_ACTIONS: readonly ActionElementKey[] = [
   "copyDiagnosticsButton",
   "saveSettingsButton",
   "resetSettingsButton",
+  "generateButton",
+  "generatePromptLayerButton",
+  "clearHistoryButton"
+];
+
+// These actions were part of the old panel-wide busy lock. They deliberately
+// remain live so another tool can be prepared or its source recaptured while
+// the current operation continues.
+export const BUSY_ALLOWED_ACTIONS: readonly ActionElementKey[] = [
   "negativePromptToggle",
   "autoImportToggle",
   "imgAutoImportToggle",
   "upscaleAutoImportToggle",
-  "generateButton",
   "captureLayerButton",
   "captureCanvasButton",
   "experimentalCheckpointToggle",
@@ -96,10 +124,8 @@ export const BUSY_DISABLED_ACTIONS: readonly ActionElementKey[] = [
   "captureUpscaleCanvasButton",
   "capturePromptLayerButton",
   "capturePromptCanvasButton",
-  "generatePromptLayerButton",
   "copyPromptLayerButton",
-  "sendPromptLayerButton",
-  "clearHistoryButton"
+  "sendPromptLayerButton"
 ];
 
 // Tool state a gated button also needs before it can be enabled: generate

--- a/tests/ui/toolDescriptors.test.ts
+++ b/tests/ui/toolDescriptors.test.ts
@@ -1,28 +1,157 @@
 import { describe, expect, it } from "vitest";
 import {
-  BUSY_DISABLED_ACTIONS,
-  BUSY_DISABLED_FIELDS,
+  BUSY_ALLOWED_ACTIONS,
+  BUSY_ALWAYS_DISABLED_ACTIONS,
+  BUSY_DISABLED_FIELD_GROUPS,
   BUSY_GATED_ACTIONS
 } from "../../src/ui/toolDescriptors";
 
 describe("busy-state tables", () => {
-  it("keeps the full inventory the hand-written setBusy used to toggle", () => {
-    // 52 form fields + 29 plain actions + 11 gated actions, counted from the
-    // function this table replaced. A silently dropped entry would leave a
-    // control enabled mid-generation with no failing test.
-    expect(BUSY_DISABLED_FIELDS).toHaveLength(52);
-    expect(BUSY_DISABLED_ACTIONS).toHaveLength(29);
-    expect(BUSY_GATED_ACTIONS).toHaveLength(11);
+  const fieldGroups = Object.values(BUSY_DISABLED_FIELD_GROUPS);
+  const allFields = fieldGroups.flat();
+
+  it("keeps a non-empty field group for global state and every tool", () => {
+    expect(Object.keys(BUSY_DISABLED_FIELD_GROUPS)).toEqual([
+      "global",
+      "text-to-image",
+      "image-to-image",
+      "sketch-to-image",
+      "inpaint",
+      "outpaint",
+      "upscale",
+      "prompt-from-layer"
+    ]);
+    expect(fieldGroups.every((fields) => fields.length > 0)).toBe(true);
   });
 
-  it("lists every element at most once across all three tables", () => {
-    const allKeys = [
-      ...BUSY_DISABLED_FIELDS,
-      ...BUSY_DISABLED_ACTIONS,
-      ...BUSY_GATED_ACTIONS.map((action) => action.button)
+  it("keeps the complete field inventory without assigning a field twice", () => {
+    const expectedFields = [
+      "serverUrl",
+      "prompt",
+      "negativePrompt",
+      "workflow",
+      "checkpoint",
+      "width",
+      "height",
+      "steps",
+      "cfg",
+      "seed",
+      "imgPrompt",
+      "imgNegativePrompt",
+      "imgWorkflow",
+      "imgCheckpoint",
+      "imgSteps",
+      "imgCfg",
+      "imgSeed",
+      "imgDenoise",
+      "sketchPrompt",
+      "sketchNegativePrompt",
+      "sketchWorkflow",
+      "sketchCheckpoint",
+      "sketchSteps",
+      "sketchCfg",
+      "sketchSeed",
+      "sketchDenoise",
+      "sketchControlStrength",
+      "inpaintPrompt",
+      "inpaintNegativePrompt",
+      "inpaintWorkflow",
+      "inpaintCheckpoint",
+      "inpaintSteps",
+      "inpaintCfg",
+      "inpaintSeed",
+      "inpaintDenoise",
+      "outpaintPrompt",
+      "outpaintWorkflow",
+      "outpaintCheckpoint",
+      "outpaintSteps",
+      "outpaintGuidance",
+      "outpaintSeed",
+      "outpaintDenoise",
+      "outpaintLeft",
+      "outpaintTop",
+      "outpaintRight",
+      "outpaintBottom",
+      "outpaintFeathering",
+      "upscaleWorkflow",
+      "upscaleModel",
+      "promptLayerTask",
+      "promptLayerNumBeams",
+      "promptLayerGeneratedText"
     ];
 
-    expect(new Set(allKeys).size).toBe(allKeys.length);
+    expect(new Set(allFields)).toEqual(new Set(expectedFields));
+    expect(new Set(allFields).size).toBe(allFields.length);
+  });
+
+  it("accounts for every formerly busy-locked action exactly once", () => {
+    const plainActions = [
+      ...BUSY_ALWAYS_DISABLED_ACTIONS,
+      ...BUSY_ALLOWED_ACTIONS
+    ];
+    const allActions = [
+      ...plainActions,
+      ...BUSY_GATED_ACTIONS.map(({ button }) => button)
+    ];
+
+    expect(plainActions).toHaveLength(29);
+    expect(BUSY_GATED_ACTIONS).toHaveLength(11);
+    expect(new Set(allActions).size).toBe(allActions.length);
+  });
+
+  it("leaves captures, preparation toggles, and prompt reuse actions out of the busy lock", () => {
+    expect(new Set(BUSY_ALLOWED_ACTIONS)).toEqual(new Set([
+      "negativePromptToggle",
+      "autoImportToggle",
+      "imgAutoImportToggle",
+      "upscaleAutoImportToggle",
+      "captureLayerButton",
+      "captureCanvasButton",
+      "experimentalCheckpointToggle",
+      "captureSketchLayerButton",
+      "captureSketchCanvasButton",
+      "captureInpaintSelectionButton",
+      "captureInpaintActiveLayerButton",
+      "captureOutpaintLayerButton",
+      "captureOutpaintCanvasButton",
+      "captureUpscaleLayerButton",
+      "captureUpscaleCanvasButton",
+      "capturePromptLayerButton",
+      "capturePromptCanvasButton",
+      "copyPromptLayerButton",
+      "sendPromptLayerButton"
+    ]));
+  });
+
+  it("always locks every Generate and Import button while busy", () => {
+    const lockedActions = new Set([
+      ...BUSY_ALWAYS_DISABLED_ACTIONS,
+      ...BUSY_GATED_ACTIONS.map(({ button }) => button)
+    ]);
+
+    expect(lockedActions).toEqual(new Set([
+      "generateButton",
+      "generateImg2ImgButton",
+      "generateSketchButton",
+      "generateInpaintButton",
+      "generateOutpaintButton",
+      "generateUpscaleButton",
+      "generatePromptLayerButton",
+      "importButton",
+      "importImg2ImgButton",
+      "importSketchButton",
+      "importInpaintButton",
+      "importOutpaintButton",
+      "importUpscaleButton",
+      "checkButton",
+      "findPortButton",
+      "detectHardwareButton",
+      "checkWorkflowHealthButton",
+      "copyDiagnosticsButton",
+      "saveSettingsButton",
+      "resetSettingsButton",
+      "clearHistoryButton"
+    ]));
   });
 
   it("gates every tool's generate button on its captured source", () => {


### PR DESCRIPTION
## Summary

Implemented by Codex under the new snapshot/verify protocol (repo integrity confirmed intact afterward), reviewed and landed by Claude.

Any generation used to freeze the **entire panel** — all 52 form fields and 29 action buttons across all seven tools. An artist waiting on a Text to Image run couldn't even type the next Inpaint prompt.

**Now, while a generation runs:**
- **Locked:** the running tool's own form fields, `serverUrl` + settings/connectivity buttons, `clearHistoryButton`, and **every Generate and Import button** — deliberately, because the generation controller supports exactly one active run (Phase A4 runId gating); a second Generate would supersede the first and silently discard its result.
- **Left live:** every *other* tool's form fields (prepare your next prompt while waiting), all source-capture buttons (safe — generation snapshots its source at submission time), auto-import/negative-prompt/experimental toggles, prompt copy/send, and **history preview** (history *import* stays blocked while busy).

The busy tables in `toolDescriptors.ts` are regrouped per tool with the same compile-checked key types; the old monolithic action list is preserved verbatim as `BUSY_ALLOWED_ACTIONS` so every formerly-locked control is accounted for rather than silently dropped. The Flux Fill reference lock now keys off "inpaint is the busy tool" and still re-asserts after every `setBusy` pass.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 261 tests (258 → 261): complete inventory accounting, no field in two groups, non-empty groups, Generate/Import always-locked contract, capture/toggle freedom
- [x] `npm run build` — green
- [ ] **Photoshop:** start a Text to Image generation, then while it runs: type in the Inpaint prompt (should work), capture an Image-to-Image source (should work), try Generate on another tool (should be locked), preview a history item (should work), try importing from history (should be blocked); Cancel still works; after the run, everything unlocks; run a Flux Fill inpaint → its Steps/CFG/Denoise stay locked after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code), implementation by Codex