### PR TITLE
Graduate all runnable presets to stable; remove experimental UI copy

### DIFF
--- a/docs/LIVE_PAINTING_V2.md
+++ b/docs/LIVE_PAINTING_V2.md
@@ -102,14 +102,14 @@ Existing screen plus: tier indicator (LIVE ⚡ / REFINING ✨ badge on the previ
 
 ## 5. Implementation plan (incremental, each step = validation trio + Mehran smoke)
 
-| Step | Content | Delegable to Codex? |
+| Step | Content | Status |
 |---|---|---|
-| 1 | Mutual exclusion guards (live vs regular generates) + in-flight cancel on stop/teardown | Yes — small, well-scoped, this spec is the brief |
-| 2 | `buildKrea2RefineWorkflow` + inventory gate + unit tests (pure) | Yes |
-| 3 | Session state machine v2 in `src/ui/tools/livePainting.ts` (port pump, add refine states, pause timer, telemetry) with unit tests against a fake client (mirror `generationController.test.ts` fixtures) | Yes, with careful review — the state machine is the heart |
-| 4 | UI: refine controls + badges + wiring | Yes |
-| 5 | WebSocket preview instead of polling for live cycles | Yes — reuse `watchProgress` |
-| 6 | Latency profiling pass on Mehran's machine; tune denoise/pause defaults; record real numbers back into this doc | Human + any model |
+| 1 | Mutual exclusion guards (live vs regular generates) + in-flight cancel on stop/teardown | **Done** — merged in PR #19 |
+| 2 | `buildKrea2RefineWorkflow` + inventory gate + unit tests (pure) | **Done** — merged in PR #19 |
+| 3 | Session state machine v2 in `src/ui/tools/livePainting.ts` (port pump, add refine states, pause timer, telemetry) with unit tests against a fake client | **Done** — merged in PR #20 |
+| 4 | UI: refine controls + badges + wiring | **Done** — merged in PR #21; refine tier host-verified working by Mehran 2026-07-21 |
+| 5 | WebSocket preview instead of polling for live cycles | Pending — reuse `watchProgress`; folded into the v2.5 plan below |
+| 6 | Latency profiling pass on Mehran's machine; tune denoise/pause defaults; record real numbers back into this doc | Pending (Human + any model) |
 
 Review checkpoints for whoever orchestrates: A1 (originatingDocument on every capture), A5 (all preview URLs through the registry/owned slots), single-job-in-flight invariant, and the mutual-exclusion guard on BOTH sides.
 
@@ -120,3 +120,20 @@ Review checkpoints for whoever orchestrates: A1 (originatingDocument on every ca
 3. LoadImage filename-reuse staleness: yes/no on his ComfyUI version.
 4. Krea2 refine wall-clock at 768² and 1024² with the fp8 model (decide default refine size from this).
 5. Whether `historyStateChanged` fires during a drag or only on mouse-up (affects debounce need; current pump absorbs either).
+
+## 7. Realtime gap and the v2.5 plan (DEFERRED — do not start without Mehran's go)
+
+Status after v2 shipped (2026-07-21): the two-tier design works — live tier repaints in ~0.5–0.7 s, refine tier delivers a Krea-2 Turbo pass in ~38–48 s at 1024² on the RTX 4070 Ti (12 GB). Mehran confirmed refine works but noted the expectation gap: this is not krea.ai/realtime. That gap is structural, not a bug:
+
+- **The refine tier can never be the realtime engine on 12 GB.** Krea-2 Turbo at 38–48 s/frame is physics, not tuning. Realtime feel must come from the live tier.
+- **`historyStateChanged` only fires on mouse-up**, so previews update per-stroke, not during a drag.
+- **Disk + poll overhead** adds ~300–500 ms per cycle on top of sampling.
+
+v2.5 scope (in order of impact, each step = validation trio + smoke):
+
+1. **Continuous capture timer** (~400 ms) while the pointer is likely painting, instead of waiting for `historyStateChanged` — previews update mid-drag.
+2. **`SaveImageWebsocket`** output node + binary WS frames — removes disk write + HTTP poll from the loop (plan step 5 above folds in here).
+3. **1–2 step models** (SD-Turbo / SDXL-Turbo / LCM at 1–2 steps, denoise-tuned) for the live tier.
+4. **v3, separate track:** StreamDiffusion sidecar process for true 10 fps+ — different architecture, not an increment of this pipeline.
+
+Do not begin any of this until Mehran explicitly asks; v2 is the released baseline.

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -557,8 +557,7 @@ const INPAINT_BASIC_CAPABILITY: WorkflowCapability = {
   uiHints: {
     showModelSelector: true,
     modelSelectorLabel: "Checkpoint",
-    primaryActionLabel: "Generate Inpaint",
-    warning: "Inpaint/Repaint Selection is experimental until Photoshop alignment and output quality are confirmed."
+    primaryActionLabel: "Generate Inpaint"
   }
 };
 
@@ -577,8 +576,7 @@ const INPAINT_FLUX_FILL_BASIC_CAPABILITY: WorkflowCapability = {
   uiHints: {
     showModelSelector: true,
     modelSelectorLabel: "Flux Fill model",
-    primaryActionLabel: "Generate Inpaint",
-    warning: "Flux Fill is experimental and may require guidance, denoise, mask blur, and context-size tuning."
+    primaryActionLabel: "Generate Inpaint"
   }
 };
 
@@ -608,8 +606,7 @@ const OUTPAINT_FLUX_FILL_BASIC_CAPABILITY: WorkflowCapability = {
   uiHints: {
     showModelSelector: true,
     modelSelectorLabel: "Flux Fill model",
-    primaryActionLabel: "Generate Outpaint",
-    warning: "Outpaint is experimental and uses Flux Fill with ImagePadForOutpaint."
+    primaryActionLabel: "Generate Outpaint"
   }
 };
 
@@ -628,8 +625,7 @@ const Z_IMAGE_TURBO_TXT2IMG_CAPABILITY: WorkflowCapability = {
   uiHints: {
     showModelSelector: true,
     modelSelectorLabel: "Z_image_Turbo model",
-    primaryActionLabel: "Generate",
-    warning: "Z_image_Turbo is experimental. Confirm the diffusion model, CLIP, and VAE stack with Check Workflow Health before relying on results."
+    primaryActionLabel: "Generate"
   }
 };
 
@@ -648,8 +644,7 @@ const Z_IMAGE_TURBO_IMG2IMG_CAPABILITY: WorkflowCapability = {
   uiHints: {
     showModelSelector: true,
     modelSelectorLabel: "Z_image_Turbo model",
-    primaryActionLabel: "Generate Image to Image",
-    warning: "Z_image_Turbo Image to Image is experimental. Confirm the diffusion model, CLIP, and VAE stack with Check Workflow Health before relying on results."
+    primaryActionLabel: "Generate Image to Image"
   }
 };
 
@@ -831,7 +826,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental Flux1-dev fp8 text-to-image workflow using a checkpoint-style ComfyUI graph.",
     workflowFile: "workflows/api/txt2img-flux1-dev-fp8.json",
     sourceWorkflowFile: "workflows/source/txt2img-flux1-dev-fp8.workflow.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 20, cfg: 3.5 },
     supportedModelFamilies: ["flux"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "zImage", "unknown"],
@@ -944,7 +939,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental Florence-2 PromptGen workflow that describes a captured Photoshop layer or canvas.",
     workflowFile: "workflows/api/prompt-from-layer-florence2.json",
     sourceWorkflowFile: "workflows/source/prompt-from-layer-florence2.workflow.json",
-    status: "experimental",
+    status: "stable",
     supportedModelFamilies: ["unknown"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "flux", "zImage"],
     modelSource: FLORENCE_MODEL_SOURCE,
@@ -983,7 +978,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental pixel upscale through ComfyUI UpscaleModelLoader and ImageUpscaleWithModel.",
     workflowFile: "workflows/api/upscale-basic.json",
     sourceWorkflowFile: "workflows/source/upscale-basic.workflow.json",
-    status: "experimental",
+    status: "stable",
     supportedModelFamilies: ["unknown"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "flux", "zImage"],
     modelSource: UPSCALE_MODEL_SOURCE,
@@ -1022,7 +1017,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental SD 1.x LineArt ControlNet sketch guidance workflow.",
     workflowFile: "workflows/api/sketch2img-linecn-basic.json",
     sourceWorkflowFile: "workflows/source/sketch2img-linecn-basic.workflow.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 20, cfg: 7 },
     supportedModelFamilies: ["sd1"],
     experimentalModelFamilies: ["sdxl", "sd3", "flux", "zImage"],
@@ -1101,7 +1096,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental SD 1.x inpainting workflow using a Photoshop selection source and mask.",
     workflowFile: "workflows/api/inpaint-basic.json",
     sourceWorkflowFile: "workflows/source/inpaint-basic.workflow.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 16, cfg: 7 },
     supportedModelFamilies: ["sd1"],
     experimentalModelFamilies: ["sdxl", "sd3", "flux", "zImage", "unknown"],
@@ -1161,7 +1156,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
       }
     ],
     compatibilityNote:
-      "inpaint-basic is an experimental SD 1.x workflow using LoadImage, ImageToMask, and InpaintModelConditioning. Start with an SD 1.x inpaint checkpoint."
+      "inpaint-basic is an SD 1.x workflow using LoadImage, ImageToMask, and InpaintModelConditioning. Start with an SD 1.x inpaint checkpoint."
   },
   {
     id: "inpaint-flux-fill-basic",
@@ -1169,7 +1164,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     mode: "inpaint",
     description: "Experimental Flux Fill inpainting workflow using a diffusion model stack.",
     workflowFile: "workflows/api/inpaint-flux-fill-basic.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 20, cfg: 30 },
     supportedModelFamilies: ["flux"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "zImage", "unknown"],
@@ -1241,7 +1236,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
       }
     ],
     compatibilityNote:
-      "inpaint-flux-fill-basic is experimental and follows the Flux Fill reference graph: UNETLoader, DifferentialDiffusion, DualCLIPLoader, FluxGuidance, InpaintModelConditioning, KSampler, VAEDecode, and SaveImage. OpenLayer embeds the Photoshop mask into the uploaded PNG alpha channel for the LoadImage mask output. T5 prefers t5xxl_fp16.safetensors and accepts t5xxl_fp8_e4m3fn.safetensors as a fallback."
+      "inpaint-flux-fill-basic follows the Flux Fill reference graph: UNETLoader, DifferentialDiffusion, DualCLIPLoader, FluxGuidance, InpaintModelConditioning, KSampler, VAEDecode, and SaveImage. OpenLayer embeds the Photoshop mask into the uploaded PNG alpha channel for the LoadImage mask output. T5 prefers t5xxl_fp16.safetensors and accepts t5xxl_fp8_e4m3fn.safetensors as a fallback."
   },
   {
     id: "outpaint-flux-fill-basic",
@@ -1250,7 +1245,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental Flux Fill outpainting workflow using ImagePadForOutpaint.",
     workflowFile: "workflows/api/outpaint-flux-fill-basic.json",
     sourceWorkflowFile: "workflows/source/outpaint-flux-fill-basic.workflow.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 20, cfg: 10 },
     supportedModelFamilies: ["flux"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "zImage", "unknown"],
@@ -1327,7 +1322,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
       }
     ],
     compatibilityNote:
-      "outpaint-flux-fill-basic is experimental and follows the attached Flux Fill outpaint graph: ImagePadForOutpaint creates the padded image and mask, then Flux Fill generates the expanded result. T5 prefers t5xxl_fp16.safetensors and accepts t5xxl_fp8_e4m3fn.safetensors as a fallback."
+      "outpaint-flux-fill-basic follows the attached Flux Fill outpaint graph: ImagePadForOutpaint creates the padded image and mask, then Flux Fill generates the expanded result. T5 prefers t5xxl_fp16.safetensors and accepts t5xxl_fp8_e4m3fn.safetensors as a fallback."
   },
   {
     id: "txt2img-z-image-turbo",
@@ -1336,7 +1331,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental text-to-image preset for the Z_image_Turbo diffusion model stack.",
     workflowFile: "workflows/api/txt2img-z-image-turbo.json",
     sourceWorkflowFile: "workflows/source/txt2img-z-image-turbo.workflow.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 8, cfg: 1 },
     supportedModelFamilies: ["zImage"],
     experimentalModelFamilies: ["unknown"],
@@ -1407,7 +1402,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     description: "Experimental image-to-image preset for the Z_image_Turbo diffusion model stack.",
     workflowFile: "workflows/api/img2img-z-image-turbo.json",
     sourceWorkflowFile: "workflows/source/img2img-z-image-turbo.workflow.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 8, cfg: 1 },
     supportedModelFamilies: ["zImage"],
     experimentalModelFamilies: ["unknown"],
@@ -1482,7 +1477,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     mode: "txt2img",
     description: "Experimental text-to-image preset for the Krea-2 Turbo diffusion model stack.",
     workflowFile: "workflows/api/txt2img-krea2-turbo.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 8, cfg: 1 },
     supportedModelFamilies: ["unknown"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "flux", "zImage"],
@@ -1547,7 +1542,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     mode: "img2img",
     description: "Experimental image-to-image preset for the Krea-2 Turbo diffusion model stack.",
     workflowFile: "workflows/api/img2img-krea2-turbo.json",
-    status: "experimental",
+    status: "stable",
     recommendedSettings: { steps: 8, cfg: 1 },
     supportedModelFamilies: ["unknown"],
     experimentalModelFamilies: ["sd1", "sdxl", "sd3", "flux", "zImage"],

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -2074,7 +2074,7 @@ export function renderApp(rootElement: HTMLElement) {
           dimensions: `${capturedSource.width} x ${capturedSource.height}`,
           sourceMode: capturedSource.sourceName,
           outpaintImportContext: generatedOutpaintContext,
-          experimental: true,
+          experimental: buildResult.preset.status === "experimental",
           diagnosticsSummary: formatInpaintOutpaintDebugContract({
             toolType: "outpaint",
             presetId: buildResult.preset.id,
@@ -2794,7 +2794,7 @@ export function renderApp(rootElement: HTMLElement) {
           sourceBounds: createMetadataBounds(submittedSource.selection.bounds),
           contextBounds: createMetadataBounds(submittedSource.selection.contextBounds),
           inpaintImportContext: generatedImportContext,
-          experimental: true,
+          experimental: buildResult.preset.status === "experimental",
           diagnosticsSummary: [
             inpaintOutputDiagnostics,
             formatInpaintOutpaintDebugContract({

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -109,9 +109,9 @@ export const TOOL_CARDS: ToolCard[] = [
   {
     id: "inpaint",
     title: "Inpaint",
-    subtitle: "Selection repaint is in testing",
+    subtitle: "Repaint a selection in place",
     icon: "brush",
-    status: "experimental",
+    status: "available",
     view: "inpaint"
   },
   {
@@ -127,7 +127,7 @@ export const TOOL_CARDS: ToolCard[] = [
     title: "Outpaint",
     subtitle: "Extend canvas content beyond edges",
     icon: "expand",
-    status: "experimental",
+    status: "available",
     view: "outpaint"
   },
   {
@@ -135,7 +135,7 @@ export const TOOL_CARDS: ToolCard[] = [
     title: "Sketch to Image",
     subtitle: "Guide generation with lineart",
     icon: "lineart",
-    status: "experimental",
+    status: "available",
     view: "sketch-to-image"
   },
   {
@@ -149,9 +149,9 @@ export const TOOL_CARDS: ToolCard[] = [
   {
     id: "live-painting",
     title: "Live Painting",
-    subtitle: "Paint and watch AI respond (spike)",
+    subtitle: "Paint and watch AI respond live",
     icon: "style",
-    status: "experimental",
+    status: "available",
     view: "live-painting"
   },
   {

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -339,10 +339,10 @@ export function createAppMarkup() {
         <section class="panel-section generator-panel" aria-label="Live Painting session">
           <div class="section-heading">
             <span class="label">Live session</span>
-            <span class="muted-label">Spike build</span>
+            <span class="muted-label">Two-tier session</span>
           </div>
           <div class="diagnostics-line">
-            Experimental stroke-sync test. Uses the Text to Image checkpoint with the local SD 1.5 LCM LoRA.
+            Live tier uses the Text to Image checkpoint with the local SD 1.5 LCM LoRA; Refine uses Krea-2 Turbo.
             Start a session, then paint in the document and watch the preview follow your strokes.
           </div>
           <label class="field">
@@ -381,7 +381,7 @@ export function createAppMarkup() {
 
         <section class="generation-status-panel" aria-label="Live Painting status">
           <div class="status-bar" role="status">
-            <span class="status-text" id="live-status-text">Live Painting spike ready.</span>
+            <span class="status-text" id="live-status-text">Live Painting ready.</span>
             <span class="status-pill live-state-badge idle" id="live-state-badge">IDLE</span>
           </div>
           <div class="diagnostics-line" id="live-timings-text">Cycle timings will appear here.</div>
@@ -633,7 +633,7 @@ export function createAppMarkup() {
             <select class="select" id="img-checkpoint">
               ${FALLBACK_CHECKPOINTS.map((checkpoint) => `<option value="${checkpoint}">${checkpoint}</option>`).join("")}
             </select>
-            ${createInfoPanelMarkup("img-compatibility-note", "img2img-basic is safest with SD 1.x and SDXL checkpoints. SD3 and Flux are experimental.")}
+            ${createInfoPanelMarkup("img-compatibility-note", "img2img-basic is safest with SD 1.x and SDXL checkpoints. SD3 and Flux may need dedicated presets.")}
           </div>
           <button class="button experimental-toggle action-control" id="experimental-checkpoint-toggle" data-openlayer-action="toggleExperimentalCheckpoints" type="button" aria-pressed="false">Experimental Checkpoints Off</button>
           <div class="settings-grid img2img-settings-grid" aria-label="Image to Image settings">
@@ -801,9 +801,6 @@ export function createAppMarkup() {
           </div>
         </div>
 
-        <div class="tool-warning" role="note">
-          Experimental: Inpaint output quality and Photoshop alignment are still being tested. Use this for debugging, not production work yet.
-        </div>
 
         <section class="panel-section generator-panel source-panel" aria-label="Inpaint selection source">
           <div class="section-heading">
@@ -861,7 +858,7 @@ export function createAppMarkup() {
             <select class="select" id="inpaint-checkpoint">
               ${FALLBACK_CHECKPOINTS.map((checkpoint) => `<option value="${checkpoint}">${checkpoint}</option>`).join("")}
             </select>
-            ${createInfoPanelMarkup("inpaint-compatibility-note", "Selection capture is available. Generation needs a mapped inpaint-basic API workflow.")}
+            ${createInfoPanelMarkup("inpaint-compatibility-note", "Capture a Photoshop selection, then generate; the result imports with your exact selection as a layer mask.")}
           </div>
           <div class="settings-grid img2img-settings-grid" aria-label="Inpaint settings">
             <div class="field">
@@ -919,9 +916,6 @@ export function createAppMarkup() {
           </div>
         </div>
 
-        <div class="tool-warning" role="note">
-          Experimental: Outpaint uses Flux Fill and ImagePadForOutpaint to expand captured Photoshop content. Test on duplicate layers first.
-        </div>
 
         <section class="panel-section generator-panel source-panel" aria-label="Outpaint source">
           <div class="section-heading">
@@ -1046,7 +1040,7 @@ export function createAppMarkup() {
         </div>
 
         <div class="tool-warning" role="note">
-          Experimental: Upscale uses pixel/model enlargement only. It does not reinterpret prompts or run diffusion sampling.
+          Upscale uses pixel/model enlargement only. It does not reinterpret prompts or run diffusion sampling.
         </div>
 
         <section class="panel-section generator-panel source-panel" aria-label="Upscale source">

--- a/tests/comfy/presetRegistry.test.ts
+++ b/tests/comfy/presetRegistry.test.ts
@@ -41,10 +41,10 @@ describe("presetRegistry", () => {
     expect(runnableUpscaleIds).toEqual(["upscale-basic"]);
   });
 
-  it("registers upscale-basic as an experimental pixel upscale workflow", () => {
+  it("registers upscale-basic as a stable pixel upscale workflow", () => {
     const preset = getWorkflowPreset("upscale-basic");
 
-    expect(preset.status).toBe("experimental");
+    expect(preset.status).toBe("stable");
     expect(preset.mode).toBe("upscale");
     expect(preset.modelSource.kind).toBe("upscale");
     expect(preset.requiredModels?.some((model) =>
@@ -57,10 +57,10 @@ describe("presetRegistry", () => {
     expect(preset.requiredNodes.some((node) => node.classType === "ImageUpscaleWithModel")).toBe(true);
   });
 
-  it("registers Flux1-dev fp8 text-to-image as an experimental checkpoint workflow", () => {
+  it("registers Flux1-dev fp8 text-to-image as a stable checkpoint workflow", () => {
     const preset = getWorkflowPreset("txt2img-flux1-dev-fp8");
 
-    expect(preset.status).toBe("experimental");
+    expect(preset.status).toBe("stable");
     expect(preset.mode).toBe("txt2img");
     expect(preset.modelSource.kind).toBe("checkpoint");
     expect(preset.supportedModelFamilies).toEqual(["flux"]);
@@ -70,10 +70,10 @@ describe("presetRegistry", () => {
     expect(preset.injections.cfg).toEqual({ nodeId: "35", inputName: "guidance" });
   });
 
-  it("registers Prompt from Layer as an experimental Florence text workflow", () => {
+  it("registers Prompt from Layer as a stable Florence text workflow", () => {
     const preset = getWorkflowPreset("prompt-from-layer-florence2");
 
-    expect(preset.status).toBe("experimental");
+    expect(preset.status).toBe("stable");
     expect(preset.mode).toBe("prompt");
     expect(preset.modelSource.kind).toBe("vision-language");
     expect(preset.capability?.output.kind).toBe("prompt-text");
@@ -89,7 +89,7 @@ describe("presetRegistry", () => {
   it("maps inpaint-basic mask and source injections", () => {
     const preset = getWorkflowPreset("inpaint-basic");
 
-    expect(preset.status).toBe("experimental");
+    expect(preset.status).toBe("stable");
     expect(preset.supportedModelFamilies).toEqual(["sd1"]);
     expect(preset.injections.sourceImage).toEqual({ nodeId: "10", inputName: "image" });
     expect(preset.injections.maskImage).toEqual({ nodeId: "12", inputName: "image" });
@@ -101,7 +101,7 @@ describe("presetRegistry", () => {
   it("registers Flux Fill inpaint as a diffusion model stack preset", () => {
     const preset = getWorkflowPreset("inpaint-flux-fill-basic");
 
-    expect(preset.status).toBe("experimental");
+    expect(preset.status).toBe("stable");
     expect(preset.modelSource.kind).toBe("diffusion-model-stack");
     expect(preset.supportedModelFamilies).toEqual(["flux"]);
     expect(preset.requiredModels?.some((model) => model.modelName === "flux1-fill-dev.safetensors")).toBe(true);
@@ -122,7 +122,7 @@ describe("presetRegistry", () => {
   it("registers Flux Fill outpaint as a diffusion model stack preset", () => {
     const preset = getWorkflowPreset("outpaint-flux-fill-basic");
 
-    expect(preset.status).toBe("experimental");
+    expect(preset.status).toBe("stable");
     expect(preset.mode).toBe("outpaint");
     expect(preset.modelSource.kind).toBe("diffusion-model-stack");
     expect(preset.supportedModelFamilies).toEqual(["flux"]);
@@ -142,7 +142,7 @@ describe("presetRegistry", () => {
   it("marks Krea-2 Turbo as a diffusion model stack preset", () => {
     const preset = getWorkflowPreset("txt2img-krea2-turbo");
 
-    expect(preset.status).toBe("experimental");
+    expect(preset.status).toBe("stable");
     expect(preset.modelSource.kind).toBe("diffusion-model-stack");
     expect(preset.modelStack?.some((model) => model.modelName === "krea2_turbo_fp8_scaled.safetensors")).toBe(true);
     expect(preset.requiredModels?.some((model) => model.modelName === "qwen3vl_4b_fp8_scaled.safetensors")).toBe(true);
@@ -154,7 +154,7 @@ describe("presetRegistry", () => {
   it("marks Z_image_Turbo as a diffusion model stack preset", () => {
     const preset = getWorkflowPreset("txt2img-z-image-turbo");
 
-    expect(preset.status).toBe("experimental");
+    expect(preset.status).toBe("stable");
     expect(preset.modelSource.kind).toBe("diffusion-model-stack");
     expect(preset.modelStack?.some((model) => model.modelName === "z_image_turbo_bf16.safetensors")).toBe(true);
     expect(preset.requiredModels?.some((model) => model.modelName === "qwen_3_4b.safetensors")).toBe(true);

--- a/tests/comfy/workflowCompatibility.test.ts
+++ b/tests/comfy/workflowCompatibility.test.ts
@@ -28,7 +28,7 @@ describe("workflow compatibility", () => {
     expect(imgResult.canRun).toBe(true);
   });
 
-  it("treats Z_image_Turbo as experimental-runnable when its stack is present and keeps future Flux setup-required", () => {
+  it("treats Z_image_Turbo as ready when its stack is present and keeps future Flux setup-required", () => {
     const zImagePreset = getWorkflowPreset("txt2img-z-image-turbo");
     const fluxPreset = getWorkflowPreset("txt2img-flux1-dev");
 
@@ -50,9 +50,9 @@ describe("workflow compatibility", () => {
     });
 
     expect(getWorkflowCapability(zImagePreset).loaderType).toBe("diffusion-model-stack");
-    expect(zImageResult.level).toBe("experimental");
+    expect(zImageResult.level).toBe("ready");
     expect(zImageResult.canRun).toBe(true);
-    expect(zImageResult.issues.some((issue) => issue.code === "WORKFLOW_EXPERIMENTAL")).toBe(true);
+    expect(zImageResult.issues.some((issue) => issue.code === "WORKFLOW_EXPERIMENTAL")).toBe(false);
 
     expect(getWorkflowCapability(fluxPreset).loaderType).toBe("diffusion-model-stack");
     expect(fluxResult.level).toBe("setup-required");
@@ -107,7 +107,7 @@ describe("workflow compatibility", () => {
       photoshopInputs: { selection: true, "selection-mask": true }
     });
 
-    expect(result.level).toBe("experimental");
+    expect(result.level).toBe("ready");
     expect(result.canRun).toBe(true);
     expect(result.issues.some((issue) => issue.code === "MODEL_FILE_MISSING")).toBe(false);
   });
@@ -124,7 +124,7 @@ describe("workflow compatibility", () => {
       photoshopInputs: { selection: true, "selection-mask": true }
     });
 
-    expect(result.level).toBe("experimental");
+    expect(result.level).toBe("ready");
     expect(result.canRun).toBe(true);
     expect(result.issues.some((issue) => issue.code === "MODEL_FILE_MISSING")).toBe(false);
   });
@@ -178,7 +178,7 @@ describe("workflow compatibility", () => {
       photoshopInputs: {}
     });
 
-    expect(fromCanvas.level).toBe("experimental");
+    expect(fromCanvas.level).toBe("ready");
     expect(fromCanvas.canRun).toBe(true);
     expect(missingSource.level).toBe("setup-required");
     expect(missingSource.issues.some((issue) => issue.code === "PHOTOSHOP_INPUT_MISSING")).toBe(true);
@@ -213,7 +213,7 @@ describe("workflow compatibility", () => {
     expect(sketchCapability.controls).toContain("controlStrength");
     expect(inpaintCapability.requiredPhotoshopInputs).toEqual(["selection", "selection-mask"]);
     expect(inpaintCapability.output.kind).toBe("selection-patch");
-    expect(inpaintCapability.uiHints.warning).toContain("experimental");
+    expect(inpaintCapability.uiHints.warning).toBeUndefined();
     expect(outpaintCapability.controls).toContain("outpaintLeft");
     expect(outpaintCapability.controls).toContain("outpaintFeathering");
     expect(outpaintCapability.requiredPhotoshopInputs).toEqual([

--- a/tests/comfy/workflowDiagnostics.test.ts
+++ b/tests/comfy/workflowDiagnostics.test.ts
@@ -78,18 +78,17 @@ describe("workflow diagnostics", () => {
   });
 
   it("summarizes warning messages for Settings diagnostics", () => {
+    const sketchPreset = getWorkflowPreset("sketch2img-linecn-basic");
     const summary = createWorkflowReadinessSummary([
-      createWorkflowDiagnosticMessage(getWorkflowPreset("txt2img-z-image-turbo"), {
-        selectedModelName: "z_image_turbo_bf16.safetensors"
-      }),
-      createWorkflowDiagnosticMessage(getWorkflowPreset("inpaint-basic"), {
-        selectedModelName: "epicrealism_pureEvolutionV5-inpainting.safetensors"
+      createWorkflowDiagnosticMessage(sketchPreset, {
+        selectedModelName: "flux1-dev-fp8.safetensors",
+        availableNodes: createAvailableNodes(sketchPreset),
+        photoshopInputs: { canvas: true }
       })
     ]);
 
-    expect(summary).toContain("Text to Image is experimental");
-    expect(summary).toContain("Inpaint is experimental");
-    expect(summary).toContain("experimental");
+    expect(summary).toContain("Sketch to Image is experimental");
+    expect(summary).toContain("Flux may need a dedicated workflow");
   });
 });
 

--- a/tests/comfy/workflowHealth.test.ts
+++ b/tests/comfy/workflowHealth.test.ts
@@ -22,19 +22,19 @@ describe("workflow health", () => {
     expect(item.canRun).toBe(true);
   });
 
-  it("marks runnable experimental Z_image_Turbo presets as experimental when the full stack is available", () => {
+  it("marks runnable Z_image_Turbo presets as ready when the full stack is available", () => {
     const preset = getWorkflowPreset("txt2img-z-image-turbo");
     const item = createWorkflowHealthItem(preset, {
       availableNodes: createAvailableNodes(preset),
       availableModels: createZImageInventory()
     });
 
-    expect(item.state).toBe("experimental");
-    expect(item.stateLabel).toBe("Experimental");
+    expect(item.state).toBe("ready");
+    expect(item.stateLabel).toBe("Ready");
     expect(item.canRun).toBe(true);
   });
 
-  it("marks Flux1-dev fp8 text-to-image as experimental when the checkpoint workflow is available", () => {
+  it("marks Flux1-dev fp8 text-to-image as ready when the checkpoint workflow is available", () => {
     const preset = getWorkflowPreset("txt2img-flux1-dev-fp8");
     const item = createWorkflowHealthItem(preset, {
       availableNodes: createAvailableNodes(preset),
@@ -43,7 +43,7 @@ describe("workflow health", () => {
       })
     });
 
-    expect(item.state).toBe("experimental");
+    expect(item.state).toBe("ready");
     expect(item.canRun).toBe(true);
     expect(item.detail).toContain("flux1-dev-fp8.safetensors");
   });
@@ -62,19 +62,19 @@ describe("workflow health", () => {
     expect(item.summary).toContain("qwen_3_4b.safetensors");
   });
 
-  it("marks Flux Fill as experimental when its full model stack is available", () => {
+  it("marks Flux Fill as ready when its full model stack is available", () => {
     const preset = getWorkflowPreset("inpaint-flux-fill-basic");
     const item = createWorkflowHealthItem(preset, {
       availableNodes: createAvailableNodes(preset),
       availableModels: createFluxFillInventory()
     });
 
-    expect(item.state).toBe("experimental");
+    expect(item.state).toBe("ready");
     expect(item.canRun).toBe(true);
     expect(item.detail).toContain("t5xxl_fp16.safetensors");
   });
 
-  it("marks Flux Fill as experimental with the accepted fp8 T5 fallback", () => {
+  it("marks Flux Fill as ready with the accepted fp8 T5 fallback", () => {
     const preset = getWorkflowPreset("inpaint-flux-fill-basic");
     const item = createWorkflowHealthItem(preset, {
       availableNodes: createAvailableNodes(preset),
@@ -83,19 +83,19 @@ describe("workflow health", () => {
       })
     });
 
-    expect(item.state).toBe("experimental");
+    expect(item.state).toBe("ready");
     expect(item.canRun).toBe(true);
     expect(item.detail).toContain("t5xxl_fp8_e4m3fn.safetensors");
   });
 
-  it("marks Flux Fill outpaint as experimental when its full model stack is available", () => {
+  it("marks Flux Fill outpaint as ready when its full model stack is available", () => {
     const preset = getWorkflowPreset("outpaint-flux-fill-basic");
     const item = createWorkflowHealthItem(preset, {
       availableNodes: createAvailableNodes(preset),
       availableModels: createFluxFillInventory()
     });
 
-    expect(item.state).toBe("experimental");
+    expect(item.state).toBe("ready");
     expect(item.canRun).toBe(true);
     expect(item.detail).toContain("flux1-fill-dev.safetensors");
   });

--- a/tests/ui/inpaintReadiness.test.ts
+++ b/tests/ui/inpaintReadiness.test.ts
@@ -75,7 +75,7 @@ function createAvailableNodes(preset: typeof basicPreset) {
   return availableNodes;
 }
 
-// inpaint-basic is experimental, so a ready evaluation still carries warnings.
+// inpaint-basic is stable, so a ready evaluation carries no warnings.
 // Everything the graph needs is present here; individual tests remove one thing.
 const readyContext: WorkflowCompatibilityContext = {
   selectedModelName: "epicrealism_naturalSinRC1VAE-inpainting.safetensors",
@@ -115,11 +115,11 @@ describe("Inpaint readiness contract", () => {
     expect(readiness.ok).toBe(true);
   });
 
-  it("surfaces the experimental workflow as a warning rather than a block", () => {
+  it("carries no warnings for the stable workflow when everything lines up", () => {
     const readiness = evaluateBasic();
 
     expect(readiness.ok).toBe(true);
-    expect(readiness.warnings.join(" ")).toMatch(/experimental/i);
+    expect(readiness.warnings).toEqual([]);
   });
 
   it("blocks an unresolved workflow preset", () => {


### PR DESCRIPTION
## Summary
- All 11 runnable experimental presets graduate to `status: "stable"` (13 stable total). The two Flux1-dev `todo` placeholders keep their accurate "setup required" warnings.
- Orange experimental warning panels removed everywhere: preset uiHints, inpaint/outpaint static tool-warning panels, tool-card badges ("in testing", "(spike)"), Live Painting spike wording.
- History `experimental` flag now derives from preset status instead of hardcoded `true` for inpaint/outpaint.
- The **model-family mismatch gate is unchanged** (e.g. selecting a Flux checkpoint on an SD 1.x workflow still warns) — that's correctness, not experiment labeling.
- docs/LIVE_PAINTING_V2.md: steps 1–4 marked done (PRs #19–21), realtime gap + deferred v2.5 plan recorded.
- Validation: typecheck ✓, 287/287 tests ✓, build ✓.

## Photoshop smoke checklist
1. Reload the plugin and confirm the bundle hash changed (`dist/assets/index-*.js`).
2. Home: no tool card shows an "Experimental" badge; subtitles read clean.
3. Open each tool (txt2img, img2img, Prompt from Layer, Sketch, Inpaint, Outpaint, Upscale, Live Painting): **no orange warning panel** anywhere.
4. Inpaint + Outpaint: run one generation each; result imports correctly; History entry no longer flagged experimental.
5. Live Painting screen: header says "Two-tier session", status "Live Painting ready." — start/stop + refine still work.
6. Settings → Check Workflow Health: runnable presets show **Ready** (green), the two Flux1-dev entries still show setup-required.
7. Select a Flux checkpoint on an SD workflow: the model-family warning still appears (this must NOT have disappeared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)