### PR TITLE
Live Painting v2 step 3: session state machine with the refine tier

### DIFF
--- a/src/ui/tools/livePainting.ts
+++ b/src/ui/tools/livePainting.ts
@@ -1,0 +1,655 @@
+import {
+  buildKrea2RefineWorkflow,
+  buildLcmLiveWorkflow,
+  clampLiveDenoise,
+  clampRefineDenoise,
+  findKrea2RefineGap,
+  findLcmLoraName,
+  LIVE_PAINTING_SAVE_NODE_ID,
+  LIVE_REFINE_SAVE_NODE_ID
+} from "../../comfy/livePainting";
+import type { ComfyHistoryItem, ComfyModelInventory, ComfyWorkflow } from "../../comfy/types";
+import type { PhotoshopDocumentIdentity } from "../../photoshop/documentContext";
+import type { LiveCaptureResult } from "../../photoshop/livePaintingCapture";
+import { createOpenLayerError, getErrorMessage } from "../../utils/errors";
+
+export type LivePaintingState =
+  | "idle"
+  | "listening"
+  | "pending"
+  | "refining"
+  | "refined"
+  | "stopped";
+
+export type LivePaintingV2Callbacks = {
+  onStatus: (message: string) => void;
+  onTimings: (message: string) => void;
+  onPreviewBlob: (blob: Blob, originatingDocument: PhotoshopDocumentIdentity) => void;
+  onRefineResult: (blob: Blob, originatingDocument: PhotoshopDocumentIdentity) => void;
+  onStateChanged: (state: LivePaintingState) => void;
+  onStopped: (reason: string) => void;
+};
+
+export type LivePaintingV2Options = {
+  checkpointName: string;
+  prompt: string;
+  denoise: number;
+  maxDimension?: number;
+  autoRefineOnPause?: boolean;
+  pauseSeconds?: number;
+  refineMaxDimension?: number;
+  refineDenoise?: number;
+};
+
+export type LivePaintingClient = {
+  checkOnline: () => Promise<void>;
+  getLoraNames: () => Promise<string[]>;
+  getModelInventory: () => Promise<ComfyModelInventory>;
+  uploadImage: (blob: Blob, fileName?: string) => Promise<string>;
+  submitPrompt: (workflow: ComfyWorkflow) => Promise<string>;
+  pollUntilComplete: (
+    promptId: string,
+    options: {
+      intervalMs?: number;
+      timeoutMs?: number;
+      isCancelled?: () => boolean;
+    }
+  ) => Promise<ComfyHistoryItem>;
+  retrieveFirstOutputImage: (
+    promptId: string,
+    history: ComfyHistoryItem,
+    options: { preferredNodeId?: string }
+  ) => Promise<{ blob: Blob }>;
+  cancelPrompt: (promptId?: string) => Promise<unknown>;
+};
+
+export type PhotoshopActionModule = {
+  addNotificationListener: (
+    events: readonly string[] | readonly { event: string }[],
+    handler: (eventName: string, descriptor: unknown) => void
+  ) => Promise<void> | void;
+  removeNotificationListener: (
+    events: readonly string[] | readonly { event: string }[],
+    handler: (eventName: string, descriptor: unknown) => void
+  ) => Promise<void> | void;
+};
+
+export type LivePaintingTimers = {
+  setTimeout: (handler: () => void, delayMs: number) => unknown;
+  clearTimeout: (timer: unknown) => void;
+};
+
+export type LivePaintingV2Dependencies = {
+  client: LivePaintingClient;
+  capture: (maxDimension: number) => Promise<LiveCaptureResult>;
+  actionModule?: PhotoshopActionModule;
+  timers?: LivePaintingTimers;
+};
+
+const STROKE_EVENT_CANDIDATES = [
+  "historyStateChanged",
+  "paint",
+  "set",
+  "move",
+  "toolModalStateChanged"
+];
+
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+type JobKind = "live" | "refine";
+
+export class LivePaintingSessionV2 {
+  private readonly options: LivePaintingV2Options;
+  private readonly callbacks: LivePaintingV2Callbacks;
+  private readonly client: LivePaintingClient;
+  private readonly capture: (maxDimension: number) => Promise<LiveCaptureResult>;
+  private readonly actionModule: PhotoshopActionModule;
+  private readonly timers: LivePaintingTimers;
+  private readonly seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+  private readonly cancelledPromptIds = new Set<string>();
+  private readonly notificationHandler = (eventName: string) => {
+    this.handleStrokeEvent(eventName);
+  };
+
+  private state: LivePaintingState = "idle";
+  private loraName = "";
+  private refineGap: string | null = null;
+  private registeredEvents: string[] = [];
+  private dirty = false;
+  private activeJob: JobKind | null = null;
+  private refineRequested = false;
+  private refineGeneration = 0;
+  private liveCycles = 0;
+  private refineCycles = 0;
+  private consecutiveFailures = 0;
+  private lastEventAt = 0;
+  private currentPromptId: string | null = null;
+  private pauseTimer: unknown = null;
+
+  constructor(
+    options: LivePaintingV2Options,
+    callbacks: LivePaintingV2Callbacks,
+    dependencies: LivePaintingV2Dependencies
+  ) {
+    this.options = options;
+    this.callbacks = callbacks;
+    this.client = dependencies.client;
+    this.capture = dependencies.capture;
+    this.actionModule = dependencies.actionModule
+      ?? (require("photoshop") as { action: PhotoshopActionModule }).action;
+    this.timers = dependencies.timers ?? {
+      setTimeout: (handler, delayMs) => window.setTimeout(handler, delayMs),
+      clearTimeout: (timer) => window.clearTimeout(timer as number)
+    };
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  isRunning() {
+    return this.state !== "idle" && this.state !== "stopped";
+  }
+
+  async start() {
+    if (this.state !== "idle") {
+      throw new Error("This Live Painting session has already been started.");
+    }
+
+    this.callbacks.onStatus("Checking ComfyUI and the LCM LoRA...");
+    await this.client.checkOnline();
+
+    if (this.hasStopped()) {
+      return;
+    }
+
+    const loraNames = await this.client.getLoraNames();
+    const lcmLoraName = findLcmLoraName(loraNames);
+
+    if (!lcmLoraName) {
+      throw createOpenLayerError(
+        "COMFY_SETUP_MISSING",
+        "Live Painting needs an SD 1.5 LCM LoRA in ComfyUI.",
+        "Install lcm-lora-sdv1-5 (pytorch_lora_weights.safetensors) in ComfyUI models/loras, then start the session again."
+      );
+    }
+
+    this.loraName = lcmLoraName;
+
+    try {
+      await this.checkRefineAvailability();
+    } catch (caughtError) {
+      this.refineGap = `Could not check Krea-2 refine availability: ${getErrorMessage(caughtError)}`;
+    }
+
+    if (this.hasStopped()) {
+      return;
+    }
+
+    await this.registerStrokeListeners();
+
+    if (this.hasStopped()) {
+      this.removeStrokeListeners();
+      return;
+    }
+
+    if (this.registeredEvents.length === 0) {
+      throw createOpenLayerError(
+        "PHOTOSHOP_EXPORT_FAILED",
+        "Photoshop did not accept any Live Painting stroke listeners.",
+        `Tried notification events: ${STROKE_EVENT_CANDIDATES.join(", ")}.`
+      );
+    }
+
+    this.setState("listening");
+    this.callbacks.onStatus(
+      `Live session started with ${this.loraName}. Listening for: ${this.registeredEvents.join(", ")}. Paint a stroke...`
+    );
+    this.markDirty();
+  }
+
+  stop(reason = "Live session stopped.") {
+    if (this.state === "stopped") {
+      return;
+    }
+
+    this.refineGeneration += 1;
+    this.refineRequested = false;
+    this.dirty = false;
+    this.clearPauseTimer();
+    this.cancelCurrentPrompt();
+    this.removeStrokeListeners();
+    this.setState("stopped");
+    this.callbacks.onStopped(reason);
+  }
+
+  async checkRefineAvailability() {
+    const inventory = await this.client.getModelInventory();
+    this.refineGap = findKrea2RefineGap(inventory);
+    return this.refineGap;
+  }
+
+  refineNow() {
+    if (!this.isRunning()) {
+      return;
+    }
+
+    if (this.refineGap) {
+      this.callbacks.onStatus(this.refineGap);
+      return;
+    }
+
+    this.clearPauseTimer();
+    this.refineGeneration += 1;
+    this.refineRequested = true;
+
+    if (this.activeJob === "refine") {
+      this.callbacks.onStatus("Restarting Krea-2 refine with the latest canvas...");
+      this.cancelCurrentPrompt();
+      return;
+    }
+
+    this.callbacks.onStatus("Krea-2 refine requested...");
+    void this.pump();
+  }
+
+  private setState(nextState: LivePaintingState) {
+    if (this.state === nextState) {
+      return;
+    }
+
+    this.state = nextState;
+    this.callbacks.onStateChanged(nextState);
+  }
+
+  private hasStopped() {
+    return this.state === "stopped";
+  }
+
+  private handleStrokeEvent(eventName: string) {
+    if (!this.isRunning()) {
+      return;
+    }
+
+    const now = Date.now();
+    const sinceLast = this.lastEventAt ? now - this.lastEventAt : 0;
+    this.lastEventAt = now;
+    this.callbacks.onStatus(
+      `Photoshop event "${eventName}"${sinceLast ? ` (+${sinceLast}ms)` : ""} — syncing...`
+    );
+    this.armPauseTimer();
+    this.markDirty();
+  }
+
+  private markDirty() {
+    if (!this.isRunning()) {
+      return;
+    }
+
+    this.dirty = true;
+
+    if (!this.activeJob && !this.refineRequested) {
+      this.setState("pending");
+    }
+
+    void this.pump();
+  }
+
+  private async pump() {
+    if (this.activeJob || !this.isRunning()) {
+      return;
+    }
+
+    if (this.refineRequested && this.refineGap) {
+      this.refineRequested = false;
+      this.callbacks.onStatus(this.refineGap);
+    }
+
+    let jobKind: JobKind;
+    let refineGeneration = this.refineGeneration;
+
+    if (this.refineRequested) {
+      jobKind = "refine";
+      this.refineRequested = false;
+      // The refine capture consumes all canvas changes made before it starts.
+      // A stroke after this point sets dirty again and queues the next live job.
+      this.dirty = false;
+      refineGeneration = this.refineGeneration;
+      this.setState("refining");
+    } else if (this.dirty) {
+      jobKind = "live";
+      this.dirty = false;
+      this.setState("pending");
+    } else {
+      if (this.state !== "refined") {
+        this.setState("listening");
+      }
+      return;
+    }
+
+    this.activeJob = jobKind;
+
+    try {
+      const completed = jobKind === "live"
+        ? await this.runLiveCycle()
+        : await this.runRefineCycle(refineGeneration);
+
+      if (completed) {
+        this.consecutiveFailures = 0;
+      }
+    } catch (caughtError) {
+      if (this.isRunning()) {
+        this.handleCycleFailure(jobKind, caughtError);
+      }
+    } finally {
+      this.activeJob = null;
+    }
+
+    if (!this.isRunning()) {
+      return;
+    }
+
+    if (this.refineRequested || this.dirty) {
+      void this.pump();
+    } else if (this.state !== "refined") {
+      this.setState("listening");
+    }
+  }
+
+  private async runLiveCycle() {
+    const cycleStart = Date.now();
+    const capture = await this.capture(this.options.maxDimension ?? 512);
+    const capturedAt = Date.now();
+
+    if (!this.isRunning()) {
+      return false;
+    }
+
+    const sourceImageName = await this.client.uploadImage(
+      capture.blob,
+      `openlayer-live-${this.seed}.png`
+    );
+    const uploadedAt = Date.now();
+
+    if (!this.isRunning()) {
+      return false;
+    }
+
+    const workflow = buildLcmLiveWorkflow({
+      checkpointName: this.options.checkpointName,
+      loraName: this.loraName,
+      prompt: this.options.prompt,
+      sourceImageName,
+      seed: this.seed,
+      denoise: clampLiveDenoise(this.options.denoise)
+    });
+    const result = await this.submitAndRetrieve(
+      workflow,
+      LIVE_PAINTING_SAVE_NODE_ID,
+      250,
+      120000,
+      () => !this.isRunning()
+    );
+    const finishedAt = Date.now();
+
+    if (!result || !this.isRunning()) {
+      return false;
+    }
+
+    this.liveCycles += 1;
+    this.callbacks.onPreviewBlob(result.blob, capture.originatingDocument);
+    this.callbacks.onStatus(`Live preview updated (cycle ${this.liveCycles}).`);
+    this.callbacks.onTimings(
+      [
+        `Cycle ${this.liveCycles}:`,
+        `capture ${capturedAt - cycleStart}ms (${capture.mode}, ${capture.width}x${capture.height})`,
+        `upload ${uploadedAt - capturedAt}ms`,
+        `generate ${finishedAt - uploadedAt}ms`,
+        `total ${((finishedAt - cycleStart) / 1000).toFixed(2)}s`
+      ].join(" | ")
+    );
+    this.setState("listening");
+    return true;
+  }
+
+  private async runRefineCycle(refineGeneration: number) {
+    const isCancelled = () => !this.isRunning() || refineGeneration !== this.refineGeneration;
+    const cycleStart = Date.now();
+    const capture = await this.capture(this.options.refineMaxDimension ?? 1024);
+    const capturedAt = Date.now();
+
+    if (isCancelled()) {
+      return false;
+    }
+
+    const sourceImageName = await this.client.uploadImage(
+      capture.blob,
+      `openlayer-refine-${this.seed}.png`
+    );
+    const uploadedAt = Date.now();
+
+    if (isCancelled()) {
+      return false;
+    }
+
+    const workflow = buildKrea2RefineWorkflow({
+      prompt: this.options.prompt,
+      sourceImageName,
+      seed: this.seed,
+      denoise: clampRefineDenoise(this.options.refineDenoise ?? 0.45),
+      width: capture.width,
+      height: capture.height
+    });
+
+    let result: { blob: Blob } | null;
+
+    try {
+      result = await this.submitAndRetrieve(
+        workflow,
+        LIVE_REFINE_SAVE_NODE_ID,
+        500,
+        180000,
+        isCancelled
+      );
+    } catch (caughtError) {
+      if (isCancelled()) {
+        return false;
+      }
+
+      throw caughtError;
+    }
+
+    const finishedAt = Date.now();
+
+    if (!result || isCancelled()) {
+      return false;
+    }
+
+    this.refineCycles += 1;
+    this.callbacks.onRefineResult(result.blob, capture.originatingDocument);
+    this.callbacks.onStatus(`Refine result updated (cycle ${this.refineCycles}).`);
+    this.callbacks.onTimings(
+      [
+        `Refine ${this.refineCycles}:`,
+        `capture ${capturedAt - cycleStart}ms (${capture.mode}, ${capture.width}x${capture.height})`,
+        `upload ${uploadedAt - capturedAt}ms`,
+        `generate ${finishedAt - uploadedAt}ms`,
+        `total ${((finishedAt - cycleStart) / 1000).toFixed(2)}s`
+      ].join(" | ")
+    );
+    this.setState("refined");
+    return true;
+  }
+
+  private async submitAndRetrieve(
+    workflow: ComfyWorkflow,
+    preferredNodeId: string,
+    intervalMs: number,
+    timeoutMs: number,
+    isCancelled: () => boolean
+  ): Promise<{ blob: Blob } | null> {
+    const promptId = await this.client.submitPrompt(workflow);
+
+    if (isCancelled()) {
+      this.cancelPrompt(promptId);
+      return null;
+    }
+
+    this.currentPromptId = promptId;
+
+    try {
+      const history = await this.client.pollUntilComplete(promptId, {
+        intervalMs,
+        timeoutMs,
+        isCancelled
+      });
+
+      if (isCancelled()) {
+        this.cancelPrompt(promptId);
+        return null;
+      }
+
+      const result = await this.client.retrieveFirstOutputImage(promptId, history, {
+        preferredNodeId
+      });
+
+      if (isCancelled()) {
+        this.cancelPrompt(promptId);
+        return null;
+      }
+
+      return result;
+    } catch (caughtError) {
+      if (isCancelled()) {
+        this.cancelPrompt(promptId);
+        return null;
+      }
+
+      throw caughtError;
+    } finally {
+      if (this.currentPromptId === promptId) {
+        this.currentPromptId = null;
+      }
+    }
+  }
+
+  private handleCycleFailure(jobKind: JobKind, caughtError: unknown) {
+    this.consecutiveFailures += 1;
+    const label = jobKind === "live" ? "Live" : "Refine";
+    const errorMessage = getErrorMessage(caughtError);
+    this.callbacks.onStatus(
+      `${label} cycle failed (${this.consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES} consecutive): ${errorMessage}`
+    );
+
+    if (this.consecutiveFailures < MAX_CONSECUTIVE_FAILURES) {
+      return;
+    }
+
+    const reason =
+      `Live Painting stopped after ${MAX_CONSECUTIVE_FAILURES} consecutive cycle failures. `
+      + `Last ${label.toLowerCase()} failure: ${errorMessage}`;
+    this.callbacks.onStatus(reason);
+    this.stop(reason);
+  }
+
+  private armPauseTimer() {
+    this.clearPauseTimer();
+    const pauseSeconds = Number.isFinite(this.options.pauseSeconds)
+      ? Math.max(0, this.options.pauseSeconds ?? 4)
+      : 4;
+
+    this.pauseTimer = this.timers.setTimeout(() => {
+      this.pauseTimer = null;
+
+      if (
+        this.options.autoRefineOnPause === true
+        && this.state === "listening"
+        && !this.dirty
+      ) {
+        this.refineNow();
+      }
+    }, pauseSeconds * 1000);
+  }
+
+  private clearPauseTimer() {
+    if (this.pauseTimer === null) {
+      return;
+    }
+
+    this.timers.clearTimeout(this.pauseTimer);
+    this.pauseTimer = null;
+  }
+
+  private cancelCurrentPrompt() {
+    if (this.currentPromptId) {
+      this.cancelPrompt(this.currentPromptId);
+    }
+  }
+
+  private cancelPrompt(promptId: string) {
+    if (this.cancelledPromptIds.has(promptId)) {
+      return;
+    }
+
+    this.cancelledPromptIds.add(promptId);
+    void this.client.cancelPrompt(promptId).catch(() => {
+      // Stop and refine restart remain synchronous and best-effort if ComfyUI is unavailable.
+    });
+  }
+
+  private async registerStrokeListeners() {
+    for (const eventName of STROKE_EVENT_CANDIDATES) {
+      if (this.state === "stopped") {
+        return;
+      }
+
+      try {
+        await this.actionModule.addNotificationListener([eventName], this.notificationHandler);
+        this.registeredEvents.push(eventName);
+      } catch {
+        try {
+          await this.actionModule.addNotificationListener([{ event: eventName }], this.notificationHandler);
+          this.registeredEvents.push(eventName);
+        } catch {
+          // Unsupported Photoshop notification candidates are skipped.
+        }
+      }
+    }
+  }
+
+  private removeStrokeListeners() {
+    for (const eventName of this.registeredEvents) {
+      this.removeStrokeListener(eventName);
+    }
+
+    this.registeredEvents = [];
+  }
+
+  private removeStrokeListener(eventName: string) {
+    try {
+      const removal = this.actionModule.removeNotificationListener(
+        [eventName],
+        this.notificationHandler
+      );
+      void Promise.resolve(removal).catch(() => {
+        this.removeStrokeListenerWithDescriptor(eventName);
+      });
+    } catch {
+      this.removeStrokeListenerWithDescriptor(eventName);
+    }
+  }
+
+  private removeStrokeListenerWithDescriptor(eventName: string) {
+    try {
+      const removal = this.actionModule.removeNotificationListener(
+        [{ event: eventName }],
+        this.notificationHandler
+      );
+      void Promise.resolve(removal).catch(() => {
+        // Listener cleanup is best-effort during synchronous teardown.
+      });
+    } catch {
+      // Listener cleanup is best-effort during synchronous teardown.
+    }
+  }
+}

--- a/tests/ui/livePaintingV2.test.ts
+++ b/tests/ui/livePaintingV2.test.ts
@@ -1,0 +1,380 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPhotoshopDocumentIdentity } from "../../src/photoshop/documentContext";
+import {
+  LivePaintingSessionV2,
+  type LivePaintingV2Callbacks,
+  type LivePaintingV2Options,
+  type PhotoshopActionModule
+} from "../../src/ui/tools/livePainting";
+
+const origin = createPhotoshopDocumentIdentity(7, "Live.psd");
+const completeHistory = { outputs: {} };
+
+const completeInventory = {
+  checkpoints: [],
+  diffusionModels: ["krea2_turbo_fp8_scaled.safetensors"],
+  clipModels: ["qwen3vl_4b_fp8_scaled.safetensors"],
+  vaeModels: ["qwen_image_vae.safetensors"],
+  controlNetModels: [],
+  visionLanguageModels: [],
+  upscaleModels: [],
+  missingSources: []
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function createFakeClient(overrides: Record<string, unknown> = {}) {
+  let nextPrompt = 0;
+  const client = {
+    checkOnline: vi.fn(async () => undefined),
+    getLoraNames: vi.fn(async () => ["lcm/SD1.5/pytorch_lora_weights.safetensors"]),
+    getModelInventory: vi.fn(async () => completeInventory),
+    uploadImage: vi.fn(async (_blob: Blob, fileName?: string) => fileName ?? "source.png"),
+    submitPrompt: vi.fn(async () => `prompt-${++nextPrompt}`),
+    pollUntilComplete: vi.fn(async () => completeHistory),
+    retrieveFirstOutputImage: vi.fn(async () => ({ blob: new Blob(["result"], { type: "image/png" }) })),
+    cancelPrompt: vi.fn(async () => "interrupted" as const)
+  };
+
+  return Object.assign(client, overrides);
+}
+
+function createFakeActionModule() {
+  const handlers = new Map<string, (eventName: string, descriptor: unknown) => void>();
+  const readEventName = (events: readonly string[] | readonly { event: string }[]) => {
+    const first = events[0];
+    return typeof first === "string" ? first : first.event;
+  };
+  const actionModule: PhotoshopActionModule = {
+    addNotificationListener: vi.fn(async (events, handler) => {
+      handlers.set(readEventName(events), handler);
+    }),
+    removeNotificationListener: vi.fn(async (events) => {
+      handlers.delete(readEventName(events));
+    })
+  };
+
+  return {
+    actionModule,
+    trigger(eventName: string) {
+      handlers.get(eventName)?.(eventName, {});
+    }
+  };
+}
+
+function createCallbacks(): LivePaintingV2Callbacks {
+  return {
+    onStatus: vi.fn(),
+    onTimings: vi.fn(),
+    onPreviewBlob: vi.fn(),
+    onRefineResult: vi.fn(),
+    onStateChanged: vi.fn(),
+    onStopped: vi.fn()
+  };
+}
+
+function createHarness(
+  options: Partial<LivePaintingV2Options> = {},
+  clientOverrides: Record<string, unknown> = {}
+) {
+  const client = createFakeClient(clientOverrides);
+  const callbacks = createCallbacks();
+  const action = createFakeActionModule();
+  const capture = vi.fn(async (maxDimension: number) => ({
+    blob: new Blob([`capture-${maxDimension}`], { type: "image/png" }),
+    width: maxDimension,
+    height: Math.max(64, Math.round(maxDimension / 2)),
+    mode: "non-modal-scaled" as const,
+    captureMs: 1,
+    originatingDocument: origin
+  }));
+  const session = new LivePaintingSessionV2(
+    {
+      checkpointName: "sd15.safetensors",
+      prompt: "a painted harbor",
+      denoise: 0.6,
+      ...options
+    },
+    callbacks,
+    {
+      client,
+      capture,
+      actionModule: action.actionModule,
+      timers: {
+        setTimeout: (handler, delayMs) => globalThis.setTimeout(handler, delayMs),
+        clearTimeout: (timer) => globalThis.clearTimeout(timer as ReturnType<typeof setTimeout>)
+      }
+    }
+  );
+
+  return { session, client, callbacks, action, capture };
+}
+
+async function startAndWaitForLive(harness: ReturnType<typeof createHarness>) {
+  await harness.session.start();
+  await vi.waitFor(() => {
+    expect(harness.callbacks.onPreviewBlob).toHaveBeenCalledTimes(1);
+  });
+}
+
+async function flushAsyncWork(turns = 20) {
+  for (let index = 0; index < turns; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("LivePaintingSessionV2", () => {
+  it("publishes a live preview with its originating document and per-cycle timings", async () => {
+    const harness = createHarness();
+
+    await startAndWaitForLive(harness);
+
+    expect(harness.session.getState()).toBe("listening");
+    expect(harness.capture).toHaveBeenCalledWith(512);
+    expect(harness.callbacks.onPreviewBlob).toHaveBeenCalledWith(expect.any(Blob), origin);
+    expect(harness.callbacks.onTimings).toHaveBeenCalledWith(
+      expect.stringMatching(/^Cycle 1: \| capture \d+ms \(non-modal-scaled, 512x256\) \| upload \d+ms \| generate \d+ms \| total \d+\.\d{2}s$/)
+    );
+    expect(harness.client.pollUntilComplete.mock.calls[0][1]).toMatchObject({
+      intervalMs: 250,
+      timeoutMs: 120000
+    });
+    expect(harness.client.submitPrompt.mock.calls[0][0]["3"].inputs).toMatchObject({
+      denoise: 0.6,
+      sampler_name: "lcm"
+    });
+
+    harness.session.stop();
+  });
+
+  it("drops three rapid strokes into at most one follow-up live cycle", async () => {
+    const firstPoll = createDeferred<typeof completeHistory>();
+    const secondPoll = createDeferred<typeof completeHistory>();
+    const pollUntilComplete = vi.fn()
+      .mockImplementationOnce(() => firstPoll.promise)
+      .mockImplementationOnce(() => secondPoll.promise);
+    const harness = createHarness({}, { pollUntilComplete });
+
+    await harness.session.start();
+    await vi.waitFor(() => expect(harness.client.submitPrompt).toHaveBeenCalledTimes(1));
+
+    harness.action.trigger("paint");
+    harness.action.trigger("paint");
+    harness.action.trigger("paint");
+    expect(harness.client.submitPrompt).toHaveBeenCalledTimes(1);
+
+    firstPoll.resolve(completeHistory);
+    await vi.waitFor(() => expect(harness.client.submitPrompt).toHaveBeenCalledTimes(2));
+    secondPoll.resolve(completeHistory);
+    await vi.waitFor(() => expect(harness.callbacks.onPreviewBlob).toHaveBeenCalledTimes(2));
+
+    expect(harness.client.submitPrompt.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(harness.capture).toHaveBeenCalledTimes(2);
+    harness.session.stop();
+  });
+
+  it("submits the Krea-2 workflow and publishes the refine result", async () => {
+    const harness = createHarness({ refineDenoise: 0.47 });
+    await startAndWaitForLive(harness);
+
+    harness.session.refineNow();
+    await vi.waitFor(() => expect(harness.callbacks.onRefineResult).toHaveBeenCalledTimes(1));
+
+    const workflow = harness.client.submitPrompt.mock.calls[1][0];
+    expect(workflow["20"]).toMatchObject({
+      class_type: "UNETLoader",
+      inputs: { unet_name: "krea2_turbo_fp8_scaled.safetensors" }
+    });
+    expect(workflow["3"].inputs).toMatchObject({ denoise: 0.47, steps: 8 });
+    expect(harness.capture).toHaveBeenLastCalledWith(1024);
+    expect(harness.client.pollUntilComplete.mock.calls[1][1]).toMatchObject({
+      intervalMs: 500,
+      timeoutMs: 180000
+    });
+    expect(harness.callbacks.onRefineResult).toHaveBeenCalledWith(expect.any(Blob), origin);
+    expect(harness.session.getState()).toBe("refined");
+
+    harness.session.stop();
+  });
+
+  it("lets a refine finish before running the live cycle queued by a stroke", async () => {
+    const refinePoll = createDeferred<typeof completeHistory>();
+    let pollCall = 0;
+    const pollUntilComplete = vi.fn(() => {
+      pollCall += 1;
+      return pollCall === 2 ? refinePoll.promise : Promise.resolve(completeHistory);
+    });
+    const harness = createHarness({}, { pollUntilComplete });
+    const published: string[] = [];
+    vi.mocked(harness.callbacks.onPreviewBlob).mockImplementation(() => published.push("live"));
+    vi.mocked(harness.callbacks.onRefineResult).mockImplementation(() => published.push("refine"));
+    await startAndWaitForLive(harness);
+    published.length = 0;
+
+    harness.session.refineNow();
+    await vi.waitFor(() => expect(harness.client.submitPrompt).toHaveBeenCalledTimes(2));
+    harness.action.trigger("paint");
+    expect(harness.client.submitPrompt).toHaveBeenCalledTimes(2);
+    expect(harness.client.cancelPrompt).not.toHaveBeenCalled();
+
+    refinePoll.resolve(completeHistory);
+    await vi.waitFor(() => expect(harness.client.submitPrompt).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(harness.callbacks.onPreviewBlob).toHaveBeenCalledTimes(2));
+
+    expect(published).toEqual(["refine", "live"]);
+    harness.session.stop();
+  });
+
+  it("cancels and restarts an in-flight refine when refineNow is pressed again", async () => {
+    const firstRefinePoll = createDeferred<typeof completeHistory>();
+    let pollCall = 0;
+    const pollUntilComplete = vi.fn(() => {
+      pollCall += 1;
+      return pollCall === 2 ? firstRefinePoll.promise : Promise.resolve(completeHistory);
+    });
+    const harness = createHarness({}, { pollUntilComplete });
+    await startAndWaitForLive(harness);
+
+    harness.session.refineNow();
+    await vi.waitFor(() => expect(harness.client.submitPrompt).toHaveBeenCalledTimes(2));
+    harness.session.refineNow();
+
+    expect(harness.client.cancelPrompt).toHaveBeenCalledTimes(1);
+    expect(harness.client.cancelPrompt).toHaveBeenCalledWith("prompt-2");
+
+    firstRefinePoll.resolve(completeHistory);
+    await vi.waitFor(() => expect(harness.client.submitPrompt).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(harness.callbacks.onRefineResult).toHaveBeenCalledTimes(1));
+
+    expect(harness.client.submitPrompt.mock.calls[2][0]["20"].class_type).toBe("UNETLoader");
+    harness.session.stop();
+  });
+
+  it("auto-refines after a pause only when the option is enabled", async () => {
+    vi.useFakeTimers();
+
+    const disabled = createHarness({ autoRefineOnPause: false, pauseSeconds: 4 });
+    await disabled.session.start();
+    await flushAsyncWork();
+    disabled.action.trigger("paint");
+    await flushAsyncWork();
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushAsyncWork();
+
+    expect(disabled.client.submitPrompt).toHaveBeenCalledTimes(2);
+    expect(disabled.callbacks.onRefineResult).not.toHaveBeenCalled();
+    disabled.session.stop();
+
+    const enabled = createHarness({ autoRefineOnPause: true, pauseSeconds: 4 });
+    await enabled.session.start();
+    await flushAsyncWork();
+    enabled.action.trigger("paint");
+    await flushAsyncWork();
+    await vi.advanceTimersByTimeAsync(3999);
+    await flushAsyncWork();
+    expect(enabled.callbacks.onRefineResult).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await flushAsyncWork();
+    expect(enabled.callbacks.onRefineResult).toHaveBeenCalledTimes(1);
+    expect(enabled.client.submitPrompt.mock.calls[2][0]["20"].class_type).toBe("UNETLoader");
+    enabled.session.stop();
+  });
+
+  it("reports a refine setup gap, skips refine, and keeps the live tier working", async () => {
+    const missingInventory = {
+      ...completeInventory,
+      diffusionModels: []
+    };
+    const harness = createHarness({}, {
+      getModelInventory: vi.fn(async () => missingInventory)
+    });
+    await startAndWaitForLive(harness);
+
+    harness.session.refineNow();
+    expect(harness.callbacks.onStatus).toHaveBeenCalledWith(
+      expect.stringContaining("Krea-2 refine setup is missing: diffusion model")
+    );
+    expect(harness.client.submitPrompt).toHaveBeenCalledTimes(1);
+
+    harness.action.trigger("paint");
+    await vi.waitFor(() => expect(harness.callbacks.onPreviewBlob).toHaveBeenCalledTimes(2));
+    expect(harness.client.submitPrompt).toHaveBeenCalledTimes(2);
+    harness.session.stop();
+  });
+
+  it("stops after three consecutive live or refine cycle failures", async () => {
+    const harness = createHarness();
+    harness.capture.mockRejectedValue(new Error("ComfyUI disappeared"));
+
+    await harness.session.start();
+    await vi.waitFor(() => {
+      expect(harness.callbacks.onStatus).toHaveBeenCalledWith(expect.stringContaining("(1/3 consecutive)"));
+    });
+
+    harness.action.trigger("paint");
+    await vi.waitFor(() => {
+      expect(harness.callbacks.onStatus).toHaveBeenCalledWith(expect.stringContaining("(2/3 consecutive)"));
+    });
+
+    harness.action.trigger("paint");
+    await vi.waitFor(() => expect(harness.callbacks.onStopped).toHaveBeenCalledTimes(1));
+
+    expect(harness.session.getState()).toBe("stopped");
+    expect(harness.callbacks.onStopped).toHaveBeenCalledWith(
+      expect.stringContaining("stopped after 3 consecutive cycle failures")
+    );
+  });
+
+  it("stop cancels the current prompt, removes listeners, and is idempotent", async () => {
+    const poll = createDeferred<typeof completeHistory>();
+    const harness = createHarness({}, {
+      pollUntilComplete: vi.fn(() => poll.promise)
+    });
+    await harness.session.start();
+    await vi.waitFor(() => expect(harness.client.pollUntilComplete).toHaveBeenCalledTimes(1));
+
+    harness.session.stop("Panel closed.");
+    harness.session.stop("Ignored second stop.");
+
+    expect(harness.session.getState()).toBe("stopped");
+    expect(harness.client.cancelPrompt).toHaveBeenCalledTimes(1);
+    expect(harness.client.cancelPrompt).toHaveBeenCalledWith("prompt-1");
+    expect(harness.callbacks.onStopped).toHaveBeenCalledTimes(1);
+    expect(harness.callbacks.onStopped).toHaveBeenCalledWith("Panel closed.");
+    expect(harness.action.actionModule.removeNotificationListener).toHaveBeenCalledTimes(5);
+
+    poll.resolve(completeHistory);
+    await flushAsyncWork();
+    expect(harness.callbacks.onPreviewBlob).not.toHaveBeenCalled();
+  });
+
+  it("cancels a prompt ID that arrives after the session has stopped", async () => {
+    const submittedPrompt = createDeferred<string>();
+    const harness = createHarness({}, {
+      submitPrompt: vi.fn(() => submittedPrompt.promise)
+    });
+    await harness.session.start();
+    await vi.waitFor(() => expect(harness.client.submitPrompt).toHaveBeenCalledTimes(1));
+
+    harness.session.stop();
+    submittedPrompt.resolve("late-prompt");
+    await vi.waitFor(() => expect(harness.client.cancelPrompt).toHaveBeenCalledWith("late-prompt"));
+
+    expect(harness.client.pollUntilComplete).not.toHaveBeenCalled();
+    expect(harness.callbacks.onPreviewBlob).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implemented by Codex (third attempt — first two hit sandbox/thread confusion and produced nothing; repo verified clean throughout), reviewed by Claude.

`LivePaintingSessionV2` (`src/ui/tools/livePainting.ts`, 655 lines) implements the spec §3.2 state machine as a **pure addition** — zero existing files changed; the app keeps using the v1 session until step 4 swaps it. All v1 behavior ported (drop-frame pump, single job in flight, prompt-cancel on stop + submit-after-stop race), plus: states with `onStateChanged`, `refineNow()` (second press cancels + restarts), stroke-during-refine defers a live cycle instead of cancelling the refine, opt-in pause auto-refine, Krea2 refine cycles, refine-availability gate that never blocks the live tier, three-consecutive-failures stop. Fully dependency-injected; ten fake-based tests map 1:1 to the spec rules.

## Test plan

- [x] typecheck / **286 tests** (276 → 286) / build — all green
- [ ] Photoshop: none needed for this PR (nothing is wired to the UI yet). Step 4 wires it in and gets the real smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code), implementation by Codex