### PR TITLE
Drop the comfyui-custom-scripts requirement from Prompt from Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Known v0.6.0-alpha boundaries:
 - Workflow Health now gives beginner-friendly next checks for missing models, missing ComfyUI nodes, missing workflow JSON, setup-required presets, and experimental presets.
 - Persistent Photoshop layer metadata is not confirmed safe in this UXP environment yet. OpenLayer keeps structured metadata in session history and prepares a serialized payload for future persistence.
 - Copy Diagnostics prepares a setup report for testers. It does not send data anywhere.
-- Prompt from Layer requires `comfyui-florence2`, `comfyui-custom-scripts`, and `Florence-2-base-PromptGen-v2.0`.
+- Prompt from Layer requires `comfyui-florence2` and `Florence-2-base-PromptGen-v2.0`. The `comfyui-custom-scripts` pack is no longer needed.
 - Outpaint is experimental and currently uses `outpaint-flux-fill-basic` with `flux1-fill-dev.safetensors`, `clip_l.safetensors`, `t5xxl_fp16.safetensors` or the accepted T5 fp8 fallback, and `ae.safetensors`.
 - Upscale currently uses a simple pixel/model upscale path. It does not use prompts, latent upscale, tiled diffusion, or creative enhancement.
 - Upscale needs ComfyUI's `UpscaleModelLoader` and `ImageUpscaleWithModel` nodes plus an installed upscale model such as `4x-UltraSharp.pth` or `RealESRGAN_x4plus.pth`.

--- a/docs/model-guide.md
+++ b/docs/model-guide.md
@@ -78,8 +78,12 @@ Prompt from Layer uses a vision-language workflow, not a diffusion image model. 
 Required local setup:
 
 - `comfyui-florence2`
-- `comfyui-custom-scripts` for `ShowText|pysssss`
 - `Florence-2-base-PromptGen-v2.0` available to `Florence2ModelLoader`
+
+`comfyui-custom-scripts` is no longer required. The workflow used to end in that pack's
+`ShowText|pysssss` node; it now ends in core ComfyUI's `PreviewAny`, which publishes the caption in
+the same history shape. The node cannot simply be deleted — `Florence2Run` is not an output node, so
+a graph without one is refused by ComfyUI before it runs.
 
 OpenLayer uploads the captured Photoshop source PNG to ComfyUI, runs Florence-2 PromptGen, reads the text output from ComfyUI history, and places the generated caption into the plugin text area. The default task is `detailed_caption` with `num_beams` set to `12`.
 

--- a/docs/workflow-files.md
+++ b/docs/workflow-files.md
@@ -85,15 +85,14 @@ The runnable API workflow uses:
 - `Florence2ModelLoader`
 - `LoadImage`
 - `Florence2Run`
-- `ShowText|pysssss`
+- `PreviewAny` (core ComfyUI)
 
 Required local setup:
 
 - `comfyui-florence2`
-- `comfyui-custom-scripts`
 - `Florence-2-base-PromptGen-v2.0`
 
-The source workflow also includes preview/save text helper nodes. OpenLayer does not rely on the `SaveText` node for normal operation; it reads the text output from the completed prompt history.
+`PreviewAny` is what makes the graph runnable, not just readable. `Florence2Run` is not an output node, so a graph containing only the three Florence nodes has no output at all and ComfyUI refuses to queue it. `PreviewAny` publishes the caption under `outputs[<node>].text`, exactly as the `ShowText|pysssss` node it replaced did — which is why dropping the `comfyui-custom-scripts` requirement was a swap rather than a deletion.
 
 ## Why Flux Is Different
 

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -273,7 +273,11 @@ const PROMPT_FROM_LAYER_FLORENCE2_NODES = {
   modelLoader: "39",
   loadImage: "42",
   florenceRun: "38",
-  showText: "45"
+  // Florence2Run is not an OUTPUT_NODE, so the graph needs one or ComfyUI
+  // refuses to queue it and no caption ever reaches history. PreviewAny is
+  // core (comfy_extras.nodes_preview_any) and publishes the same
+  // {"ui": {"text": [...]}} shape the pysssss ShowText node did.
+  textPreview: "41"
 } as const;
 
 const UPSCALE_BASIC_NODES = {
@@ -947,7 +951,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     requiredModels: [FLORENCE2_PROMPTGEN_MODEL],
     injections: PROMPT_FROM_LAYER_FLORENCE2_INJECTIONS,
     compatibilityNote:
-      "prompt-from-layer-florence2 uses comfyui-florence2 plus ShowText from comfyui-custom-scripts. It returns text from ComfyUI history instead of an image.",
+      "prompt-from-layer-florence2 needs only comfyui-florence2. The caption is published by core ComfyUI's PreviewAny node, so it returns text from ComfyUI history instead of an image.",
     requiredNodes: [
       {
         id: PROMPT_FROM_LAYER_FLORENCE2_NODES.modelLoader,
@@ -965,9 +969,9 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
         requiredInputs: ["image", "florence2_model", "text_input", "task", "fill_mask"]
       },
       {
-        id: PROMPT_FROM_LAYER_FLORENCE2_NODES.showText,
-        classType: "ShowText|pysssss",
-        requiredInputs: ["text"]
+        id: PROMPT_FROM_LAYER_FLORENCE2_NODES.textPreview,
+        classType: "PreviewAny",
+        requiredInputs: ["source"]
       }
     ]
   },
@@ -1701,6 +1705,20 @@ export function getWorkflowPreset(presetId: string): WorkflowPresetDefinition {
 
 export function isWorkflowPreset(presetId: string): presetId is WorkflowPreset {
   return WORKFLOW_PRESETS.some((preset) => preset.id === presetId);
+}
+
+/**
+ * ComfyUI node classes that publish text into a history entry's `outputs`.
+ * Both shapes seen here return `{"ui": {"text": [...]}}`; `PreviewAny` is core,
+ * `ShowText|pysssss` is the comfyui-custom-scripts node OpenLayer used to
+ * require and is still accepted so hand-edited workflows keep working.
+ */
+const TEXT_OUTPUT_NODE_CLASS_TYPES = ["PreviewAny", "ShowText|pysssss"] as const;
+
+export function getPresetTextOutputNodeId(preset: WorkflowPresetDefinition): string | undefined {
+  return preset.requiredNodes.find((node) =>
+    TEXT_OUTPUT_NODE_CLASS_TYPES.some((classType) => node.classType === classType)
+  )?.id;
 }
 
 export type RecommendedPresetSettings = {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -58,6 +58,7 @@ import {
 } from "../metadata/layerMetadata";
 import { getCheckpointCompatibility } from "../comfy/modelCompatibility";
 import {
+  getPresetTextOutputNodeId,
   getRecommendedPresetSettings,
   getWorkflowPreset,
   listRunnableWorkflowPresets,
@@ -3056,7 +3057,7 @@ export function renderApp(rootElement: HTMLElement) {
         numBeams,
         seed
       });
-      const textOutputNodeId = getTextOutputNodeId(workflowResult.preset);
+      const textOutputNodeId = getPresetTextOutputNodeId(workflowResult.preset);
 
       setPromptLayerStatus(elements, "Running Florence-2 PromptGen...", "idle");
       setPromptLayerDiagnostics(
@@ -4108,10 +4109,6 @@ function createSourceMetaText(source: ExportedSourceImage) {
 
 function getSaveImageNodeId(preset: WorkflowPresetDefinition) {
   return preset.requiredNodes.find((node) => node.classType === "SaveImage")?.id;
-}
-
-function getTextOutputNodeId(preset: WorkflowPresetDefinition) {
-  return preset.requiredNodes.find((node) => node.classType.startsWith("ShowText"))?.id;
 }
 
 function readPromptLayerTask(elements: AppElements) {

--- a/src/workflows/api/prompt-from-layer-florence2.json
+++ b/src/workflows/api/prompt-from-layer-florence2.json
@@ -44,16 +44,16 @@
       "title": "Run Florence-2 PromptGen"
     }
   },
-  "45": {
-    "class_type": "ShowText|pysssss",
+  "41": {
+    "class_type": "PreviewAny",
     "inputs": {
-      "text": [
+      "source": [
         "38",
         2
       ]
     },
     "_meta": {
-      "title": "Show generated prompt text"
+      "title": "Preview generated prompt text"
     }
   }
 }

--- a/src/workflows/source/README.md
+++ b/src/workflows/source/README.md
@@ -30,7 +30,7 @@ The runnable OpenLayer API versions are in `src/workflows/api/`. If the GUI work
 
 `prompt-from-layer-florence2.workflow.json` is the GUI-editable Florence-2 PromptGen workflow for the Prompt from Layer tool.
 
-The runnable API version is in `src/workflows/api/prompt-from-layer-florence2.json`. It uses Florence2ModelLoader, LoadImage, Florence2Run, and ShowText to return caption text through ComfyUI history. If this source workflow is edited in ComfyUI, export a matching API workflow and update `src/comfy/presetRegistry.ts` node mappings before relying on it.
+The runnable API version is in `src/workflows/api/prompt-from-layer-florence2.json`. It uses Florence2ModelLoader, LoadImage, Florence2Run, and core ComfyUI's PreviewAny to return caption text through ComfyUI history. The `ShowText|pysssss` and `SaveText|pysssss` nodes this graph used to carry were removed so the preset needs no `comfyui-custom-scripts` install; PreviewAny was already wired to the same caption output. If this source workflow is edited in ComfyUI, export a matching API workflow and update `src/comfy/presetRegistry.ts` node mappings before relying on it — `tests/comfy/workflowFiles.test.ts` fails if the two drift apart.
 
 ## Flux Fill Notes
 

--- a/src/workflows/source/prompt-from-layer-florence2.workflow.json
+++ b/src/workflows/source/prompt-from-layer-florence2.workflow.json
@@ -85,50 +85,6 @@
       "widgets_values": []
     },
     {
-      "id": 43,
-      "type": "SaveText|pysssss",
-      "pos": [
-        1074.7272137707923,
-        764.6091738797028
-      ],
-      "size": [
-        270,
-        130
-      ],
-      "flags": {},
-      "order": 5,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "text",
-          "type": "STRING",
-          "link": 61
-        }
-      ],
-      "outputs": [
-        {
-          "name": "STRING",
-          "type": "STRING",
-          "links": null
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfyui-custom-scripts",
-        "ver": "1.2.5",
-        "ue_properties": {
-          "widget_ue_connectable": {},
-          "input_ue_unconnectable": {}
-        },
-        "Node name for S&R": "SaveText|pysssss"
-      },
-      "widgets_values": [
-        "input",
-        "file.txt",
-        "append",
-        true
-      ]
-    },
-    {
       "id": 42,
       "type": "LoadImage",
       "pos": [
@@ -217,9 +173,7 @@
           "name": "caption",
           "type": "STRING",
           "links": [
-            59,
-            61,
-            63
+            59
           ]
         },
         {
@@ -249,48 +203,6 @@
         "",
         284075328336101,
         "randomize"
-      ]
-    },
-    {
-      "id": 45,
-      "type": "ShowText|pysssss",
-      "pos": [
-        1032.3334223631023,
-        460.6842525814802
-      ],
-      "size": [
-        307.22540177843143,
-        223.46881422654906
-      ],
-      "flags": {},
-      "order": 6,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "text",
-          "type": "STRING",
-          "link": 63
-        }
-      ],
-      "outputs": [
-        {
-          "name": "STRING",
-          "shape": 6,
-          "type": "STRING",
-          "links": null
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfyui-custom-scripts",
-        "ver": "1.2.5",
-        "ue_properties": {
-          "widget_ue_connectable": {},
-          "input_ue_unconnectable": {}
-        },
-        "Node name for S&R": "ShowText|pysssss"
-      },
-      "widgets_values": [
-        "The image shows a sculpture of a ghostly figure suspended in mid-air, suspended from a skylight above an empty room with concrete floors and white walls. The sculpture is made of white, fluid-like material that appears to be suspended in the air, creating a surreal and eerie atmosphere. On the right side of the image, there is a black and white abstract painting hanging on the wall. The room has a modern, minimalist design with clean lines and a minimalist aesthetic. The image is taken from a low angle, looking up at the sculpture."
       ]
     },
     {
@@ -348,22 +260,6 @@
       38,
       0,
       "IMAGE"
-    ],
-    [
-      61,
-      38,
-      2,
-      43,
-      0,
-      "STRING"
-    ],
-    [
-      63,
-      38,
-      2,
-      45,
-      0,
-      "STRING"
     ]
   ],
   "groups": [],

--- a/tests/comfy/presetRegistry.test.ts
+++ b/tests/comfy/presetRegistry.test.ts
@@ -80,7 +80,7 @@ describe("presetRegistry", () => {
     expect(preset.requiredModels?.some((model) => model.modelName === "Florence-2-base-PromptGen-v2.0")).toBe(true);
     expect(preset.requiredNodes.some((node) => node.classType === "Florence2ModelLoader")).toBe(true);
     expect(preset.requiredNodes.some((node) => node.classType === "Florence2Run")).toBe(true);
-    expect(preset.requiredNodes.some((node) => node.classType === "ShowText|pysssss")).toBe(true);
+    expect(preset.requiredNodes.some((node) => node.classType === "PreviewAny")).toBe(true);
     expect(preset.injections.sourceImage).toEqual({ nodeId: "42", inputName: "image" });
     expect(preset.injections.task).toEqual({ nodeId: "38", inputName: "task" });
     expect(preset.injections.numBeams).toEqual({ nodeId: "38", inputName: "num_beams" });

--- a/tests/comfy/workflowBuilder.test.ts
+++ b/tests/comfy/workflowBuilder.test.ts
@@ -99,7 +99,7 @@ describe("workflowBuilder", () => {
     expect(result.workflow["38"].inputs.task).toBe("detailed_caption");
     expect(result.workflow["38"].inputs.num_beams).toBe(12);
     expect(result.workflow["38"].inputs.seed).toBe(202607);
-    expect(result.workflow["45"].inputs.text).toEqual(["38", 2]);
+    expect(result.workflow["41"].inputs.source).toEqual(["38", 2]);
   });
 
   it("injects source image and model into upscale-basic", async () => {

--- a/tests/comfy/workflowFiles.test.ts
+++ b/tests/comfy/workflowFiles.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  getPresetTextOutputNodeId,
+  getWorkflowPreset,
+  listRunnableWorkflowPresets,
+  validateWorkflowForPreset
+} from "../../src/comfy/presetRegistry";
+import { ComfyWorkflow, WorkflowPresetDefinition } from "../../src/comfy/types";
+
+const SRC_ROOT = resolve(__dirname, "../../src");
+
+function loadApiWorkflow(preset: WorkflowPresetDefinition): ComfyWorkflow {
+  return JSON.parse(readFileSync(resolve(SRC_ROOT, preset.workflowFile), "utf8")) as ComfyWorkflow;
+}
+
+/**
+ * Every ComfyUI node class used by a runnable preset that does NOT ship with
+ * core ComfyUI, and the repository that provides it. Freezing this list is the
+ * point of the test: a preset that quietly reintroduces a custom-node
+ * dependency is a setup burden pushed onto every user, and it should not be
+ * possible to add one without editing this line.
+ */
+const EXPECTED_CUSTOM_NODE_CLASSES: Record<string, string> = {
+  LineArtPreprocessor: "comfyui_controlnet_aux",
+  Florence2ModelLoader: "ComfyUI-Florence2",
+  Florence2Run: "ComfyUI-Florence2"
+};
+
+describe("shipped API workflow files", () => {
+  const runnablePresets = listRunnableWorkflowPresets();
+
+  it("ships a workflow file for every runnable preset", () => {
+    expect(runnablePresets.length).toBeGreaterThan(0);
+
+    for (const preset of runnablePresets) {
+      expect(() => loadApiWorkflow(preset), `${preset.id} workflow file is missing`).not.toThrow();
+    }
+  });
+
+  it("keeps every runnable preset's node mapping in sync with its workflow JSON", () => {
+    for (const preset of runnablePresets) {
+      const workflow = loadApiWorkflow(preset);
+
+      expect(
+        () => validateWorkflowForPreset(workflow, preset),
+        `${preset.id} registry mapping drifted from its workflow JSON`
+      ).not.toThrow();
+    }
+  });
+
+  it("requires no custom nodes beyond the frozen inventory", () => {
+    const seen = new Set<string>();
+
+    for (const preset of runnablePresets) {
+      for (const node of preset.requiredNodes) {
+        if (node.classType in EXPECTED_CUSTOM_NODE_CLASSES) {
+          seen.add(node.classType);
+        }
+
+        // pysssss-style nodes namespace themselves with a pipe. None should
+        // remain: Prompt from Layer now publishes its caption through core
+        // ComfyUI's PreviewAny instead of ShowText|pysssss.
+        expect(node.classType, `${preset.id} requires a namespaced custom node`).not.toContain("|");
+      }
+    }
+
+    expect([...seen].sort()).toEqual(Object.keys(EXPECTED_CUSTOM_NODE_CLASSES).sort());
+  });
+});
+
+describe("getPresetTextOutputNodeId", () => {
+  it("finds the PreviewAny node that publishes the Florence caption", () => {
+    const preset = getWorkflowPreset("prompt-from-layer-florence2");
+
+    expect(getPresetTextOutputNodeId(preset)).toBe("41");
+  });
+
+  it("returns undefined for presets that produce images rather than text", () => {
+    expect(getPresetTextOutputNodeId(getWorkflowPreset("txt2img-basic"))).toBeUndefined();
+    expect(getPresetTextOutputNodeId(getWorkflowPreset("upscale-basic"))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Prompt from Layer was the only preset pulling in pythongosssss's `comfyui-custom-scripts`, for a single node that displays text. Dropping a whole custom-node install from the setup burden is worth doing before the setup pack starts telling people to install it.

### It is a swap, not a deletion

The brief assumed the node could just be removed. It can't, and `object_info` on the live server says why:

- `Florence2Run` → `output_node: false`
- `ShowText|pysssss` → `output_node: true`, `python_module: custom_nodes.comfyui-custom-scripts`
- `PreviewAny` → `output_node: true`, `python_module: comfy_extras.nodes_preview_any` (**core**)

A graph of only the three Florence nodes has no output node, so ComfyUI refuses to queue it — and even if it ran, the caption would never land in `/history`, which is where OpenLayer reads it from. `PreviewAny` publishes under the same `{"ui": {"text": [...]}}` shape, so `findTextOutput` needs no change.

Corroborating evidence: the GUI source workflow **already had** a `PreviewAny` node (id 41) wired to the same `Florence2Run` caption output. The API export had simply kept `ShowText` instead. The API workflow now uses node 41 / `PreviewAny`, matching the source graph, and the source graph loses its `ShowText|pysssss` and `SaveText|pysssss` nodes so both formats are core-only — someone opening the reference graph in ComfyUI is no longer silently asked to install the pack anyway.

### Changed
- `src/workflows/api/prompt-from-layer-florence2.json` — node `45`/`ShowText|pysssss` → `41`/`PreviewAny`.
- `src/workflows/source/prompt-from-layer-florence2.workflow.json` — removed both pysssss nodes and their links (105 deletions, no additions).
- `src/comfy/presetRegistry.ts` — node map, `requiredNodes`, compatibility note; new exported `getPresetTextOutputNodeId`.
- `src/ui/App.ts` — the ad-hoc `classType.startsWith("ShowText")` predicate is replaced by that registry helper. Hand-edited workflows still ending in `ShowText` keep working.
- Docs: `README.md`, `docs/model-guide.md`, `docs/workflow-files.md`, `src/workflows/source/README.md`.

### New tests
- **Workflow files match the registry** — loads every shipped API workflow JSON and runs `validateWorkflowForPreset` against its preset. *Nothing did this before*, so the registry and the files it describes could drift apart silently — exactly the failure this change could have introduced.
- **Custom-node inventory frozen** — three classes across two repos (`LineArtPreprocessor`, `Florence2ModelLoader`, `Florence2Run`), plus a hard fail on any pipe-namespaced node class. Reintroducing a pack dependency now requires editing that list on purpose.

### Validation
`npm run typecheck` ✅ · `npm test` ✅ **292/292** (287 + 5 new) · `npm run build` ✅ · `dist/` API workflow confirmed to contain only `Florence2Run`, `Florence2ModelLoader`, `PreviewAny`, `LoadImage`.

Touches no `src/photoshop/*` and no `generationController`. No §2 invariant in scope.

### Smoke checklist (Photoshop) — this is the real gate
The ComfyUI query was kept read-only, so **no prompt was queued and the caption round-trip is unverified at runtime**. That is what these steps prove:

1. Load `dist/` in UDT, open **Plugins → OpenLayer**.
2. Open any document with visible artwork on a layer. Select that layer.
3. **Prompt from Layer** → **Capture Layer** → confirm the source thumbnail appears.
4. **Generate Text from Layer**. Watch the status line go through "Running Florence-2 PromptGen…".
5. **A caption must appear in the generated-text box.** If the box stays empty or you get a text-output error, the swap failed — say so and I'll revert to `ShowText`.
6. Click **Use as Prompt** (or copy it) and confirm the text carries into a prompt field.
7. Optional but useful: in ComfyUI's own UI, open `src/workflows/source/prompt-from-layer-florence2.workflow.json` and confirm it loads with no red "missing node" boxes.

If you have `comfyui-custom-scripts` still installed, step 5 passing does not prove the dependency is gone — but the workflow JSON no longer references it, and the frozen-inventory test does.