### PR TITLE
Live Painting v2 steps 1-2: mutual exclusion and Krea2 refine builder

### DIFF
--- a/src/comfy/livePainting.ts
+++ b/src/comfy/livePainting.ts
@@ -1,8 +1,13 @@
-import { ComfyWorkflow } from "./types";
+import { ComfyModelInventory, ComfyWorkflow } from "./types";
 
 export const LIVE_PAINTING_SAVE_NODE_ID = "9";
+export const LIVE_REFINE_SAVE_NODE_ID = "9";
 export const LIVE_PAINTING_STEPS = 5;
 export const LIVE_PAINTING_CFG = 1.5;
+
+const KREA2_REFINE_DIFFUSION_MODEL = "krea2_turbo_fp8_scaled.safetensors";
+const KREA2_REFINE_CLIP_MODEL = "qwen3vl_4b_fp8_scaled.safetensors";
+const KREA2_REFINE_VAE_MODEL = "qwen_image_vae.safetensors";
 
 export type BuildLcmLiveWorkflowOptions = {
   checkpointName: string;
@@ -11,6 +16,15 @@ export type BuildLcmLiveWorkflowOptions = {
   sourceImageName: string;
   seed: number;
   denoise: number;
+};
+
+export type BuildKrea2RefineWorkflowOptions = {
+  prompt: string;
+  sourceImageName: string;
+  seed: number;
+  denoise: number;
+  width?: number;
+  height?: number;
 };
 
 // The live loop needs the fastest dependable local engine. SD 1.5 plus the
@@ -74,6 +88,87 @@ export function buildLcmLiveWorkflow(options: BuildLcmLiveWorkflowOptions): Comf
   };
 }
 
+export function buildKrea2RefineWorkflow(options: BuildKrea2RefineWorkflowOptions): ComfyWorkflow {
+  return {
+    "20": {
+      class_type: "UNETLoader",
+      inputs: {
+        unet_name: KREA2_REFINE_DIFFUSION_MODEL,
+        weight_dtype: "default"
+      }
+    },
+    "21": {
+      class_type: "CLIPLoader",
+      inputs: {
+        clip_name: KREA2_REFINE_CLIP_MODEL,
+        type: "krea2",
+        device: "default"
+      }
+    },
+    "22": {
+      class_type: "VAELoader",
+      inputs: { vae_name: KREA2_REFINE_VAE_MODEL }
+    },
+    "10": {
+      class_type: "LoadImage",
+      inputs: { image: options.sourceImageName }
+    },
+    "11": {
+      class_type: "VAEEncode",
+      inputs: { pixels: ["10", 0], vae: ["22", 0] }
+    },
+    "6": {
+      class_type: "CLIPTextEncode",
+      inputs: { text: options.prompt, clip: ["21", 0] }
+    },
+    "7": {
+      class_type: "CLIPTextEncode",
+      inputs: { text: "", clip: ["21", 0] }
+    },
+    "3": {
+      class_type: "KSampler",
+      inputs: {
+        seed: options.seed,
+        steps: 8,
+        cfg: 1,
+        sampler_name: "euler",
+        scheduler: "simple",
+        denoise: clampRefineDenoise(options.denoise),
+        model: ["20", 0],
+        positive: ["6", 0],
+        negative: ["7", 0],
+        latent_image: ["11", 0]
+      }
+    },
+    "8": {
+      class_type: "VAEDecode",
+      inputs: { samples: ["3", 0], vae: ["22", 0] }
+    },
+    [LIVE_REFINE_SAVE_NODE_ID]: {
+      class_type: "SaveImage",
+      inputs: { filename_prefix: "OpenLayer_LiveRefine", images: ["8", 0] }
+    }
+  };
+}
+
+export function findKrea2RefineGap(inventory: Partial<ComfyModelInventory>): string | null {
+  const missingModels = [
+    inventory.diffusionModels?.includes(KREA2_REFINE_DIFFUSION_MODEL)
+      ? null
+      : `diffusion model ${KREA2_REFINE_DIFFUSION_MODEL}`,
+    inventory.clipModels?.includes(KREA2_REFINE_CLIP_MODEL)
+      ? null
+      : `text encoder ${KREA2_REFINE_CLIP_MODEL}`,
+    inventory.vaeModels?.includes(KREA2_REFINE_VAE_MODEL) ? null : `VAE ${KREA2_REFINE_VAE_MODEL}`
+  ].filter((model): model is string => model !== null);
+
+  if (missingModels.length === 0) {
+    return null;
+  }
+
+  return `Krea-2 refine setup is missing: ${missingModels.join(", ")}.`;
+}
+
 export function findLcmLoraName(loraNames: readonly string[]): string | null {
   const lcmNames = loraNames.filter((name) => /lcm/i.test(name));
 
@@ -92,4 +187,12 @@ export function clampLiveDenoise(value: number) {
   }
 
   return Math.min(0.95, Math.max(0.2, Math.round(value * 100) / 100));
+}
+
+export function clampRefineDenoise(value: number) {
+  if (!Number.isFinite(value)) {
+    return 0.45;
+  }
+
+  return Math.min(0.9, Math.max(0.2, Math.round(value * 100) / 100));
 }

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -1003,7 +1003,20 @@ export function renderApp(rootElement: HTMLElement) {
     }
   }
 
+  function blockRegularGenerationDuringLivePainting(reportStatus: (message: string) => void) {
+    if (!livePaintingSession?.isRunning()) {
+      return false;
+    }
+
+    reportStatus("Stop the live session before generating.");
+    return true;
+  }
+
   async function handleGenerate() {
+    if (blockRegularGenerationDuringLivePainting((message) => setStatus(elements, message, "error"))) {
+      return;
+    }
+
     setDiagnostics(elements, `Generate pressed at ${new Date().toLocaleTimeString()}.`);
 
     if (!elements.prompt.value.trim()) {
@@ -1384,6 +1397,10 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleGenerateImg2Img() {
+    if (blockRegularGenerationDuringLivePainting((message) => setImageStatus(elements, message, "error"))) {
+      return;
+    }
+
     setImageDiagnostics(elements, `Image to Image generate pressed at ${new Date().toLocaleTimeString()}.`);
 
     if (!imageSource) {
@@ -1654,6 +1671,10 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleGenerateUpscale() {
+    if (blockRegularGenerationDuringLivePainting((message) => setUpscaleStatus(elements, message, "error"))) {
+      return;
+    }
+
     setUpscaleDiagnostics(elements, `Upscale generate pressed at ${new Date().toLocaleTimeString()}.`);
 
     if (!upscaleSource) {
@@ -1888,6 +1909,10 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleGenerateOutpaint() {
+    if (blockRegularGenerationDuringLivePainting((message) => setOutpaintStatus(elements, message, "error"))) {
+      return;
+    }
+
     setOutpaintDiagnostics(elements, `Outpaint generate pressed at ${new Date().toLocaleTimeString()}.`);
 
     if (!outpaintSource) {
@@ -2226,6 +2251,10 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleGenerateSketch() {
+    if (blockRegularGenerationDuringLivePainting((message) => setSketchStatus(elements, message, "error"))) {
+      return;
+    }
+
     setSketchDiagnostics(elements, `Sketch to Image generate pressed at ${new Date().toLocaleTimeString()}.`);
 
     if (!sketchSource) {
@@ -2513,6 +2542,10 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleGenerateInpaint() {
+    if (blockRegularGenerationDuringLivePainting((message) => setInpaintStatus(elements, message, "error"))) {
+      return;
+    }
+
     setInpaintDiagnostics(elements, `Inpaint generate pressed at ${new Date().toLocaleTimeString()}.`);
 
     const presetId = readSelectValue(elements.inpaintWorkflow, DEFAULT_INPAINT_WORKFLOW);
@@ -2974,6 +3007,10 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleGeneratePromptFromLayer() {
+    if (blockRegularGenerationDuringLivePainting((message) => setPromptLayerStatus(elements, message, "error"))) {
+      return;
+    }
+
     if (!promptLayerSource) {
       setPromptLayerStatus(elements, "Source required.", "error");
       setPromptLayerError(elements, "Capture an active layer or canvas before generating prompt text.");
@@ -3083,6 +3120,11 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleStartLivePainting() {
+    if (isBusy) {
+      setLiveStatus("Finish the current generation before starting a live session.");
+      return;
+    }
+
     if (livePaintingSession?.isRunning()) {
       setLiveStatus("A live session is already running.");
       return;

--- a/src/ui/livePaintingSession.ts
+++ b/src/ui/livePaintingSession.ts
@@ -56,6 +56,7 @@ export class LivePaintingSession {
   private dirty = false;
   private cycles = 0;
   private lastEventAt = 0;
+  private currentPromptId: string | null = null;
 
   constructor(options: LivePaintingOptions, callbacks: LivePaintingCallbacks) {
     this.options = options;
@@ -107,6 +108,7 @@ export class LivePaintingSession {
     }
 
     this.running = false;
+    this.cancelCurrentPrompt();
     this.removeStrokeListeners();
     this.callbacks.onStopped(reason);
   }
@@ -145,6 +147,10 @@ export class LivePaintingSession {
     try {
       await this.runCycle();
     } catch (caughtError) {
+      if (!this.running) {
+        this.cancelCurrentPrompt();
+      }
+
       this.callbacks.onStatus(`Live cycle failed: ${getErrorMessage(caughtError)}`);
     }
 
@@ -177,32 +183,63 @@ export class LivePaintingSession {
     });
 
     const promptId = await this.client.submitPrompt(workflow);
-    const history = await this.client.pollUntilComplete(promptId, {
-      intervalMs: 250,
-      timeoutMs: 120000,
-      isCancelled: () => !this.running
-    });
-    const result = await this.client.retrieveFirstOutputImage(promptId, history, {
-      preferredNodeId: LIVE_PAINTING_SAVE_NODE_ID
-    });
-    const finishedAt = Date.now();
+    this.currentPromptId = promptId;
 
-    if (!this.running) {
-      return;
+    try {
+      if (!this.running) {
+        this.cancelPrompt(promptId);
+        return;
+      }
+
+      const history = await this.client.pollUntilComplete(promptId, {
+        intervalMs: 250,
+        timeoutMs: 120000,
+        isCancelled: () => !this.running
+      });
+      const result = await this.client.retrieveFirstOutputImage(promptId, history, {
+        preferredNodeId: LIVE_PAINTING_SAVE_NODE_ID
+      });
+      const finishedAt = Date.now();
+
+      if (!this.running) {
+        return;
+      }
+
+      this.cycles += 1;
+      this.callbacks.onPreviewBlob(result.blob, capture.originatingDocument);
+      this.callbacks.onStatus(`Live preview updated (cycle ${this.cycles}).`);
+      this.callbacks.onTimings(
+        [
+          `Cycle ${this.cycles}:`,
+          `capture ${capturedAt - cycleStart}ms (${capture.mode}, ${capture.width}x${capture.height})`,
+          `upload ${uploadedAt - capturedAt}ms`,
+          `generate ${finishedAt - uploadedAt}ms`,
+          `total ${((finishedAt - cycleStart) / 1000).toFixed(2)}s`
+        ].join(" | ")
+      );
+    } catch (caughtError) {
+      if (!this.running) {
+        this.cancelPrompt(promptId);
+      }
+
+      throw caughtError;
+    } finally {
+      if (this.currentPromptId === promptId) {
+        this.currentPromptId = null;
+      }
     }
+  }
 
-    this.cycles += 1;
-    this.callbacks.onPreviewBlob(result.blob, capture.originatingDocument);
-    this.callbacks.onStatus(`Live preview updated (cycle ${this.cycles}).`);
-    this.callbacks.onTimings(
-      [
-        `Cycle ${this.cycles}:`,
-        `capture ${capturedAt - cycleStart}ms (${capture.mode}, ${capture.width}x${capture.height})`,
-        `upload ${uploadedAt - capturedAt}ms`,
-        `generate ${finishedAt - uploadedAt}ms`,
-        `total ${((finishedAt - cycleStart) / 1000).toFixed(2)}s`
-      ].join(" | ")
-    );
+  private cancelCurrentPrompt() {
+    if (this.currentPromptId) {
+      this.cancelPrompt(this.currentPromptId);
+    }
+  }
+
+  private cancelPrompt(promptId: string) {
+    void this.client.cancelPrompt(promptId).catch(() => {
+      // Stopping stays synchronous and best-effort even if ComfyUI is unavailable.
+    });
   }
 
   private async registerStrokeListeners() {

--- a/tests/comfy/livePainting.test.ts
+++ b/tests/comfy/livePainting.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildKrea2RefineWorkflow,
   buildLcmLiveWorkflow,
   clampLiveDenoise,
+  clampRefineDenoise,
+  findKrea2RefineGap,
   findLcmLoraName,
   LIVE_PAINTING_CFG,
   LIVE_PAINTING_SAVE_NODE_ID,
-  LIVE_PAINTING_STEPS
+  LIVE_PAINTING_STEPS,
+  LIVE_REFINE_SAVE_NODE_ID
 } from "../../src/comfy/livePainting";
 
 describe("livePainting", () => {
@@ -68,5 +72,72 @@ describe("livePainting", () => {
     expect(clampLiveDenoise(0.05)).toBe(0.2);
     expect(clampLiveDenoise(1.4)).toBe(0.95);
     expect(clampLiveDenoise(Number.NaN)).toBe(0.6);
+  });
+
+  it("builds the Krea2 refine graph with the expected image pipeline wiring", () => {
+    const workflow = buildKrea2RefineWorkflow({
+      prompt: "a luminous forest city",
+      sourceImageName: "openlayer-refine-source.png",
+      seed: 9876,
+      denoise: 0.45
+    });
+
+    expect(workflow["11"].inputs.pixels).toEqual(["10", 0]);
+    expect(workflow["11"].inputs.vae).toEqual(["22", 0]);
+    expect(workflow["3"].inputs.latent_image).toEqual(["11", 0]);
+    expect(workflow["8"].inputs.samples).toEqual(["3", 0]);
+    expect(workflow[LIVE_REFINE_SAVE_NODE_ID].inputs.images).toEqual(["8", 0]);
+  });
+
+  it("injects Krea2 refine prompt, seed, denoise, and source image inputs", () => {
+    const workflow = buildKrea2RefineWorkflow({
+      prompt: "a luminous forest city",
+      sourceImageName: "openlayer-refine-source.png",
+      seed: 9876,
+      denoise: 0.45
+    });
+
+    expect(workflow["10"].inputs.image).toBe("openlayer-refine-source.png");
+    expect(workflow["6"].inputs.text).toBe("a luminous forest city");
+    expect(workflow["7"].inputs.text).toBe("");
+    expect(workflow["3"].inputs.seed).toBe(9876);
+    expect(workflow["3"].inputs.denoise).toBe(0.45);
+    expect(workflow[LIVE_REFINE_SAVE_NODE_ID].inputs.filename_prefix).toBe("OpenLayer_LiveRefine");
+  });
+
+  it("clamps Krea2 refine denoise into the supported range", () => {
+    expect(clampRefineDenoise(0.45)).toBe(0.45);
+    expect(clampRefineDenoise(0.05)).toBe(0.2);
+    expect(clampRefineDenoise(1.4)).toBe(0.9);
+    expect(clampRefineDenoise(Number.NaN)).toBe(0.45);
+
+    expect(
+      buildKrea2RefineWorkflow({
+        prompt: "test",
+        sourceImageName: "source.png",
+        seed: 1,
+        denoise: 2
+      })["3"].inputs.denoise
+    ).toBe(0.9);
+  });
+
+  it("accepts a complete Krea2 refine model inventory", () => {
+    expect(
+      findKrea2RefineGap({
+        diffusionModels: ["krea2_turbo_fp8_scaled.safetensors"],
+        clipModels: ["qwen3vl_4b_fp8_scaled.safetensors"],
+        vaeModels: ["qwen_image_vae.safetensors"]
+      })
+    ).toBeNull();
+  });
+
+  it("names a missing Krea2 refine model", () => {
+    const gap = findKrea2RefineGap({
+      diffusionModels: ["krea2_turbo_fp8_scaled.safetensors"],
+      clipModels: [],
+      vaeModels: ["qwen_image_vae.safetensors"]
+    });
+
+    expect(gap).toContain("qwen3vl_4b_fp8_scaled.safetensors");
   });
 });


### PR DESCRIPTION
## Summary

Implemented by Codex from `docs/LIVE_PAINTING_V2.md` (steps 1–2), reviewed by Claude. Cleanest delegation run yet — no git incidents, exact spec compliance, and it correctly mirrored the real `img2img-krea2-turbo.json` model names (qwen3vl CLIP `type: krea2`, qwen VAE) beyond what the brief spelled out.

- **Step 1 — mutual exclusion (spec §3.3):** all 7 generate handlers refuse while a live session runs ("Stop the live session before generating."); starting a live session refuses while any tool run is busy. Stopping a session now interrupts its in-flight ComfyUI prompt (fire-and-forget, never throws), including the submit-finishes-after-stop race — no more orphan server jobs.
- **Step 2 — Krea2 refine tier foundation (spec §3.5):** `buildKrea2RefineWorkflow` (exact graph of the krea2 img2img preset, euler/simple, 8 steps, cfg 1, clamped denoise), `LIVE_REFINE_SAVE_NODE_ID`, and `findKrea2RefineGap` naming any missing server model. Pure + unit-tested; UI wiring is step 3.

## Test plan

- [x] typecheck / 276 tests (271 → 276) / build — all green
- [x] **Photoshop:** start a live session → try Generate on any tool → blocked with message; stop session → Generate works. Start a generation → try starting a live session → blocked. Stop a live session mid-cycle → ComfyUI queue shows the job interrupted (no orphan completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code), implementation by Codex