### PR TITLE
Verified download URLs + derived install folders for every required model

### DIFF
--- a/src/comfy/modelFolders.ts
+++ b/src/comfy/modelFolders.ts
@@ -1,0 +1,111 @@
+import { WorkflowModelFolder, WorkflowPresetDefinition, WorkflowRequiredModel } from "./types";
+import { createOpenLayerError } from "../utils/errors";
+
+/**
+ * Which folder under ComfyUI's `models/` each loader node actually reads.
+ *
+ * This mapping exists exactly once. Every consumer — the setup pack, the
+ * downloader it generates, the future in-panel Setup tab — derives folders from
+ * here rather than restating them, because a restated folder is a folder that
+ * can drift from the preset it describes.
+ *
+ * Getting this wrong is the most common OpenLayer setup failure and it fails
+ * quietly: `CheckpointLoaderSimple` reads `models/checkpoints/` while
+ * `UNETLoader` reads `models/diffusion_models/`, so a Flux model dropped in the
+ * checkpoints folder is simply invisible, and the panel can only say the model
+ * is missing. Verified against the live ComfyUI at 127.0.0.1:8190 via
+ * `GET /models/<folder>` rather than assumed:
+ *   - `text_encoders` holds clip_l/t5xxl/qwen; the legacy `clip` folder is empty
+ *   - `Florence2ModelLoader` states its own location in its input tooltip
+ *     ("models are expected to be in Comfyui/models/LLM folder")
+ */
+export const MODEL_FOLDER_BY_OBJECT_INFO_NODE = {
+  CheckpointLoaderSimple: "checkpoints",
+  UNETLoader: "diffusion_models",
+  CLIPLoader: "text_encoders",
+  DualCLIPLoader: "text_encoders",
+  VAELoader: "vae",
+  ControlNetLoader: "controlnet",
+  UpscaleModelLoader: "upscale_models",
+  Florence2ModelLoader: "LLM"
+} as const satisfies Record<string, WorkflowModelFolder>;
+
+export type MappedModelLoaderNode = keyof typeof MODEL_FOLDER_BY_OBJECT_INFO_NODE;
+
+export function isMappedModelLoaderNode(objectInfoNode: string): objectInfoNode is MappedModelLoaderNode {
+  return objectInfoNode in MODEL_FOLDER_BY_OBJECT_INFO_NODE;
+}
+
+/**
+ * The folder a model belongs in, derived from the loader that reads it.
+ * Throws rather than guessing: a preset that names an unmapped loader would
+ * otherwise produce setup instructions that quietly send files nowhere.
+ */
+export function getModelTargetFolder(model: WorkflowRequiredModel): WorkflowModelFolder {
+  if (model.targetFolder) {
+    return model.targetFolder;
+  }
+
+  if (!isMappedModelLoaderNode(model.objectInfoNode)) {
+    throw createOpenLayerError(
+      "WORKFLOW_INVALID",
+      `No ComfyUI model folder is mapped for the ${model.objectInfoNode} loader.`,
+      `Add ${model.objectInfoNode} to MODEL_FOLDER_BY_OBJECT_INFO_NODE in src/comfy/modelFolders.ts.`
+    );
+  }
+
+  return MODEL_FOLDER_BY_OBJECT_INFO_NODE[model.objectInfoNode];
+}
+
+/** Install path relative to the ComfyUI root, e.g. `models/diffusion_models`. */
+export function getModelTargetPath(model: WorkflowRequiredModel): string {
+  return `models/${getModelTargetFolder(model)}`;
+}
+
+/**
+ * Identity of a model for de-duplication. Two presets naming the same file for
+ * the same loader are the same download — `ae.safetensors` is shared by the
+ * Flux Fill and Z_image_Turbo stacks, and should be fetched once.
+ */
+export function getRequiredModelKey(model: WorkflowRequiredModel): string {
+  return `${getModelTargetFolder(model)}/${model.modelName}`;
+}
+
+/**
+ * Every model a preset needs, de-duplicated. `modelStack` and `requiredModels`
+ * deliberately overlap in the registry (the stack drives model selection, the
+ * requirement list drives health checks), so callers must not concatenate them
+ * blindly.
+ */
+export function listPresetRequiredModels(preset: WorkflowPresetDefinition): WorkflowRequiredModel[] {
+  const byKey = new Map<string, WorkflowRequiredModel>();
+
+  for (const model of [...(preset.requiredModels ?? []), ...(preset.modelStack ?? [])]) {
+    const key = getRequiredModelKey(model);
+
+    if (!byKey.has(key)) {
+      byKey.set(key, model);
+    }
+  }
+
+  return [...byKey.values()];
+}
+
+/** Models across several presets, de-duplicated the same way. */
+export function listRequiredModelsForPresets(
+  presets: readonly WorkflowPresetDefinition[]
+): WorkflowRequiredModel[] {
+  const byKey = new Map<string, WorkflowRequiredModel>();
+
+  for (const preset of presets) {
+    for (const model of listPresetRequiredModels(preset)) {
+      const key = getRequiredModelKey(model);
+
+      if (!byKey.has(key)) {
+        byKey.set(key, model);
+      }
+    }
+  }
+
+  return [...byKey.values()];
+}

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -3,11 +3,41 @@ import {
   WorkflowInputTarget,
   WorkflowInjectionTargetList,
   WorkflowCapability,
+  WorkflowModelLicenseGate,
   WorkflowPreset,
   WorkflowPresetDefinition,
   WorkflowNodeRequirement
 } from "./types";
 import { createOpenLayerError } from "../utils/errors";
+
+/*
+ * Download metadata for required models.
+ *
+ * Every `downloadUrl` below was verified with a live HEAD request, and every
+ * `downloadSizeBytes` is the Content-Length that request returned. Where the
+ * model is also installed on the development rig, the served Content-Length
+ * matches the local file byte for byte — so these are the files that are known
+ * to work, not merely files with the right name.
+ *
+ * Publisher repositories are preferred, except where the publisher's repo is
+ * gated behind an access request. `black-forest-labs/FLUX.1-dev` and
+ * `FLUX.1-Fill-dev` both answer 401 without a user token, so the Flux weights
+ * point at Comfy-Org's public repackaging instead. That changes how the file is
+ * fetched, not what it is licensed as, which is why they still carry a
+ * licence gate.
+ */
+
+const FLUX1_DEV_LICENSE: WorkflowModelLicenseGate = {
+  name: "FLUX.1 [dev] Non-Commercial License",
+  url: "https://huggingface.co/black-forest-labs/FLUX.1-dev/blob/main/LICENSE.md",
+  summary:
+    "Black Forest Labs restricts these weights to non-commercial use. Read the licence before downloading them or publishing work made with them."
+};
+
+const COMFY_ORG_FLUX1_DEV_REPO = "https://huggingface.co/Comfy-Org/flux1-dev";
+const COMFY_ORG_Z_IMAGE_TURBO_REPO = "https://huggingface.co/Comfy-Org/z_image_turbo";
+const COMFY_ORG_KREA2_REPO = "https://huggingface.co/Comfy-Org/Krea-2";
+const FLUX_TEXT_ENCODERS_REPO = "https://huggingface.co/comfyanonymous/flux_text_encoders";
 
 const CHECKPOINT_MODEL_SOURCE = {
   kind: "checkpoint",
@@ -44,7 +74,10 @@ const Z_IMAGE_TURBO_STACK = [
     inputName: "unet_name",
     label: "Z_image_Turbo diffusion model",
     modelName: "z_image_turbo_bf16.safetensors",
-    setupHint: "Install z_image_turbo_bf16.safetensors where ComfyUI's UNETLoader can find it."
+    setupHint: "Install z_image_turbo_bf16.safetensors where ComfyUI's UNETLoader can find it.",
+    downloadUrl: `${COMFY_ORG_Z_IMAGE_TURBO_REPO}/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors`,
+    sourcePageUrl: COMFY_ORG_Z_IMAGE_TURBO_REPO,
+    downloadSizeBytes: 12309866400
   },
   {
     kind: "clip",
@@ -52,15 +85,24 @@ const Z_IMAGE_TURBO_STACK = [
     inputName: "clip_name",
     label: "Z_image_Turbo CLIP",
     modelName: "qwen_3_4b.safetensors",
-    setupHint: "Install qwen_3_4b.safetensors where ComfyUI's CLIPLoader can find it."
+    setupHint: "Install qwen_3_4b.safetensors where ComfyUI's CLIPLoader can find it.",
+    downloadUrl: `${COMFY_ORG_Z_IMAGE_TURBO_REPO}/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors`,
+    sourcePageUrl: COMFY_ORG_Z_IMAGE_TURBO_REPO,
+    downloadSizeBytes: 8044982048
   },
   {
+    // The same 335 MB autoencoder the Flux Fill stack loads. Comfy-Org
+    // republishes it inside the Z-Image bundle, which is the only public
+    // source: Black Forest Labs' own copy sits behind a gated repo.
     kind: "vae",
     objectInfoNode: "VAELoader",
     inputName: "vae_name",
     label: "Z_image_Turbo VAE",
     modelName: "ae.safetensors",
-    setupHint: "Install ae.safetensors where ComfyUI's VAELoader can find it."
+    setupHint: "Install ae.safetensors where ComfyUI's VAELoader can find it.",
+    downloadUrl: `${COMFY_ORG_Z_IMAGE_TURBO_REPO}/resolve/main/split_files/vae/ae.safetensors`,
+    sourcePageUrl: COMFY_ORG_Z_IMAGE_TURBO_REPO,
+    downloadSizeBytes: 335304388
   }
 ] as const;
 
@@ -71,7 +113,10 @@ const KREA2_TURBO_STACK = [
     inputName: "unet_name",
     label: "Krea-2 Turbo diffusion model",
     modelName: "krea2_turbo_fp8_scaled.safetensors",
-    setupHint: "Install krea2_turbo_fp8_scaled.safetensors where ComfyUI's UNETLoader can find it."
+    setupHint: "Install krea2_turbo_fp8_scaled.safetensors where ComfyUI's UNETLoader can find it.",
+    downloadUrl: `${COMFY_ORG_KREA2_REPO}/resolve/main/diffusion_models/krea2_turbo_fp8_scaled.safetensors`,
+    sourcePageUrl: COMFY_ORG_KREA2_REPO,
+    downloadSizeBytes: 13141730784
   },
   {
     kind: "clip",
@@ -79,7 +124,10 @@ const KREA2_TURBO_STACK = [
     inputName: "clip_name",
     label: "Krea-2 text encoder",
     modelName: "qwen3vl_4b_fp8_scaled.safetensors",
-    setupHint: "Install qwen3vl_4b_fp8_scaled.safetensors in ComfyUI models/text_encoders."
+    setupHint: "Install qwen3vl_4b_fp8_scaled.safetensors in ComfyUI models/text_encoders.",
+    downloadUrl: `${COMFY_ORG_KREA2_REPO}/resolve/main/text_encoders/qwen3vl_4b_fp8_scaled.safetensors`,
+    sourcePageUrl: COMFY_ORG_KREA2_REPO,
+    downloadSizeBytes: 5242467968
   },
   {
     kind: "vae",
@@ -87,7 +135,10 @@ const KREA2_TURBO_STACK = [
     inputName: "vae_name",
     label: "Qwen image VAE",
     modelName: "qwen_image_vae.safetensors",
-    setupHint: "Install qwen_image_vae.safetensors where ComfyUI's VAELoader can find it."
+    setupHint: "Install qwen_image_vae.safetensors where ComfyUI's VAELoader can find it.",
+    downloadUrl: `${COMFY_ORG_KREA2_REPO}/resolve/main/vae/qwen_image_vae.safetensors`,
+    sourcePageUrl: COMFY_ORG_KREA2_REPO,
+    downloadSizeBytes: 253806246
   }
 ] as const;
 
@@ -98,17 +149,28 @@ const FLUX1_DEV_STACK = [
     inputName: "unet_name",
     label: "Flux diffusion model",
     modelName: "flux1-dev.safetensors",
-    setupHint: "Install flux1-dev.safetensors where ComfyUI's UNETLoader can find it."
+    setupHint: "Install flux1-dev.safetensors where ComfyUI's UNETLoader can find it.",
+    downloadUrl: `${COMFY_ORG_FLUX1_DEV_REPO}/resolve/main/flux1-dev.safetensors`,
+    sourcePageUrl: "https://huggingface.co/black-forest-labs/FLUX.1-dev",
+    downloadSizeBytes: 23802932552,
+    licenseGate: FLUX1_DEV_LICENSE
   }
 ] as const;
 
 const FLUX1_DEV_FP8_CHECKPOINT = {
+  // An all-in-one checkpoint: UNET, both text encoders, and the VAE in one
+  // file. A UNET-only "flux1-dev-fp8" from elsewhere will load and then fail
+  // for want of CLIP, which is why the URL and size are pinned here.
   kind: "checkpoint",
   objectInfoNode: "CheckpointLoaderSimple",
   inputName: "ckpt_name",
   label: "Flux1-dev fp8 checkpoint",
   modelName: "flux1-dev-fp8.safetensors",
-  setupHint: "Install flux1-dev-fp8.safetensors where ComfyUI's CheckpointLoaderSimple can find it."
+  setupHint: "Install flux1-dev-fp8.safetensors where ComfyUI's CheckpointLoaderSimple can find it.",
+  downloadUrl: `${COMFY_ORG_FLUX1_DEV_REPO}/resolve/main/flux1-dev-fp8.safetensors`,
+  sourcePageUrl: "https://huggingface.co/black-forest-labs/FLUX.1-dev",
+  downloadSizeBytes: 17246524772,
+  licenseGate: FLUX1_DEV_LICENSE
 } as const;
 
 const FLORENCE2_PROMPTGEN_MODEL = {
@@ -117,7 +179,11 @@ const FLORENCE2_PROMPTGEN_MODEL = {
   inputName: "model",
   label: "Florence-2 PromptGen model",
   modelName: "Florence-2-base-PromptGen-v2.0",
-  setupHint: "Install Florence-2-base-PromptGen-v2.0 where ComfyUI's Florence2ModelLoader can find it."
+  setupHint:
+    "Clone the whole Florence-2-base-PromptGen-v2.0 repository into ComfyUI models/LLM. Florence2ModelLoader loads a model directory, not a single file.",
+  downloadUrl: "https://huggingface.co/MiaoshouAI/Florence-2-base-PromptGen-v2.0",
+  sourcePageUrl: "https://huggingface.co/MiaoshouAI/Florence-2-base-PromptGen-v2.0",
+  downloadLayout: "repo-folder"
 } as const;
 
 const UPSCALE_BASIC_MODEL = {
@@ -127,7 +193,10 @@ const UPSCALE_BASIC_MODEL = {
   label: "Upscale model",
   modelName: "4x-UltraSharp.pth",
   acceptedModelNames: ["RealESRGAN_x4plus.pth"],
-  setupHint: "Install 4x-UltraSharp.pth or RealESRGAN_x4plus.pth where ComfyUI's UpscaleModelLoader can find it."
+  setupHint: "Install 4x-UltraSharp.pth or RealESRGAN_x4plus.pth where ComfyUI's UpscaleModelLoader can find it.",
+  downloadUrl: "https://huggingface.co/Kim2091/UltraSharp/resolve/main/4x-UltraSharp.pth",
+  sourcePageUrl: "https://huggingface.co/Kim2091/UltraSharp",
+  downloadSizeBytes: 66961958
 } as const;
 
 const TXT2IMG_BASIC_NODES = {
@@ -430,7 +499,11 @@ const FLUX_FILL_STACK = [
     inputName: "unet_name",
     label: "Flux Fill diffusion model",
     modelName: "flux1-fill-dev.safetensors",
-    setupHint: "Install flux1-fill-dev.safetensors where ComfyUI's UNETLoader can find it."
+    setupHint: "Install flux1-fill-dev.safetensors where ComfyUI's UNETLoader can find it.",
+    downloadUrl: `${COMFY_ORG_FLUX1_DEV_REPO}/resolve/main/split_files/diffusion_models/flux1-fill-dev.safetensors`,
+    sourcePageUrl: "https://huggingface.co/black-forest-labs/FLUX.1-Fill-dev",
+    downloadSizeBytes: 23804922408,
+    licenseGate: FLUX1_DEV_LICENSE
   },
   // The working Flux Fill reference maps CLIP-L to clip_name1 and T5 to
   // clip_name2 on DualCLIPLoader. Keep this metadata in sync with
@@ -441,7 +514,10 @@ const FLUX_FILL_STACK = [
     inputName: "clip_name1",
     label: "Flux CLIP-L",
     modelName: "clip_l.safetensors",
-    setupHint: "Install clip_l.safetensors in ComfyUI models/text_encoders."
+    setupHint: "Install clip_l.safetensors in ComfyUI models/text_encoders.",
+    downloadUrl: `${FLUX_TEXT_ENCODERS_REPO}/resolve/main/clip_l.safetensors`,
+    sourcePageUrl: FLUX_TEXT_ENCODERS_REPO,
+    downloadSizeBytes: 246144152
   },
   {
     kind: "clip",
@@ -451,15 +527,23 @@ const FLUX_FILL_STACK = [
     modelName: "t5xxl_fp16.safetensors",
     acceptedModelNames: ["t5xxl_fp8_e4m3fn.safetensors"],
     setupHint:
-      "Install t5xxl_fp16.safetensors in ComfyUI models/text_encoders. t5xxl_fp8_e4m3fn.safetensors is accepted as a local fallback when available."
+      "Install t5xxl_fp16.safetensors in ComfyUI models/text_encoders. t5xxl_fp8_e4m3fn.safetensors is accepted as a local fallback when available.",
+    downloadUrl: `${FLUX_TEXT_ENCODERS_REPO}/resolve/main/t5xxl_fp16.safetensors`,
+    sourcePageUrl: FLUX_TEXT_ENCODERS_REPO,
+    downloadSizeBytes: 9787841024
   },
   {
+    // Same file as the Z_image_Turbo stack's VAE entry, so the setup pack
+    // de-duplicates it and downloads 335 MB once rather than twice.
     kind: "vae",
     objectInfoNode: "VAELoader",
     inputName: "vae_name",
     label: "Flux VAE",
     modelName: "ae.safetensors",
-    setupHint: "Install ae.safetensors where ComfyUI's VAELoader can find it."
+    setupHint: "Install ae.safetensors where ComfyUI's VAELoader can find it.",
+    downloadUrl: `${COMFY_ORG_Z_IMAGE_TURBO_REPO}/resolve/main/split_files/vae/ae.safetensors`,
+    sourcePageUrl: COMFY_ORG_Z_IMAGE_TURBO_REPO,
+    downloadSizeBytes: 335304388
   }
 ] as const;
 
@@ -1033,7 +1117,11 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
         inputName: "control_net_name",
         label: "LineArt ControlNet",
         modelName: "control_v11p_sd15_lineart_fp16.safetensors",
-        setupHint: "Install an SD 1.5 LineArt ControlNet model in ComfyUI's controlnet models folder."
+        setupHint: "Install an SD 1.5 LineArt ControlNet model in ComfyUI's controlnet models folder.",
+        downloadUrl:
+          "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11p_sd15_lineart_fp16.safetensors",
+        sourcePageUrl: "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors",
+        downloadSizeBytes: 722601100
       }
     ],
     requiredNodes: [

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -247,10 +247,61 @@ export type WorkflowModelSource = {
   label: string;
 };
 
+/**
+ * The folder under ComfyUI's `models/` that a loader actually reads from.
+ * Kept as a closed union so a typo cannot invent a folder that ComfyUI will
+ * never scan — the wrong-folder mistake is this project's most common setup
+ * failure and it fails silently, as "model not found".
+ */
+export type WorkflowModelFolder =
+  | "checkpoints"
+  | "diffusion_models"
+  | "text_encoders"
+  | "vae"
+  | "controlnet"
+  | "upscale_models"
+  | "LLM";
+
+/**
+ * A model whose terms have to be accepted by a person before it is fetched.
+ * Its presence means "do not download this without explicit consent", even
+ * when `downloadUrl` resolves without credentials.
+ */
+export type WorkflowModelLicenseGate = {
+  /** Licence name as the publisher writes it. */
+  name: string;
+  /** Where the actual terms live. */
+  url: string;
+  /** The restriction in one sentence, for a setup README or a dialog. */
+  summary: string;
+};
+
+export type WorkflowModelDownloadLayout = "file" | "repo-folder";
+
 export type WorkflowRequiredModel = WorkflowModelSource & {
   modelName: string;
   acceptedModelNames?: readonly string[];
   setupHint?: string;
+  /**
+   * Direct download URL. Every URL in the registry was verified with a live
+   * HEAD request; see `downloadSizeBytes` for the Content-Length observed at
+   * the time. Absent when no unauthenticated URL exists.
+   */
+  downloadUrl?: string;
+  /** Human-readable page for the model: licence, model card, release notes. */
+  sourcePageUrl?: string;
+  /** Content-Length observed when the URL was verified. Used to warn about disk cost. */
+  downloadSizeBytes?: number;
+  /** `repo-folder` models are a directory of files, not a single download. */
+  downloadLayout?: WorkflowModelDownloadLayout;
+  /** Set when a person must accept terms before the file may be fetched. */
+  licenseGate?: WorkflowModelLicenseGate;
+  /**
+   * Only for the rare loader whose folder is not implied by its node class.
+   * Leave unset: the folder is derived from `objectInfoNode` so the mapping
+   * lives in exactly one place (`src/comfy/modelFolders.ts`).
+   */
+  targetFolder?: WorkflowModelFolder;
 };
 
 export type WorkflowRecommendedSettings = {

--- a/tests/comfy/modelFolders.test.ts
+++ b/tests/comfy/modelFolders.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  MODEL_FOLDER_BY_OBJECT_INFO_NODE,
+  getModelTargetFolder,
+  getModelTargetPath,
+  getRequiredModelKey,
+  isMappedModelLoaderNode,
+  listPresetRequiredModels,
+  listRequiredModelsForPresets
+} from "../../src/comfy/modelFolders";
+import { WORKFLOW_PRESETS, getWorkflowPreset, listRunnableWorkflowPresets } from "../../src/comfy/presetRegistry";
+import { WorkflowRequiredModel } from "../../src/comfy/types";
+import { getTechnicalErrorDetails } from "../../src/utils/errors";
+
+function model(overrides: Partial<WorkflowRequiredModel>): WorkflowRequiredModel {
+  return {
+    kind: "checkpoint",
+    objectInfoNode: "CheckpointLoaderSimple",
+    inputName: "ckpt_name",
+    label: "Test model",
+    modelName: "test.safetensors",
+    ...overrides
+  };
+}
+
+describe("model folder mapping", () => {
+  it("sends each loader to the folder ComfyUI actually reads", () => {
+    // Verified against a live ComfyUI via GET /models/<folder>. The
+    // checkpoints/diffusion_models split is the one that has bitten this
+    // project before: the same Flux file is invisible in the wrong folder.
+    expect(MODEL_FOLDER_BY_OBJECT_INFO_NODE).toEqual({
+      CheckpointLoaderSimple: "checkpoints",
+      UNETLoader: "diffusion_models",
+      CLIPLoader: "text_encoders",
+      DualCLIPLoader: "text_encoders",
+      VAELoader: "vae",
+      ControlNetLoader: "controlnet",
+      UpscaleModelLoader: "upscale_models",
+      Florence2ModelLoader: "LLM"
+    });
+  });
+
+  it("builds install paths relative to the ComfyUI root", () => {
+    expect(getModelTargetPath(model({ objectInfoNode: "UNETLoader" }))).toBe("models/diffusion_models");
+    expect(getModelTargetPath(model({ objectInfoNode: "CheckpointLoaderSimple" }))).toBe("models/checkpoints");
+    expect(getModelTargetPath(model({ objectInfoNode: "Florence2ModelLoader" }))).toBe("models/LLM");
+  });
+
+  it("lets a model override the derived folder", () => {
+    expect(getModelTargetFolder(model({ objectInfoNode: "UNETLoader", targetFolder: "checkpoints" }))).toBe(
+      "checkpoints"
+    );
+  });
+
+  it("refuses to guess a folder for an unmapped loader", () => {
+    let thrown: unknown;
+
+    try {
+      getModelTargetFolder(model({ objectInfoNode: "SomeFutureLoader" }));
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(getTechnicalErrorDetails(thrown)).toContain("MODEL_FOLDER_BY_OBJECT_INFO_NODE");
+  });
+
+  it("maps every loader node any preset actually names", () => {
+    const unmapped: string[] = [];
+
+    for (const preset of WORKFLOW_PRESETS) {
+      const nodes = [
+        preset.modelSource.objectInfoNode,
+        ...(preset.requiredModels ?? []).map((entry) => entry.objectInfoNode),
+        ...(preset.modelStack ?? []).map((entry) => entry.objectInfoNode)
+      ];
+
+      for (const node of nodes) {
+        if (!isMappedModelLoaderNode(node)) {
+          unmapped.push(`${preset.id}: ${node}`);
+        }
+      }
+    }
+
+    expect(unmapped).toEqual([]);
+  });
+});
+
+describe("required model inventory", () => {
+  const runnableModels = listRequiredModelsForPresets(listRunnableWorkflowPresets());
+
+  it("freezes what a complete install of the runnable presets needs", () => {
+    expect(runnableModels.map(getRequiredModelKey).sort()).toEqual(
+      [
+        "LLM/Florence-2-base-PromptGen-v2.0",
+        "checkpoints/flux1-dev-fp8.safetensors",
+        "controlnet/control_v11p_sd15_lineart_fp16.safetensors",
+        "diffusion_models/flux1-fill-dev.safetensors",
+        "diffusion_models/krea2_turbo_fp8_scaled.safetensors",
+        "diffusion_models/z_image_turbo_bf16.safetensors",
+        "text_encoders/clip_l.safetensors",
+        "text_encoders/qwen3vl_4b_fp8_scaled.safetensors",
+        "text_encoders/qwen_3_4b.safetensors",
+        "text_encoders/t5xxl_fp16.safetensors",
+        "upscale_models/4x-UltraSharp.pth",
+        "vae/ae.safetensors",
+        "vae/qwen_image_vae.safetensors"
+      ].sort()
+    );
+  });
+
+  it("counts ae.safetensors once even though two stacks load it", () => {
+    const fluxFill = listPresetRequiredModels(getWorkflowPreset("inpaint-flux-fill-basic"));
+    const zImage = listPresetRequiredModels(getWorkflowPreset("txt2img-z-image-turbo"));
+
+    expect(fluxFill.filter((entry) => entry.modelName === "ae.safetensors")).toHaveLength(1);
+    expect(zImage.filter((entry) => entry.modelName === "ae.safetensors")).toHaveLength(1);
+    expect(runnableModels.filter((entry) => entry.modelName === "ae.safetensors")).toHaveLength(1);
+  });
+
+  it("gives every required model somewhere to download from", () => {
+    for (const entry of runnableModels) {
+      expect(entry.downloadUrl, `${entry.modelName} has no download URL`).toBeTruthy();
+      expect(entry.downloadUrl).toMatch(/^https:\/\//);
+      expect(entry.sourcePageUrl).toMatch(/^https:\/\//);
+      expect(() => getModelTargetFolder(entry)).not.toThrow();
+    }
+  });
+
+  it("records a verified size for every single-file download", () => {
+    for (const entry of runnableModels) {
+      if (entry.downloadLayout === "repo-folder") {
+        expect(entry.downloadSizeBytes).toBeUndefined();
+        continue;
+      }
+
+      expect(entry.downloadSizeBytes, `${entry.modelName} has no verified size`).toBeGreaterThan(0);
+    }
+  });
+
+  it("gates the licence-restricted Flux weights and nothing else", () => {
+    const gated = runnableModels.filter((entry) => entry.licenseGate).map((entry) => entry.modelName);
+
+    expect(gated.sort()).toEqual(["flux1-dev-fp8.safetensors", "flux1-fill-dev.safetensors"]);
+
+    for (const entry of runnableModels) {
+      if (!entry.licenseGate) {
+        continue;
+      }
+
+      expect(entry.licenseGate.name).toBeTruthy();
+      expect(entry.licenseGate.url).toMatch(/^https:\/\//);
+      expect(entry.licenseGate.summary.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("keeps the Florence model marked as a repository folder, not a file", () => {
+    const florence = runnableModels.find((entry) => entry.modelName === "Florence-2-base-PromptGen-v2.0");
+
+    expect(florence?.downloadLayout).toBe("repo-folder");
+    expect(getModelTargetPath(florence!)).toBe("models/LLM");
+  });
+});


### PR DESCRIPTION
The data layer for the ComfyUI setup pack (and, later, the in-panel Setup tab). It has to tell a new machine which models to fetch **and exactly where each one goes**, and it must be impossible for those instructions to drift from the presets they describe.

Pure data + one new module. No `src/photoshop/*`, no `generationController`, no UI.

### Folders are derived, not stored

The brief allowed a `targetFolder` field per model. A stored folder is one that can disagree with the loader that reads it, and this project has already lost time to exactly that: a Flux model in `models/checkpoints/` is invisible to `UNETLoader`, and the only symptom is "model not found".

So `src/comfy/modelFolders.ts` holds **one** mapping from loader node to folder, everything derives from it, and `getModelTargetFolder` throws rather than guessing for an unmapped loader. The optional per-model override stays on the type for the loader that eventually doesn't fit; nothing sets it today.

The mapping was **checked, not recalled** — `GET /models/<folder>` on your running server:
- `text_encoders` holds `clip_l` / `t5xxl_*` / `qwen_*`; the legacy `clip` folder is **empty**
- `Florence2ModelLoader` states its own location in its input tooltip: *"models are expected to be in Comfyui/models/LLM folder"*

### Every URL was verified, and most were verified twice

Each `downloadUrl` got a live HEAD request; each `downloadSizeBytes` is the `Content-Length` that request returned. Where the model is also installed on your rig, **the served size matches your local file exactly**:

| Model | Served | On disk |
|---|---|---|
| `z_image_turbo_bf16.safetensors` | 12,309,866,400 | 12,309,866,400 |
| `krea2_turbo_fp8_scaled.safetensors` | 13,141,730,784 | 13,141,730,784 |
| `qwen_3_4b.safetensors` | 8,044,982,048 | 8,044,982,048 |
| `qwen3vl_4b_fp8_scaled.safetensors` | 5,242,467,968 | 5,242,467,968 |
| `flux1-dev-fp8.safetensors` | 17,246,524,772 | 17,246,524,772 |
| `qwen_image_vae.safetensors` | 253,806,246 | 253,806,246 |
| `ae.safetensors` | 335,304,388 | 335,304,388 |
| `4x-UltraSharp.pth` | 66,961,958 | 66,961,958 |

So these are the files known to work here, not files with the right name. (`clip_l`, `t5xxl_fp16`, `flux1-fill-dev` and `control_v11p_sd15_lineart_fp16` are URL-verified only — they resolve through an `extra_model_paths` root rather than the main models folder on this machine.)

### Licence gating
`black-forest-labs/FLUX.1-dev` and `FLUX.1-Fill-dev` both answer **401** without a user token, so the two Flux weights point at Comfy-Org's public repackaging. Mirroring changes how a file is fetched, not what it's licensed as — so both carry a `licenseGate` naming the FLUX.1 [dev] non-commercial terms and linking them. The downloader in the next PR must refuse to fetch a gated model without explicit acknowledgement; that flag is what it keys off.

`Florence-2-base-PromptGen-v2.0` is marked `repo-folder`, not `file` — `Florence2ModelLoader` loads a *directory*, and a single-file fetch would produce a broken install that looks complete.

`ae.safetensors` is deliberately one shared entry across the Flux Fill and Z_image_Turbo stacks, and `listPresetRequiredModels` de-duplicates across `modelStack`/`requiredModels`, so the pack downloads 335 MB once instead of twice.

### Known gap
`acceptedModelNames` fallbacks (`t5xxl_fp8_e4m3fn.safetensors`, `RealESRGAN_x4plus.pth`) carry no URLs — the type has one URL per entry. They're listed as "also accepted" for people who already have them. Worth revisiting if the pack should offer the smaller T5 as a low-VRAM option.

### Tests (11 new, 298 total)
Freeze the mapping itself; exhaustiveness over every loader any preset names; the **13 models** a complete install of the runnable presets needs; that every one resolves to both a folder and a URL; that sizes exist for file downloads but not the repo-folder one; and that exactly the two Flux entries are licence-gated.

### Validation
`npm run typecheck` ✅ · `npm test` ✅ **298/298** · `npm run build` ✅

### Smoke checklist (Photoshop)
This PR adds data and one unused-by-UI module; nothing in the panel reads it yet, so behaviour should be **identical**. The check is that nothing regressed:

1. Load `dist/` in UDT, open **Plugins → OpenLayer**.
2. **Settings → Check Workflow Health.** Confirm the report still lists the same presets as ready/not-ready as before this branch — the required-model lists it reads are unchanged in content.
3. Run one generation end to end (Text to Image → prompt → **Generate** → import) to confirm the registry still loads and injects normally.
4. Open **Sketch to Image** and **Inpaint** and confirm their model selectors still populate.

If health output changes at all, that's a bug — say so.