### PR TITLE
Live Painting v2 step 4: wire the refine tier into the panel

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1489,6 +1489,21 @@ a:hover {
   color: #ffb0b0;
 }
 
+.live-state-badge.live {
+  background: rgba(72, 153, 210, 0.28);
+  color: #9bd7ff;
+}
+
+.live-state-badge.refining {
+  background: rgba(186, 123, 225, 0.28);
+  color: #dfb5fa;
+}
+
+.live-state-badge.refined {
+  background: rgba(58, 148, 94, 0.28);
+  color: #9fe0b5;
+}
+
 .diagnostics-line {
   color: #9a9a9a;
   font-size: 11px;
@@ -1621,6 +1636,22 @@ a:hover {
 .import-actions {
   display: block;
   margin-top: 4px;
+}
+
+.live-refine-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.live-refine-actions .button {
+  min-width: 0;
+  flex: 1 1 0;
+}
+
+.live-refined-import-button {
+  width: 100%;
+  margin-top: 8px;
 }
 
 .auto-import-toggle {
@@ -7113,6 +7144,30 @@ body,
 
 .app-shell.theme-compact .preview-panel.preview-zoomed img {
   max-height: 552px !important;
+}
+
+/* Live Painting state badge: intentionally after the compact status-pill
+   !important reset so the tier colors and badge shape remain visible. */
+.app-shell.theme-compact .status-pill.live-state-badge {
+  min-height: 18px !important;
+  padding: 2px 8px !important;
+  border-radius: 20px !important;
+  background: rgba(255, 255, 255, 0.06) !important;
+}
+
+.app-shell.theme-compact .status-pill.live-state-badge.live {
+  background: rgba(72, 153, 210, 0.28) !important;
+  color: #9bd7ff !important;
+}
+
+.app-shell.theme-compact .status-pill.live-state-badge.refining {
+  background: rgba(186, 123, 225, 0.28) !important;
+  color: #dfb5fa !important;
+}
+
+.app-shell.theme-compact .status-pill.live-state-badge.refined {
+  background: rgba(58, 148, 94, 0.28) !important;
+  color: #9fe0b5 !important;
 }
 
 /* #7: the header progress bar renders as one clean full-width bar. */

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -107,6 +107,7 @@ import {
   DocumentContextBound,
   PhotoshopDocumentIdentity
 } from "../photoshop/documentContext";
+import { captureCanvasForLivePainting } from "../photoshop/livePaintingCapture";
 import {
   createInpaintSourceModeDiagnostic,
   getInpaintSourceModeLabel,
@@ -137,7 +138,11 @@ import {
   HistoryImportStatus,
   HistoryToolType
 } from "./historyMetadata";
-import { LivePaintingSession } from "./livePaintingSession";
+import {
+  getLivePaintingStateBadgeLabel,
+  LivePaintingSessionV2,
+  type LivePaintingState
+} from "./tools/livePainting";
 import {
   createInpaintImportContext,
   createInpaintSourceSnapshot,
@@ -263,11 +268,13 @@ export function renderApp(rootElement: HTMLElement) {
   let upscaleImportAutomatically = false;
   let isNegativePromptOpen = false;
   let allowExperimentalCheckpoints = false;
-  let livePaintingSession: LivePaintingSession | null = null;
+  let livePaintingSession: LivePaintingSessionV2 | null = null;
   let livePreviewImage: HTMLImageElement | null = null;
   let livePreviewObjectUrl = "";
   let liveLastResult: LiveGeneratedImageResult | null = null;
+  let liveRefinedResult: LiveGeneratedImageResult | null = null;
   let liveImportAutomatically = false;
+  let liveAutoRefine = false;
   let livePreviewZoomed = false;
   let hardwareReport: HardwareRecommendationReport | null = null;
   let workflowHealthReport: WorkflowHealthReport | null = null;
@@ -513,9 +520,12 @@ export function renderApp(rootElement: HTMLElement) {
     clearHistory: createActionRunner(elements, "clearHistory", handleClearHistory),
     startLivePainting: createActionRunner(elements, "startLivePainting", handleStartLivePainting),
     stopLivePainting: createActionRunner(elements, "stopLivePainting", handleStopLivePainting),
+    refineLivePainting: createActionRunner(elements, "refineLivePainting", handleRefineLivePainting),
     toggleLiveZoom: createActionRunner(elements, "toggleLiveZoom", handleToggleLiveZoom),
     importLiveResult: createActionRunner(elements, "importLiveResult", handleImportLiveResult),
-    toggleLiveAutoImport: createActionRunner(elements, "toggleLiveAutoImport", handleToggleLiveAutoImport)
+    importLiveRefined: createActionRunner(elements, "importLiveRefined", handleImportLiveRefined),
+    toggleLiveAutoImport: createActionRunner(elements, "toggleLiveAutoImport", handleToggleLiveAutoImport),
+    toggleLiveAutoRefine: createActionRunner(elements, "toggleLiveAutoRefine", handleToggleLiveAutoRefine)
   };
 
   bindActionControl(elements.checkButton, actionHandlers.check);
@@ -561,9 +571,12 @@ export function renderApp(rootElement: HTMLElement) {
   bindActionControl(elements.clearHistoryButton, actionHandlers.clearHistory);
   bindActionControl(elements.liveStartButton, actionHandlers.startLivePainting);
   bindActionControl(elements.liveStopButton, actionHandlers.stopLivePainting);
+  bindActionControl(elements.liveRefineButton, actionHandlers.refineLivePainting);
   bindActionControl(elements.liveZoomToggle, actionHandlers.toggleLiveZoom);
   bindActionControl(elements.importLiveButton, actionHandlers.importLiveResult);
+  bindActionControl(elements.importLiveRefinedButton, actionHandlers.importLiveRefined);
   bindActionControl(elements.liveAutoImportToggle, actionHandlers.toggleLiveAutoImport);
+  bindActionControl(elements.liveAutoRefineToggle, actionHandlers.toggleLiveAutoRefine);
   bindDelegatedActions(rootElement, actionHandlers);
   bindDocumentActions(rootElement, actionHandlers);
   bindHomeSectionToggles(rootElement);
@@ -615,6 +628,8 @@ export function renderApp(rootElement: HTMLElement) {
   updateLiveButtons(false);
   setActionDisabled(elements.importLiveButton, true);
   updateLiveAutoImportToggle(liveImportAutomatically);
+  updateLiveAutoRefineToggle(liveAutoRefine);
+  updateLiveStateBadge("idle");
   void loadInitialCheckpoints();
 
   elements.workflow.addEventListener("change", () => {
@@ -3145,12 +3160,15 @@ export function renderApp(rootElement: HTMLElement) {
     }
 
     const denoise = Number(elements.liveDenoise.value);
-    const session = new LivePaintingSession(
+    const session = new LivePaintingSessionV2(
       {
-        serverUrl: elements.serverUrl.value,
         checkpointName,
         prompt,
-        denoise: Number.isFinite(denoise) ? denoise : 0.6
+        denoise: Number.isFinite(denoise) ? denoise : 0.6,
+        autoRefineOnPause: liveAutoRefine,
+        refineDenoise: 0.45,
+        refineMaxDimension: 1024,
+        pauseSeconds: 4
       },
       {
         onStatus: (message) => setLiveStatus(message),
@@ -3158,10 +3176,20 @@ export function renderApp(rootElement: HTMLElement) {
           elements.liveTimingsText.textContent = message;
         },
         onPreviewBlob: (blob, originatingDocument) => updateLivePreview(blob, originatingDocument),
+        onRefineResult: (blob, originatingDocument) => {
+          liveRefinedResult = bindDocumentContext({ blob }, originatingDocument);
+          setActionDisabled(elements.importLiveRefinedButton, false);
+          updateLivePreview(blob, originatingDocument, false);
+        },
+        onStateChanged: (state) => updateLiveStateBadge(state),
         onStopped: (reason) => {
           setLiveStatus(reason);
           updateLiveButtons(false);
         }
+      },
+      {
+        client: new ComfyClient(elements.serverUrl.value),
+        capture: captureCanvasForLivePainting
       }
     );
 
@@ -3170,6 +3198,17 @@ export function renderApp(rootElement: HTMLElement) {
 
     try {
       await session.start();
+      void session.checkRefineAvailability()
+        .then((gapMessage) => {
+          if (gapMessage && livePaintingSession === session && session.isRunning()) {
+            setLiveStatus(gapMessage);
+          }
+        })
+        .catch((caughtError) => {
+          if (livePaintingSession === session && session.isRunning()) {
+            setLiveStatus(`Could not check Krea-2 refine availability: ${getErrorMessage(caughtError)}`);
+          }
+        });
     } catch (caughtError) {
       if (session.isRunning()) {
         session.stop("Live session stopped after a startup error.");
@@ -3177,9 +3216,19 @@ export function renderApp(rootElement: HTMLElement) {
 
       livePaintingSession = null;
       updateLiveButtons(false);
+      updateLiveStateBadge("idle");
       setLiveStatus(getErrorMessage(caughtError));
       elements.liveTimingsText.textContent = getTechnicalErrorDetails(caughtError);
     }
+  }
+
+  function handleRefineLivePainting() {
+    if (!livePaintingSession?.isRunning()) {
+      setLiveStatus("Start a live session before refining.");
+      return;
+    }
+
+    livePaintingSession.refineNow();
   }
 
   function handleStopLivePainting() {
@@ -3226,6 +3275,28 @@ export function renderApp(rootElement: HTMLElement) {
     }
   }
 
+  async function handleImportLiveRefined() {
+    if (!liveRefinedResult) {
+      setLiveStatus("Generate a refined live result before importing.");
+      return;
+    }
+
+    setLiveStatus("Importing refined live result into Photoshop...");
+
+    try {
+      const importedLayerName = await importGeneratedImageAsLayer({
+        blob: liveRefinedResult.blob,
+        originatingDocument: liveRefinedResult.originatingDocument,
+        layerName: createLayerName("OpenLayer_LiveRefine"),
+        onProgress: (message) => setLiveStatus(message)
+      });
+      setLiveStatus(`Imported layer: ${importedLayerName}`);
+      flashImported(elements.liveStatusText);
+    } catch (caughtError) {
+      setLiveStatus(getErrorMessage(caughtError));
+    }
+  }
+
   function handleToggleLiveAutoImport() {
     liveImportAutomatically = !liveImportAutomatically;
     updateLiveAutoImportToggle(liveImportAutomatically);
@@ -3242,6 +3313,22 @@ export function renderApp(rootElement: HTMLElement) {
     elements.liveAutoImportToggle.classList.toggle("is-active", isEnabled);
   }
 
+  function handleToggleLiveAutoRefine() {
+    liveAutoRefine = !liveAutoRefine;
+    updateLiveAutoRefineToggle(liveAutoRefine);
+    setLiveStatus(
+      liveAutoRefine
+        ? "Auto refine will run after a 4-second painting pause in the next live session."
+        : "Live auto refine is off."
+    );
+  }
+
+  function updateLiveAutoRefineToggle(isEnabled: boolean) {
+    elements.liveAutoRefineToggle.textContent = isEnabled ? "Auto Refine On" : "Auto Refine on Pause";
+    elements.liveAutoRefineToggle.setAttribute("aria-pressed", String(isEnabled));
+    elements.liveAutoRefineToggle.classList.toggle("is-active", isEnabled);
+  }
+
   function setLiveStatus(message: string) {
     elements.liveStatusText.textContent = message;
   }
@@ -3249,9 +3336,22 @@ export function renderApp(rootElement: HTMLElement) {
   function updateLiveButtons(isLive: boolean) {
     setActionDisabled(elements.liveStartButton, isLive);
     setActionDisabled(elements.liveStopButton, !isLive);
+    setActionDisabled(elements.liveRefineButton, !isLive);
+    setActionDisabled(elements.importLiveRefinedButton, !liveRefinedResult);
   }
 
-  function updateLivePreview(blob: Blob, originatingDocument: PhotoshopDocumentIdentity) {
+  function updateLiveStateBadge(state: LivePaintingState) {
+    const label = getLivePaintingStateBadgeLabel(state);
+    elements.liveStateBadge.textContent = label;
+    elements.liveStateBadge.classList.remove("idle", "live", "refining", "refined");
+    elements.liveStateBadge.classList.add(label.toLowerCase());
+  }
+
+  function updateLivePreview(
+    blob: Blob,
+    originatingDocument: PhotoshopDocumentIdentity,
+    recordLiveResult = true
+  ) {
     // One persistent img element: swapping src avoids the rebuild flicker the
     // per-frame progress previews show elsewhere in the panel.
     if (!livePreviewImage) {
@@ -3267,6 +3367,10 @@ export function renderApp(rootElement: HTMLElement) {
 
     if (previousUrl) {
       objectUrls.revoke(previousUrl);
+    }
+
+    if (!recordLiveResult) {
+      return;
     }
 
     liveLastResult = bindDocumentContext({ blob }, originatingDocument);
@@ -4083,9 +4187,12 @@ type ActionName =
   | "clearHistory"
   | "startLivePainting"
   | "stopLivePainting"
+  | "refineLivePainting"
   | "toggleLiveZoom"
   | "importLiveResult"
-  | "toggleLiveAutoImport";
+  | "importLiveRefined"
+  | "toggleLiveAutoImport"
+  | "toggleLiveAutoRefine";
 type HistoryActionName = "preview" | "import" | "reuse";
 type ActionRunner = (eventName: string) => void;
 type ActionHandlers = Record<ActionName, ActionRunner>;

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -235,11 +235,15 @@ export type AppElements = {
   liveDenoise: HTMLInputElement;
   liveStartButton: HTMLElement;
   liveStopButton: HTMLElement;
+  liveRefineButton: HTMLElement;
+  liveAutoRefineToggle: HTMLElement;
   liveStatusText: HTMLElement;
+  liveStateBadge: HTMLElement;
   liveTimingsText: HTMLElement;
   liveResultPreviewPanel: HTMLElement;
   liveZoomToggle: HTMLElement;
   importLiveButton: HTMLElement;
+  importLiveRefinedButton: HTMLElement;
   liveAutoImportToggle: HTMLElement;
 };
 
@@ -351,6 +355,10 @@ export function createAppMarkup() {
           </label>
           <button class="button button-primary button-generate button-wide action-control" id="start-live-painting" data-openlayer-action="startLivePainting" type="button">Start Live Session</button>
           <button class="button button-wide action-control" id="stop-live-painting" data-openlayer-action="stopLivePainting" type="button">Stop Live Session</button>
+          <div class="live-refine-actions">
+            <button class="button action-control" id="refine-live-painting" data-openlayer-action="refineLivePainting" type="button">Refine Now</button>
+            <button class="button action-control" id="live-auto-refine-toggle" data-openlayer-action="toggleLiveAutoRefine" type="button" aria-pressed="false">Auto Refine on Pause</button>
+          </div>
         </section>
 
         <section class="panel-section generator-panel" aria-label="Live Painting preview">
@@ -365,6 +373,7 @@ export function createAppMarkup() {
             <button class="button action-control" id="import-live-result" data-openlayer-action="importLiveResult" type="button">Import to Layers</button>
             <button class="button action-control" id="live-auto-import-toggle" data-openlayer-action="toggleLiveAutoImport" type="button" aria-pressed="false">Import Automatically</button>
           </div>
+          <button class="button live-refined-import-button action-control" id="import-live-refined" data-openlayer-action="importLiveRefined" type="button">Import Refined as Layer</button>
           <div class="diagnostics-line">
             Import Automatically brings the latest live result into Photoshop as a new layer when you stop the session.
           </div>
@@ -373,7 +382,7 @@ export function createAppMarkup() {
         <section class="generation-status-panel" aria-label="Live Painting status">
           <div class="status-bar" role="status">
             <span class="status-text" id="live-status-text">Live Painting spike ready.</span>
-            <span class="status-pill idle">Spike</span>
+            <span class="status-pill live-state-badge idle" id="live-state-badge">IDLE</span>
           </div>
           <div class="diagnostics-line" id="live-timings-text">Cycle timings will appear here.</div>
         </section>
@@ -1457,11 +1466,15 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     liveDenoise: getElement<HTMLInputElement>(rootElement, "live-denoise"),
     liveStartButton: getElement<HTMLElement>(rootElement, "start-live-painting"),
     liveStopButton: getElement<HTMLElement>(rootElement, "stop-live-painting"),
+    liveRefineButton: getElement<HTMLElement>(rootElement, "refine-live-painting"),
+    liveAutoRefineToggle: getElement<HTMLElement>(rootElement, "live-auto-refine-toggle"),
     liveStatusText: getElement<HTMLElement>(rootElement, "live-status-text"),
+    liveStateBadge: getElement<HTMLElement>(rootElement, "live-state-badge"),
     liveTimingsText: getElement<HTMLElement>(rootElement, "live-timings-text"),
     liveResultPreviewPanel: getElement<HTMLElement>(rootElement, "live-result-preview-panel"),
     liveZoomToggle: getElement<HTMLElement>(rootElement, "live-zoom-toggle"),
     importLiveButton: getElement<HTMLElement>(rootElement, "import-live-result"),
+    importLiveRefinedButton: getElement<HTMLElement>(rootElement, "import-live-refined"),
     liveAutoImportToggle: getElement<HTMLElement>(rootElement, "live-auto-import-toggle")
   };
 }

--- a/src/ui/tools/livePainting.ts
+++ b/src/ui/tools/livePainting.ts
@@ -21,6 +21,22 @@ export type LivePaintingState =
   | "refined"
   | "stopped";
 
+export type LivePaintingStateBadgeLabel = "IDLE" | "LIVE" | "REFINING" | "REFINED";
+
+export function getLivePaintingStateBadgeLabel(state: LivePaintingState): LivePaintingStateBadgeLabel {
+  switch (state) {
+    case "listening":
+    case "pending":
+      return "LIVE";
+    case "refining":
+      return "REFINING";
+    case "refined":
+      return "REFINED";
+    default:
+      return "IDLE";
+  }
+}
+
 export type LivePaintingV2Callbacks = {
   onStatus: (message: string) => void;
   onTimings: (message: string) => void;

--- a/tests/ui/livePaintingV2.test.ts
+++ b/tests/ui/livePaintingV2.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPhotoshopDocumentIdentity } from "../../src/photoshop/documentContext";
 import {
+  getLivePaintingStateBadgeLabel,
   LivePaintingSessionV2,
   type LivePaintingV2Callbacks,
   type LivePaintingV2Options,
@@ -134,6 +135,23 @@ async function flushAsyncWork(turns = 20) {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe("getLivePaintingStateBadgeLabel", () => {
+  it("maps session states to the four UI labels", () => {
+    const expectedLabels = {
+      idle: "IDLE",
+      listening: "LIVE",
+      pending: "LIVE",
+      refining: "REFINING",
+      refined: "REFINED",
+      stopped: "IDLE"
+    } as const;
+
+    for (const [state, label] of Object.entries(expectedLabels)) {
+      expect(getLivePaintingStateBadgeLabel(state as keyof typeof expectedLabels)).toBe(label);
+    }
+  });
 });
 
 describe("LivePaintingSessionV2", () => {


### PR DESCRIPTION
## Summary

Implemented by Codex (took three attempts across two sessions — the first two hit shared-runtime brief contamination unrelated to the code itself, resolved by restarting the Codex app; repo stayed clean throughout all of them), reviewed and validated by Claude.

The app now runs `LivePaintingSessionV2` (merged in step 3) instead of the v1 spike session. Every existing behavior carries over unchanged — start/stop guards from step 1, auto-import on stop, live preview, status/timings, panel-close teardown — since v2 implements the same session shape.

**New on the Live Painting screen:**
- **Refine Now** — calls `session.refineNow()`, enabled only while a session runs
- **Auto Refine on Pause** toggle — mirrors the existing auto-import toggle
- **State badge** (IDLE / LIVE / REFINING / REFINED) driven by `onStateChanged`, backed by an exported pure mapper with its own test
- **Import Refined as Layer** — enabled once a refine result exists, imports via the standard `importGeneratedImageAsLayer` path (A1 origin binding preserved)
- A refine result also renders in the existing live preview panel (extended `updateLivePreview` with a flag so it can display without clobbering the separate live-tier result the plain Import button targets — two result slots, one shared render path)
- `checkRefineAvailability()` runs in the background on session start and surfaces a Krea2 setup gap via the status line without blocking the live tier, guarded against a stale/replaced session

I specifically checked the one CSS trap that's bitten this project before (compact-theme `!important` silently overriding base rules): the state badge's compact styling is placed after the theme's `status-pill` reset, and I confirmed no `.status-pill` rule anywhere later in the file could re-override it.

## Test plan

- [x] typecheck / **287 tests** (286 → 287) / build — all green
- [ ] **Photoshop — the real milestone test:**
  1. Start a live session, paint a stroke → live preview updates as before
  2. Click **Refine Now** → status shows REFINING, then REFINED; the refined (higher-quality Krea2) image appears in the preview
  3. Click **Import Refined as Layer** → new layer imports correctly
  4. Toggle **Auto Refine on Pause** on, start a new session, paint then stop painting for ~4s → refine triggers automatically
  5. Paint a stroke *while* a refine is running → refine is NOT interrupted; a live cycle runs after it completes
  6. Click **Refine Now** a second time while refining → the first refine is cancelled and a new one starts
  7. If Krea2 models aren't fully installed, confirm the status line names the gap and the **live tier still works**
  8. Stop the session → still auto-imports the live result if that toggle is on; refined result is separate and untouched
  9. Confirm the mutual-exclusion guards from step 1 still work (Generate blocked during live session, live session blocked during a generate)

🤖 Generated with [Claude Code](https://claude.com/claude-code), implementation by Codex