### PR TITLE
Expand the canvas and align the Outpaint import exactly

### DIFF
--- a/src/photoshop/outpaintExpansion.ts
+++ b/src/photoshop/outpaintExpansion.ts
@@ -1,0 +1,110 @@
+import type { PixelDimensions } from "./exactInpaintMask";
+
+export type OutpaintPads = Readonly<{
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}>;
+
+// ComfyUI's VAE encode rounds the padded image down to multiples of 8, so a
+// padded size that is not a multiple of 8 comes back smaller than requested and
+// the translate-only aligned import would drift by up to 7px. Mirrors
+// INPAINT_CONTEXT_MULTIPLE in photoshopAdapter/inpaintReadiness.
+export const OUTPAINT_DIMENSION_MULTIPLE = 8;
+
+export type SnappedOutpaintPads = Readonly<{
+  pads: OutpaintPads;
+  adjustedRight: number;
+  adjustedBottom: number;
+}>;
+
+// Grows the right/bottom pads just enough that the padded totals are multiples
+// of 8. Right/bottom are chosen because extending them never shifts the
+// artist's existing content, so the alignment math stays exact.
+export function snapOutpaintPads(pads: OutpaintPads, source: PixelDimensions): SnappedOutpaintPads {
+  const totalWidth = source.width + pads.left + pads.right;
+  const totalHeight = source.height + pads.top + pads.bottom;
+  const widthRemainder = totalWidth % OUTPAINT_DIMENSION_MULTIPLE;
+  const heightRemainder = totalHeight % OUTPAINT_DIMENSION_MULTIPLE;
+  const adjustedRight = widthRemainder === 0 ? 0 : OUTPAINT_DIMENSION_MULTIPLE - widthRemainder;
+  const adjustedBottom = heightRemainder === 0 ? 0 : OUTPAINT_DIMENSION_MULTIPLE - heightRemainder;
+
+  return {
+    pads: {
+      left: pads.left,
+      top: pads.top,
+      right: pads.right + adjustedRight,
+      bottom: pads.bottom + adjustedBottom
+    },
+    adjustedRight,
+    adjustedBottom
+  };
+}
+
+export type OutpaintExpansionPlan = Readonly<{
+  sourceDimensions: PixelDimensions;
+  pads: OutpaintPads;
+  expandedWidth: number;
+  expandedHeight: number;
+  // Where the artist's original content sits inside the expanded canvas.
+  contentOffset: Readonly<{ x: number; y: number }>;
+  // The generated result covers the whole expanded canvas.
+  resultBounds: Readonly<{ left: number; top: number; right: number; bottom: number }>;
+}>;
+
+export function createOutpaintExpansionPlan(
+  source: PixelDimensions,
+  pads: OutpaintPads
+): OutpaintExpansionPlan {
+  if (!isNonNegativeInteger(pads.left) || !isNonNegativeInteger(pads.top) ||
+      !isNonNegativeInteger(pads.right) || !isNonNegativeInteger(pads.bottom)) {
+    throw new Error("Outpaint padding must be non-negative whole pixel values.");
+  }
+
+  if (!isPositiveInteger(source.width) || !isPositiveInteger(source.height)) {
+    throw new Error("The captured Outpaint source has invalid dimensions.");
+  }
+
+  if (pads.left + pads.top + pads.right + pads.bottom === 0) {
+    throw new Error("Outpaint padding is zero on every side; there is nothing to expand.");
+  }
+
+  const expandedWidth = source.width + pads.left + pads.right;
+  const expandedHeight = source.height + pads.top + pads.bottom;
+
+  return {
+    sourceDimensions: { width: source.width, height: source.height },
+    pads,
+    expandedWidth,
+    expandedHeight,
+    contentOffset: { x: pads.left, y: pads.top },
+    resultBounds: { left: 0, top: 0, right: expandedWidth, bottom: expandedHeight }
+  };
+}
+
+// The generated image must exactly match the canvas the plan will create;
+// anything else means the workflow resized behind our back, and expanding the
+// artist's canvas around a wrong-sized image would misalign their artwork.
+export function validateOutpaintResultDimensions(
+  result: PixelDimensions | null,
+  plan: OutpaintExpansionPlan
+): string | null {
+  if (!result) {
+    return "The generated Outpaint result dimensions could not be read, so the canvas will not be expanded.";
+  }
+
+  if (Math.round(result.width) !== plan.expandedWidth || Math.round(result.height) !== plan.expandedHeight) {
+    return `The generated Outpaint result is ${Math.round(result.width)} x ${Math.round(result.height)}, but the expanded canvas needs ${plan.expandedWidth} x ${plan.expandedHeight}. Generate again before importing with canvas expansion.`;
+  }
+
+  return null;
+}
+
+function isNonNegativeInteger(value: number) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isPositiveInteger(value: number) {
+  return Number.isInteger(value) && value > 0;
+}

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -2,6 +2,7 @@ import { createLayerName, deleteTemporaryFileBestEffort, saveBlobToTemporaryFile
 import { createOpenLayerError, getErrorMessage } from "../utils/errors";
 import { encodeRgbaPng } from "../utils/png";
 import { calculatePlacementOffset, createOpaqueGrayscaleMaskPng, PixelDimensions } from "./exactInpaintMask";
+import { OutpaintExpansionPlan } from "./outpaintExpansion";
 import {
   createPaddedSelectionBounds,
   normalizeSelectionBounds,
@@ -38,10 +39,24 @@ type PhotoshopModule = {
     batchPlay: (commands: unknown[], options: Record<string, unknown>) => Promise<unknown[]>;
   };
   core: {
-    executeAsModal: <T>(command: () => Promise<T>, options: { commandName: string }) => Promise<T>;
+    executeAsModal: <T>(
+      command: (executionContext: PhotoshopExecutionContext) => Promise<T>,
+      options: { commandName: string }
+    ) => Promise<T>;
   };
   imaging?: {
     getPixels: (options: Record<string, unknown>) => Promise<PhotoshopPixelResult>;
+  };
+};
+
+// Passed by executeAsModal to its callback. suspendHistory groups every edit in
+// the block into one undoable history state; resumeHistory(id, false) reverts
+// the document to the pre-suspension state, which is the only rollback that
+// cannot clip artist pixels the way a programmatic canvas re-crop would.
+type PhotoshopExecutionContext = {
+  hostControl?: {
+    suspendHistory?: (options: { documentID: number; name: string }) => Promise<number>;
+    resumeHistory?: (suspensionID: number, commit: boolean) => Promise<void>;
   };
 };
 
@@ -824,6 +839,170 @@ export async function importImageAlignedToSelection(options: AlignedRegionalImpo
   } finally {
     await deleteTemporaryFileBestEffort(file);
   }
+}
+
+export type OutpaintCanvasImportOptions = {
+  blob: Blob;
+  originatingDocument: PhotoshopDocumentIdentity | null;
+  plan: OutpaintExpansionPlan;
+  layerName?: string;
+  onProgress?: ImportProgress;
+};
+
+// Expands the artist's canvas by the plan's padding and places the generated
+// result covering the whole expanded canvas, so the original content lines up
+// exactly under its region of the outpaint. The whole operation is wrapped in a
+// suspended history state: on any failure the placed layer is removed and the
+// document reverts to its pre-import state in one step. The canvas is never
+// re-cropped programmatically, because reducing canvas size clips pixel data
+// outside the new bounds and artist layers may extend past the original canvas.
+export async function importOutpaintResultExpandingCanvas(
+  options: OutpaintCanvasImportOptions
+): Promise<string> {
+  const photoshop = getPhotoshop();
+  const layerName = options.layerName ?? createLayerName("OpenLayer_Outpaint");
+  let file: UxpFile | undefined;
+
+  try {
+    assertActiveDocumentMatchesOrigin(photoshop, options.originatingDocument);
+    assertCanvasMatchesOutpaintPlan(getActiveDocument(), options.plan);
+
+    if (!options.blob || options.blob.size === 0) {
+      throw new Error("The generated outpaint image blob is empty.");
+    }
+
+    options.onProgress?.("Saving outpaint result to a temporary PNG...");
+    file = await saveBlobToTemporaryFile(options.blob, `${layerName}.png`);
+    const uxp = getUxp();
+    options.onProgress?.("Creating Photoshop file token...");
+    const token = await uxp.storage.localFileSystem.createSessionToken(file);
+
+    options.onProgress?.("Expanding the canvas and placing the outpaint result...");
+    await photoshop.core.executeAsModal(
+      async (executionContext) => {
+        assertActiveDocumentMatchesOrigin(photoshop, options.originatingDocument);
+        const transactionDocument = getActiveDocument();
+        assertCanvasMatchesOutpaintPlan(transactionDocument, options.plan);
+
+        const hostControl = executionContext?.hostControl;
+        const canSuspendHistory = typeof transactionDocument.id === "number" &&
+          typeof hostControl?.suspendHistory === "function" &&
+          typeof hostControl?.resumeHistory === "function";
+        const suspensionId = canSuspendHistory
+          ? await hostControl!.suspendHistory!({
+            documentID: transactionDocument.id!,
+            name: "OpenLayer Outpaint Canvas Expansion"
+          })
+          : null;
+        let resultLayerId: number | undefined;
+        let operationError: unknown;
+
+        try {
+          const { pads, sourceDimensions, expandedWidth, expandedHeight } = options.plan;
+
+          // Two anchored steps because canvasSize distributes new space
+          // around a single anchor: first pin the content bottom-right to
+          // add the left/top padding, then pin it top-left for right/bottom.
+          if (pads.left > 0 || pads.top > 0) {
+            await resizeCanvas(photoshop, sourceDimensions.width + pads.left, sourceDimensions.height + pads.top, "right", "bottom");
+          }
+
+          if (pads.right > 0 || pads.bottom > 0) {
+            await resizeCanvas(photoshop, expandedWidth, expandedHeight, "left", "top");
+          }
+
+          await placeFileAsLayer(photoshop, token);
+          resultLayerId = getActiveDocument().activeLayers?.[0]?.id;
+          if (resultLayerId === undefined) throw new Error("Photoshop did not expose the imported outpaint layer ID.");
+          await renameActiveLayer(photoshop, layerName);
+          await alignActiveLayerToBounds(photoshop, normalizeSelectionBounds(options.plan.resultBounds));
+
+          // The placed layer must cover the expanded canvas exactly; anything
+          // else means the result image did not match the plan after all.
+          const placedBounds = await readActiveLayerBounds(photoshop);
+          if (
+            placedBounds.left !== 0 ||
+            placedBounds.top !== 0 ||
+            placedBounds.width !== expandedWidth ||
+            placedBounds.height !== expandedHeight
+          ) {
+            throw new Error(
+              `The placed outpaint layer covers ${placedBounds.width} x ${placedBounds.height} at ${placedBounds.left}, ${placedBounds.top}, not the expanded ${expandedWidth} x ${expandedHeight} canvas.`
+            );
+          }
+
+          assertActiveDocumentMatchesOrigin(photoshop, options.originatingDocument);
+        } catch (caughtError) {
+          operationError = caughtError;
+        }
+
+        if (operationError) {
+          // Belt and suspenders: remove the placed layer even though the
+          // history revert below should also erase it, in case this host
+          // cannot suspend history at all.
+          if (resultLayerId !== undefined) {
+            await deleteLayerById(photoshop, resultLayerId, true);
+          }
+        }
+
+        if (suspensionId !== null) {
+          await hostControl!.resumeHistory!(suspensionId, !operationError);
+        }
+
+        if (operationError) {
+          const revertNote = suspensionId !== null
+            ? " The document was reverted to its state before the import."
+            : " Undo (Ctrl+Z) restores the canvas if it was already expanded.";
+          throw new Error(`${getErrorMessage(operationError)}${revertNote}`);
+        }
+      },
+      { commandName: "Import OpenLayer Outpaint With Canvas Expansion" }
+    );
+
+    options.onProgress?.(`Imported ${layerName} on an expanded canvas.`);
+    return layerName;
+  } catch (caughtError) {
+    throw createOpenLayerError(
+      "PHOTOSHOP_IMPORT_FAILED",
+      `Could not import the outpaint result with canvas expansion. ${getErrorMessage(caughtError)}`
+    );
+  } finally {
+    await deleteTemporaryFileBestEffort(file);
+  }
+}
+
+// The canvas must still be exactly the size that was captured and padded; if
+// the artist resized the document after capturing, expanding it would misalign
+// everything silently.
+function assertCanvasMatchesOutpaintPlan(document: PhotoshopDocument, plan: OutpaintExpansionPlan) {
+  const width = Math.round(Number(document.width ?? 0));
+  const height = Math.round(Number(document.height ?? 0));
+
+  if (width !== plan.sourceDimensions.width || height !== plan.sourceDimensions.height) {
+    throw new Error(
+      `The document is now ${width} x ${height}, but this outpaint was generated from a ${plan.sourceDimensions.width} x ${plan.sourceDimensions.height} canvas. Capture and generate again before importing with canvas expansion.`
+    );
+  }
+}
+
+async function resizeCanvas(
+  photoshop: PhotoshopModule,
+  width: number,
+  height: number,
+  horizontalAnchor: "left" | "center" | "right",
+  verticalAnchor: "top" | "center" | "bottom"
+) {
+  await photoshop.action.batchPlay(
+    [{
+      _obj: "canvasSize",
+      width: { _unit: "pixelsUnit", _value: width },
+      height: { _unit: "pixelsUnit", _value: height },
+      horizontal: { _enum: "horizontalLocation", _value: horizontalAnchor },
+      vertical: { _enum: "verticalLocation", _value: verticalAnchor },
+      _options: { dialogOptions: "dontDisplay" }
+    }],
+    {}
+  );
 }
 
 export async function preserveSelection<T>(_operation: PreserveSelectionOperation<T>): Promise<T> {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -99,7 +99,8 @@ import {
   getActiveDocumentIdentity,
   getActiveDocumentInfo,
   importGeneratedImageAsLayer,
-  importImageAlignedToSelectionWithLayerMask
+  importImageAlignedToSelectionWithLayerMask,
+  importOutpaintResultExpandingCanvas
 } from "../photoshop/photoshopAdapter";
 import {
   bindDocumentContext,
@@ -113,6 +114,12 @@ import {
 } from "../photoshop/inpaintSourceMode";
 import { writeOpenLayerLayerMetadata } from "../photoshop/layerMetadata";
 import { formatSelectionBounds } from "../photoshop/selectionUtils";
+import {
+  createOutpaintExpansionPlan,
+  OutpaintPads,
+  snapOutpaintPads,
+  validateOutpaintResultDimensions
+} from "../photoshop/outpaintExpansion";
 import { createOpenLayerError, getErrorMessage, getTechnicalErrorDetails } from "../utils/errors";
 import { createLayerName, sweepStaleTemporaryFiles } from "../utils/fileUtils";
 import {
@@ -187,6 +194,7 @@ type HistoryEntry = {
   result: AppGeneratedImageResult;
   originatingDocument: PhotoshopDocumentIdentity | null;
   inpaintImportContext?: AppInpaintImportContext;
+  outpaintImportContext?: AppOutpaintImportContext;
   previewUrl: string;
   prompt: string;
   checkpointName: string;
@@ -214,6 +222,15 @@ type InpaintSourceState = SelectedRegionSourceImage & {
 
 type AppGeneratedImageResult = DocumentContextBound<GeneratedImageResult>;
 type AppInpaintImportContext = InpaintImportContext<SelectedRegionSourceImage, AppGeneratedImageResult>;
+type OutpaintCaptureKind = "layer" | "canvas";
+// What the canvas-expansion import needs, frozen at submission time: the pads
+// actually sent to ComfyUI (after /8 snapping) and the canvas size they padded.
+type OutpaintExpansionSource = Readonly<{
+  pads: OutpaintPads;
+  sourceDimensions: Readonly<{ width: number; height: number }>;
+  captureKind: OutpaintCaptureKind;
+}>;
+type AppOutpaintImportContext = InpaintImportContext<OutpaintExpansionSource, AppGeneratedImageResult>;
 type LiveGeneratedImageResult = DocumentContextBound<{ blob: Blob }>;
 
 const statusProgressTimers = new WeakMap<HTMLElement, number>();
@@ -234,6 +251,8 @@ export function renderApp(rootElement: HTMLElement) {
   let inpaintSource: InpaintSourceState | null = null;
   let inpaintResult: AppGeneratedImageResult | null = null;
   let activeInpaintImportContext: AppInpaintImportContext | null = null;
+  let activeOutpaintImportContext: AppOutpaintImportContext | null = null;
+  let outpaintCaptureKind: OutpaintCaptureKind | null = null;
   let outpaintSource: ImageSourceState | null = null;
   let outpaintResult: AppGeneratedImageResult | null = null;
   let upscaleSource: ImageSourceState | null = null;
@@ -1177,6 +1196,7 @@ export function renderApp(rootElement: HTMLElement) {
         setView("inpaint");
         return;
       case "outpaint":
+        activeOutpaintImportContext = entry.outpaintImportContext ?? null;
         setOutpaintResult(entry.result);
         setView("outpaint");
         return;
@@ -1203,7 +1223,7 @@ export function renderApp(rootElement: HTMLElement) {
         await handleImportInpaint(entry.inpaintImportContext);
         return;
       case "outpaint":
-        await handleImportOutpaint();
+        await handleImportOutpaint(entry.outpaintImportContext);
         return;
       case "upscale":
         await handleImportUpscale();
@@ -1814,6 +1834,7 @@ export function renderApp(rootElement: HTMLElement) {
       progressMessage: "Capturing active Photoshop layer for Outpaint...",
       statusMessage: "Capturing active layer...",
       successMessage: "Outpaint source captured.",
+      captureKind: "layer",
       capture: exportActiveLayerForImageToImage
     });
   }
@@ -1823,6 +1844,7 @@ export function renderApp(rootElement: HTMLElement) {
       progressMessage: "Capturing Photoshop canvas for Outpaint...",
       statusMessage: "Capturing canvas...",
       successMessage: "Outpaint canvas captured.",
+      captureKind: "canvas",
       capture: exportCanvasForImageToImage
     });
   }
@@ -1831,6 +1853,7 @@ export function renderApp(rootElement: HTMLElement) {
     progressMessage: string;
     statusMessage: string;
     successMessage: string;
+    captureKind: OutpaintCaptureKind;
     capture: () => Promise<ExportedSourceImage>;
   }) {
     setOutpaintDiagnostics(elements, options.progressMessage);
@@ -1847,6 +1870,7 @@ export function renderApp(rootElement: HTMLElement) {
         ...exportedSource,
         previewUrl: sourcePreview
       });
+      outpaintCaptureKind = options.captureKind;
       setOutpaintStatus(elements, options.successMessage, "ready");
       setOutpaintDiagnostics(
         elements,
@@ -1944,6 +1968,13 @@ export function renderApp(rootElement: HTMLElement) {
       setOutpaintStatus(elements, "Uploading source image to ComfyUI...", "idle");
       setOutpaintProgressPreview(elements, "Uploading source image...");
       const sourceImageName = await client.uploadImage(outpaintSource.blob, outpaintSource.filename);
+      // ComfyUI's VAE rounds the padded image down to multiples of 8; snapping
+      // the pads up-front keeps the result exactly the size the canvas
+      // expansion import will create, instead of drifting by up to 7px.
+      const snappedPads = snapOutpaintPads(
+        { left: settings.left, top: settings.top, right: settings.right, bottom: settings.bottom },
+        { width: outpaintSource.width, height: outpaintSource.height }
+      );
       const buildResult = await buildOutpaintWorkflow({
         presetId: preset.id,
         prompt: elements.outpaintPrompt.value,
@@ -1953,10 +1984,10 @@ export function renderApp(rootElement: HTMLElement) {
         cfg: settings.cfg,
         seed: settings.seed,
         denoise: settings.denoise,
-        left: settings.left,
-        top: settings.top,
-        right: settings.right,
-        bottom: settings.bottom,
+        left: snappedPads.pads.left,
+        top: snappedPads.pads.top,
+        right: snappedPads.pads.right,
+        bottom: snappedPads.pads.bottom,
         feathering: settings.feathering,
         requiredModelSelections
       });
@@ -1964,6 +1995,7 @@ export function renderApp(rootElement: HTMLElement) {
       // The commit closure runs after awaits; a const keeps the null-checked
       // source from the top of the handler rather than re-reading mutable state.
       const capturedSource = outpaintSource;
+      const capturedCaptureKind = outpaintCaptureKind ?? "layer";
       const generatedResult = await generation.runPipeline({
         toolType: "outpaint",
         client,
@@ -1981,7 +2013,16 @@ export function renderApp(rootElement: HTMLElement) {
           livePreview: "Live ComfyUI Outpaint preview..."
         },
         commit: (generatedResult) => {
+        const generatedOutpaintContext = createInpaintImportContext<OutpaintExpansionSource, AppGeneratedImageResult>(
+          {
+            pads: snappedPads.pads,
+            sourceDimensions: { width: capturedSource.width, height: capturedSource.height },
+            captureKind: capturedCaptureKind
+          },
+          generatedResult
+        );
         setOutpaintResult(generatedResult);
+        activeOutpaintImportContext = generatedOutpaintContext;
         addHistoryEntry(elements, historyEntries, objectUrls, generatedResult, {
           prompt: elements.outpaintPrompt.value,
           checkpointName,
@@ -1992,6 +2033,7 @@ export function renderApp(rootElement: HTMLElement) {
           sizeLabel: "Outpaint",
           dimensions: `${capturedSource.width} x ${capturedSource.height}`,
           sourceMode: capturedSource.sourceName,
+          outpaintImportContext: generatedOutpaintContext,
           experimental: true,
           diagnosticsSummary: formatInpaintOutpaintDebugContract({
             toolType: "outpaint",
@@ -2014,7 +2056,13 @@ export function renderApp(rootElement: HTMLElement) {
       setOutpaintStatus(elements, "Outpaint generation complete.", "ready");
       setOutpaintDiagnostics(
         elements,
-        `Seed used: ${buildResult.seed}. Source uploaded as ${sourceImageName}. Workflow: ${buildResult.preset.id}. Padding left ${settings.left}, top ${settings.top}, right ${settings.right}, bottom ${settings.bottom}, feather ${settings.feathering}.`
+        [
+          `Seed used: ${buildResult.seed}. Source uploaded as ${sourceImageName}. Workflow: ${buildResult.preset.id}.`,
+          `Padding left ${snappedPads.pads.left}, top ${snappedPads.pads.top}, right ${snappedPads.pads.right}, bottom ${snappedPads.pads.bottom}, feather ${settings.feathering}.`,
+          snappedPads.adjustedRight || snappedPads.adjustedBottom
+            ? `Right/bottom padding grew by ${snappedPads.adjustedRight}/${snappedPads.adjustedBottom}px so the result size stays a multiple of 8.`
+            : ""
+        ].filter(Boolean).join(" ")
       );
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {
@@ -2033,10 +2081,12 @@ export function renderApp(rootElement: HTMLElement) {
     }
   }
 
-  async function handleImportOutpaint() {
+  async function handleImportOutpaint(savedHistoryContext?: AppOutpaintImportContext) {
     setOutpaintDiagnostics(elements, "Outpaint import pressed.");
+    const importContext = resolveInpaintImportContext(savedHistoryContext, activeOutpaintImportContext);
+    const importResultImage = importContext?.result ?? outpaintResult;
 
-    if (!outpaintResult) {
+    if (!importResultImage) {
       setOutpaintError(elements, "Generate an Outpaint result before importing.");
       return;
     }
@@ -2050,10 +2100,51 @@ export function renderApp(rootElement: HTMLElement) {
     try {
       const layerName = createLayerName("OpenLayer_Outpaint");
 
-      setOutpaintDiagnostics(elements, `Importing into ${outpaintResult.originatingDocument?.name || "the originating document"}...`);
+      setOutpaintDiagnostics(elements, `Importing into ${importResultImage.originatingDocument?.name || "the originating document"}...`);
+
+      // Canvas expansion needs the exact pads this result was generated with
+      // and a canvas-covering source; both live in the saved context. Layer
+      // captures carry no position, so they keep the floating-layer import.
+      let expansionBlockedReason = "";
+
+      if (importContext && importContext.source.captureKind === "canvas") {
+        const plan = createOutpaintExpansionPlan(importContext.source.sourceDimensions, importContext.source.pads);
+        const resultDimensions = await readImageDimensionsFromBlob(importResultImage.blob);
+        expansionBlockedReason = validateOutpaintResultDimensions(resultDimensions, plan) ?? "";
+
+        if (!expansionBlockedReason) {
+          setOutpaintStatus(elements, "Expanding the canvas for the outpaint result...", "idle");
+          const importedLayerName = await importOutpaintResultExpandingCanvas({
+            blob: importResultImage.blob,
+            originatingDocument: importResultImage.originatingDocument,
+            plan,
+            layerName,
+            onProgress: (message) => {
+              setOutpaintStatus(elements, message, "idle");
+              setOutpaintDiagnostics(elements, message);
+            }
+          });
+          setOutpaintStatus(elements, `Imported layer: ${importedLayerName}`, "ready");
+          flashImported(elements.outpaintStatusText);
+          markHistoryImported(elements, historyEntries, importResultImage, importedLayerName);
+          const metadataMessage = await writeMetadataForImportedResult(historyEntries, importResultImage, importedLayerName, (message) => {
+            setOutpaintDiagnostics(elements, message);
+          });
+          setOutpaintDiagnostics(
+            elements,
+            `Layer created: ${importedLayerName}. Canvas expanded to ${plan.expandedWidth} x ${plan.expandedHeight}; your original artwork now sits at ${plan.contentOffset.x}, ${plan.contentOffset.y}. ${metadataMessage}`
+          );
+          return;
+        }
+      } else if (importContext) {
+        expansionBlockedReason = "This result was generated from a layer capture, which carries no canvas position; importing it as a floating layer instead.";
+      } else {
+        expansionBlockedReason = "This result predates canvas-expansion support; importing it as a floating layer.";
+      }
+
       const importedLayerName = await importGeneratedImageAsLayer({
-        blob: outpaintResult.blob,
-        originatingDocument: outpaintResult.originatingDocument,
+        blob: importResultImage.blob,
+        originatingDocument: importResultImage.originatingDocument,
         layerName,
         onProgress: (message) => {
           setOutpaintStatus(elements, message, "idle");
@@ -2062,11 +2153,14 @@ export function renderApp(rootElement: HTMLElement) {
       });
       setOutpaintStatus(elements, `Imported layer: ${importedLayerName}`, "ready");
       flashImported(elements.outpaintStatusText);
-      markHistoryImported(elements, historyEntries, outpaintResult, importedLayerName);
-      const metadataMessage = await writeMetadataForImportedResult(historyEntries, outpaintResult, importedLayerName, (message) => {
+      markHistoryImported(elements, historyEntries, importResultImage, importedLayerName);
+      const metadataMessage = await writeMetadataForImportedResult(historyEntries, importResultImage, importedLayerName, (message) => {
         setOutpaintDiagnostics(elements, message);
       });
-      setOutpaintDiagnostics(elements, `Layer created: ${importedLayerName}. ${metadataMessage}`);
+      setOutpaintDiagnostics(
+        elements,
+        [`Layer created: ${importedLayerName}.`, expansionBlockedReason, metadataMessage].filter(Boolean).join(" ")
+      );
     } catch (caughtError) {
       setOutpaintStatus(elements, "Import failed.", "error");
       setOutpaintError(elements, getErrorMessage(caughtError));
@@ -3244,6 +3338,10 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   function setOutpaintResult(nextResult: AppGeneratedImageResult | null) {
+    if (!nextResult) {
+      activeOutpaintImportContext = null;
+    }
+
     outpaintResult = nextResult;
     outpaintResultPanel.showResult(outpaintResult?.blob ?? null);
     syncBusy();
@@ -5533,6 +5631,7 @@ function addHistoryEntry(
     sourceBounds?: OpenLayerLayerBounds;
     contextBounds?: OpenLayerLayerBounds;
     inpaintImportContext?: AppInpaintImportContext;
+    outpaintImportContext?: AppOutpaintImportContext;
     experimental?: boolean;
     diagnosticsSummary?: string;
   }
@@ -5560,6 +5659,7 @@ function addHistoryEntry(
     result,
     originatingDocument: result.originatingDocument,
     inpaintImportContext: details.inpaintImportContext,
+    outpaintImportContext: details.outpaintImportContext,
     previewUrl: objectUrls.create(result.blob),
     prompt: details.prompt.trim() || "Untitled prompt",
     checkpointName: details.checkpointName,

--- a/tests/photoshop/outpaintExpansion.test.ts
+++ b/tests/photoshop/outpaintExpansion.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  createOutpaintExpansionPlan,
+  snapOutpaintPads,
+  validateOutpaintResultDimensions
+} from "../../src/photoshop/outpaintExpansion";
+
+describe("outpaint pad snapping", () => {
+  it("leaves pads alone when the padded totals are already multiples of 8", () => {
+    const snapped = snapOutpaintPads({ left: 400, top: 0, right: 400, bottom: 400 }, { width: 1024, height: 1024 });
+
+    expect(snapped.pads).toEqual({ left: 400, top: 0, right: 400, bottom: 400 });
+    expect(snapped.adjustedRight).toBe(0);
+    expect(snapped.adjustedBottom).toBe(0);
+  });
+
+  it("grows only right and bottom so existing content never shifts", () => {
+    // 1030 + 100 + 100 = 1230 -> needs +2 to reach 1232; 999 + 50 + 50 = 1099 -> +5 to 1104.
+    const snapped = snapOutpaintPads({ left: 100, top: 50, right: 100, bottom: 50 }, { width: 1030, height: 999 });
+
+    expect(snapped.pads.left).toBe(100);
+    expect(snapped.pads.top).toBe(50);
+    expect(snapped.pads.right).toBe(102);
+    expect(snapped.pads.bottom).toBe(55);
+    expect((1030 + snapped.pads.left + snapped.pads.right) % 8).toBe(0);
+    expect((999 + snapped.pads.top + snapped.pads.bottom) % 8).toBe(0);
+  });
+
+  it("reports how much it adjusted, for the diagnostics line", () => {
+    const snapped = snapOutpaintPads({ left: 0, top: 0, right: 1, bottom: 3 }, { width: 512, height: 512 });
+
+    expect(snapped.adjustedRight).toBe(7);
+    expect(snapped.adjustedBottom).toBe(5);
+  });
+});
+
+describe("outpaint expansion plan", () => {
+  it("places the original content at the pad offset inside the expanded canvas", () => {
+    const plan = createOutpaintExpansionPlan({ width: 1024, height: 768 }, { left: 400, top: 0, right: 400, bottom: 400 });
+
+    expect(plan.expandedWidth).toBe(1824);
+    expect(plan.expandedHeight).toBe(1168);
+    expect(plan.contentOffset).toEqual({ x: 400, y: 0 });
+    expect(plan.resultBounds).toEqual({ left: 0, top: 0, right: 1824, bottom: 1168 });
+  });
+
+  it("rejects all-zero padding", () => {
+    expect(() => createOutpaintExpansionPlan({ width: 512, height: 512 }, { left: 0, top: 0, right: 0, bottom: 0 }))
+      .toThrow(/nothing to expand/i);
+  });
+
+  it("rejects negative or fractional padding", () => {
+    expect(() => createOutpaintExpansionPlan({ width: 512, height: 512 }, { left: -1, top: 0, right: 0, bottom: 0 }))
+      .toThrow(/non-negative/i);
+    expect(() => createOutpaintExpansionPlan({ width: 512, height: 512 }, { left: 0.5, top: 0, right: 0, bottom: 0 }))
+      .toThrow(/non-negative/i);
+  });
+
+  it("rejects an invalid source size", () => {
+    expect(() => createOutpaintExpansionPlan({ width: 0, height: 512 }, { left: 8, top: 0, right: 0, bottom: 0 }))
+      .toThrow(/invalid dimensions/i);
+  });
+});
+
+describe("outpaint result validation", () => {
+  const plan = createOutpaintExpansionPlan({ width: 1024, height: 1024 }, { left: 400, top: 0, right: 400, bottom: 400 });
+
+  it("accepts a result exactly matching the expanded canvas", () => {
+    expect(validateOutpaintResultDimensions({ width: 1824, height: 1424 }, plan)).toBeNull();
+  });
+
+  it("refuses to expand the canvas around a wrong-sized result", () => {
+    const message = validateOutpaintResultDimensions({ width: 1820, height: 1424 }, plan);
+
+    expect(message).toContain("1820 x 1424");
+    expect(message).toContain("1824 x 1424");
+  });
+
+  it("refuses when the result dimensions could not be read", () => {
+    expect(validateOutpaintResultDimensions(null, plan)).toMatch(/could not be read/i);
+  });
+});


### PR DESCRIPTION
## Summary

The real outpaint: importing now **expands the Photoshop canvas by the exact padding and places the result so your original artwork lines up perfectly** under its region — instead of dropping a centered floating layer on the unchanged canvas.

Three pieces:

1. **Generate-time pad snapping.** ComfyUI's VAE rounds the padded image down to multiples of 8, so naive expansion math could misalign by up to 7px. Pads are snapped at submission (growing only right/bottom, so existing content never shifts), and the snapped pads + source canvas size + capture kind are frozen into a submission-time context (the B1 pattern) carried on the result and into history.
2. **Transactional canvas expansion** (`importOutpaintResultExpandingCanvas`): document-origin asserted twice, canvas-still-matches-capture guard, two anchored `canvasSize` steps, place + align to (0,0), placed-bounds verification, all inside a **suspended history state** — any failure deletes the placed layer and reverts the document in one step. The canvas is deliberately never re-cropped programmatically (reducing canvas size clips pixel data outside the new bounds, and artist layers may extend past the original canvas — that would violate A3).
3. **Honest fallbacks:** layer-capture sources (no canvas position) and pre-context results keep the floating-layer import with a clear explanation; a result whose size disagrees with the plan refuses expansion and falls back with the reason.

Pure expansion math (snapping/plan/validation) is unit-tested: 271 tests (261 → 271), typecheck + build green.

## Photoshop smoke checklist (this is deep host work — please be thorough)

1. **Canvas outpaint happy path:** capture **canvas** → pads e.g. L400/T0/R400/B400 → generate → Import. Canvas grows by exactly the pads; your original artwork is pixel-identical in its region (toggle the new layer's visibility to compare edges); the outpaint layer covers the whole canvas.
2. **Asymmetric + odd pads:** e.g. L130/T77/R0/B33 on a canvas whose width isn't a multiple of 8 — diagnostics should mention the right/bottom snap; alignment must still be exact.
3. **One-side-only pads:** L0/T0/R400/B0 — only the right side grows.
4. **Undo:** after a successful import, a single Ctrl+Z should revert the whole import (one history state: "OpenLayer Outpaint Canvas Expansion").
5. **Resize guard:** generate, then crop/resize the document, then Import → clear refusal naming both sizes, document untouched.
6. **Layer capture:** capture **layer** → generate → Import → floating-layer import with the explanation message.
7. **History:** import an outpaint from History (after another generation) → expansion still exact (uses the saved context, not current UI values).
8. **Failure rollback (if easy to trigger):** any mid-import failure should leave the document exactly as before — no expanded empty canvas, no partial layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)