### PR TITLE
Land the setup pack on main (follow-up to #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Known v0.6.0-alpha boundaries:
 - Workflow Health now gives beginner-friendly next checks for missing models, missing ComfyUI nodes, missing workflow JSON, setup-required presets, and experimental presets.
 - Persistent Photoshop layer metadata is not confirmed safe in this UXP environment yet. OpenLayer keeps structured metadata in session history and prepares a serialized payload for future persistence.
 - Copy Diagnostics prepares a setup report for testers. It does not send data anywhere.
-- Prompt from Layer requires `comfyui-florence2`, `comfyui-custom-scripts`, and `Florence-2-base-PromptGen-v2.0`.
+- Prompt from Layer requires `comfyui-florence2` and `Florence-2-base-PromptGen-v2.0`. The `comfyui-custom-scripts` pack is no longer needed.
 - Outpaint is experimental and currently uses `outpaint-flux-fill-basic` with `flux1-fill-dev.safetensors`, `clip_l.safetensors`, `t5xxl_fp16.safetensors` or the accepted T5 fp8 fallback, and `ae.safetensors`.
 - Upscale currently uses a simple pixel/model upscale path. It does not use prompts, latent upscale, tiled diffusion, or creative enhancement.
 - Upscale needs ComfyUI's `UpscaleModelLoader` and `ImageUpscaleWithModel` nodes plus an installed upscale model such as `4x-UltraSharp.pth` or `RealESRGAN_x4plus.pth`.

--- a/docs/model-guide.md
+++ b/docs/model-guide.md
@@ -78,8 +78,12 @@ Prompt from Layer uses a vision-language workflow, not a diffusion image model. 
 Required local setup:
 
 - `comfyui-florence2`
-- `comfyui-custom-scripts` for `ShowText|pysssss`
 - `Florence-2-base-PromptGen-v2.0` available to `Florence2ModelLoader`
+
+`comfyui-custom-scripts` is no longer required. The workflow used to end in that pack's
+`ShowText|pysssss` node; it now ends in core ComfyUI's `PreviewAny`, which publishes the caption in
+the same history shape. The node cannot simply be deleted — `Florence2Run` is not an output node, so
+a graph without one is refused by ComfyUI before it runs.
 
 OpenLayer uploads the captured Photoshop source PNG to ComfyUI, runs Florence-2 PromptGen, reads the text output from ComfyUI history, and places the generated caption into the plugin text area. The default task is `detailed_caption` with `num_beams` set to `12`.
 

--- a/docs/setup-pack.md
+++ b/docs/setup-pack.md
@@ -1,0 +1,74 @@
+# ComfyUI Setup Pack
+
+A downloadable zip that takes a machine from bare ComfyUI to "OpenLayer works". Build it with:
+
+```powershell
+npm run setup-pack
+```
+
+Output: `packages/openlayer-comfyui-setup-<version>.zip` (gitignored — attach it to a release).
+
+## The one rule
+
+**Nothing in the pack is written by hand.** `scripts/build-setup-pack.mjs` generates all of it from
+`src/comfy/setupManifest.ts`, which reads the preset registry. A setup guide maintained separately
+drifts from the software the first time a preset changes, and a setup guide that is wrong about
+which folder a model belongs in is worse than no guide at all — ComfyUI does not warn about a model
+in the wrong folder, it simply cannot see it.
+
+If you find yourself editing `REQUIREMENTS.md` or `requirements.json` directly, you are editing a
+build artifact. Change the registry instead.
+
+## What ships
+
+| Path in the zip | Generated from |
+| --- | --- |
+| `README.md` | The manifest plus the port-8190 setup from `docs/setup-windows.md` |
+| `REQUIREMENTS.md` | The manifest: models, exact target folders, custom node repos, per-preset breakdown |
+| `requirements.json` | The manifest verbatim (`schemaVersion: 1`) |
+| `Install-OpenLayerModels.ps1` | Static script; reads `requirements.json` at run time |
+| `workflows/api/*`, `workflows/source/*` | Copied from `src/workflows/` |
+
+**No model weights.** They are ~85 GB, and two are licence-restricted. The pack ships the list and
+the downloader; the user needs an internet connection.
+
+## The downloader
+
+`Install-OpenLayerModels.ps1 -ComfyUIRoot <path>` reads `requirements.json` and fetches each model
+into its target folder. Behaviour worth knowing:
+
+- **Skips files already present.** Safe to re-run.
+- **Downloads to `.partial` first**, then renames. An interrupted run never leaves a truncated file
+  that looks installed to both this script and ComfyUI.
+- **Verifies size** against the registry's recorded `Content-Length` and deletes the download on
+  mismatch.
+- **Refuses licence-gated models** without `-AcceptLicenseRestrictedModels`, printing the licence
+  name, a one-line summary, and the terms URL.
+- **Will not fetch `repo-folder` models** (the Florence model is a directory, not a file). It prints
+  the `git clone` command instead — a single-file fetch would produce a broken install that looks
+  complete.
+- `-WhatIf` works throughout.
+
+Rigs using `extra_model_paths.yaml` have more than one model root. `-ComfyUIRoot` writes to one of
+them; the folder table in `REQUIREMENTS.md` covers moving files by hand.
+
+## Why the zip is written by hand
+
+`scripts/lib/zipWriter.mjs` is a small spec-correct ZIP writer rather than a call to
+`Compress-Archive`. Windows PowerShell 5.1 runs on .NET Framework, which stores entry paths with
+**backslashes**; the ZIP specification requires forward slashes. The existing release zip carries 40
+such entries. Windows tooling tolerates it, other unzippers are entitled not to, and this pack goes
+to strangers' machines. See `docs/DISTRIBUTION_SPIKE.md` for how that surfaced.
+
+`scripts/package.mjs` is untouched and still uses `Compress-Archive`. Fixing the plugin zip is worth
+doing when `.ccx` generation is automated, since they would share a writer.
+
+## Known gaps
+
+- Four presets (`txt2img-basic`, `img2img-basic`, `sketch2img-linecn-basic`, `inpaint-basic`) declare
+  a `sourceWorkflowFile` that was never exported to `src/workflows/source/`. The generator prints a
+  note and omits those lines rather than advertising files the zip does not contain.
+- `acceptedModelNames` fallbacks (`t5xxl_fp8_e4m3fn.safetensors`, `RealESRGAN_x4plus.pth`) carry no
+  download URLs — the model type has one URL per entry. They are listed as "also accepted".
+- The pack does not check a running server. That is the in-panel Setup tab (ORCHESTRATION §6 item 2),
+  which is meant to read this same `requirements.json` structure.

--- a/docs/workflow-files.md
+++ b/docs/workflow-files.md
@@ -85,15 +85,14 @@ The runnable API workflow uses:
 - `Florence2ModelLoader`
 - `LoadImage`
 - `Florence2Run`
-- `ShowText|pysssss`
+- `PreviewAny` (core ComfyUI)
 
 Required local setup:
 
 - `comfyui-florence2`
-- `comfyui-custom-scripts`
 - `Florence-2-base-PromptGen-v2.0`
 
-The source workflow also includes preview/save text helper nodes. OpenLayer does not rely on the `SaveText` node for normal operation; it reads the text output from the completed prompt history.
+`PreviewAny` is what makes the graph runnable, not just readable. `Florence2Run` is not an output node, so a graph containing only the three Florence nodes has no output at all and ComfyUI refuses to queue it. `PreviewAny` publishes the caption under `outputs[<node>].text`, exactly as the `ShowText|pysssss` node it replaced did — which is why dropping the `comfyui-custom-scripts` requirement was a swap rather than a deletion.
 
 ## Why Flux Is Different
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit && vite build && node scripts/copy-uxp-assets.mjs",
     "package": "npm run build && node scripts/package.mjs",
+    "setup-pack": "node scripts/build-setup-pack.mjs",
     "test": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {

--- a/scripts/build-setup-pack.mjs
+++ b/scripts/build-setup-pack.mjs
@@ -1,0 +1,463 @@
+import { mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { build } from "vite";
+import { writeZip } from "./lib/zipWriter.mjs";
+
+/**
+ * Builds the ComfyUI setup pack: a zip that takes a machine with bare ComfyUI
+ * to "OpenLayer works".
+ *
+ * Everything in it is generated from `src/comfy/setupManifest.ts`, which reads
+ * the preset registry. That is the whole point — a setup guide maintained by
+ * hand drifts from the software the first time a preset changes, and a setup
+ * guide that is wrong about which folder a model goes in is worse than none.
+ *
+ * The pack contains no model weights. They are tens of gigabytes and two of
+ * them are licence-restricted; it ships workflows, an exact requirements list,
+ * and a downloader.
+ */
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const packagesDir = resolve(root, "packages");
+const packageJson = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
+const version = packageJson.version;
+
+/**
+ * The manifest lives in TypeScript so the panel can import it later. Node
+ * cannot load it directly (extensionless relative imports), so bundle it with
+ * the Vite already in devDependencies rather than adding a build dependency.
+ */
+async function loadSetupManifestModule() {
+  const outDir = await mkdtemp(join(tmpdir(), "openlayer-setup-pack-"));
+
+  await build({
+    configFile: false,
+    logLevel: "error",
+    build: {
+      outDir,
+      emptyOutDir: true,
+      minify: false,
+      lib: {
+        entry: resolve(root, "src/comfy/setupManifest.ts"),
+        formats: ["es"],
+        fileName: () => "setupManifest.mjs"
+      }
+    }
+  });
+
+  const module = await import(pathToFileURL(join(outDir, "setupManifest.mjs")).href);
+  await rm(outDir, { recursive: true, force: true });
+  return module;
+}
+
+const { buildSetupManifest, formatBytes } = await loadSetupManifestModule();
+const manifest = buildSetupManifest({ pluginVersion: version });
+
+function renderRequirementsMarkdown() {
+  const lines = [];
+
+  lines.push(`# OpenLayer ${manifest.pluginVersion} — ComfyUI Requirements`);
+  lines.push("");
+  lines.push(
+    "Generated from OpenLayer's preset registry. Do not edit by hand — regenerate with `npm run setup-pack`."
+  );
+  lines.push("");
+  lines.push(
+    `${manifest.totals.presets} runnable presets need ${manifest.totals.models} models ` +
+      `(${formatBytes(manifest.totals.knownDownloadBytes)} of downloads) and ` +
+      `${manifest.customNodes.length} custom node package${manifest.customNodes.length === 1 ? "" : "s"}.`
+  );
+  lines.push("");
+
+  lines.push("## Put each file in the right folder");
+  lines.push("");
+  lines.push(
+    "This is the mistake that costs people the most time. ComfyUI reads each loader from exactly one " +
+      "folder. A model in the wrong folder is not a warning — it is simply invisible, and OpenLayer can " +
+      "only report that the model is missing."
+  );
+  lines.push("");
+  lines.push("| Model | Goes in | Size | Loaded by |");
+  lines.push("| --- | --- | --- | --- |");
+
+  for (const model of manifest.models) {
+    const size = model.layout === "repo-folder" ? "repository" : formatBytes(model.sizeBytes ?? 0);
+    lines.push(`| \`${model.modelName}\` | \`${model.targetPath}/\` | ${size} | \`${model.loaderNode}\` |`);
+  }
+
+  lines.push("");
+  lines.push("## Custom nodes");
+  lines.push("");
+
+  if (manifest.customNodes.length === 0) {
+    lines.push("None. Every node these workflows use ships with core ComfyUI.");
+  } else {
+    lines.push("Clone these into `ComfyUI/custom_nodes/` (or install them through ComfyUI-Manager):");
+    lines.push("");
+
+    for (const node of manifest.customNodes) {
+      lines.push(`- **${node.name}** — ${node.repoUrl}`);
+      lines.push(`  - provides: ${node.classTypes.map((entry) => `\`${entry}\``).join(", ")}`);
+      lines.push(`  - needed by: ${node.usedByPresets.join(", ")}`);
+    }
+  }
+
+  lines.push("");
+
+  const gated = manifest.models.filter((model) => model.licenseGate);
+
+  if (gated.length > 0) {
+    lines.push("## Licence-restricted models");
+    lines.push("");
+    lines.push(
+      "The downloader will not fetch these without an explicit flag. Read the terms first — they are " +
+        "not the usual permissive model licences."
+    );
+    lines.push("");
+
+    for (const model of gated) {
+      lines.push(`- \`${model.modelName}\` — ${model.licenseGate.name}`);
+      lines.push(`  - ${model.licenseGate.summary}`);
+      lines.push(`  - terms: ${model.licenseGate.url}`);
+    }
+
+    lines.push("");
+  }
+
+  lines.push("## What each preset needs");
+  lines.push("");
+
+  for (const preset of manifest.presets) {
+    lines.push(`### ${preset.id}`);
+    lines.push("");
+    lines.push(preset.description);
+    lines.push("");
+    lines.push(`- workflow: \`${preset.workflowFile}\``);
+
+    // Several presets name a source workflow the repository never exported.
+    // Listing one that is not in the zip sends people looking for a file that
+    // does not exist, so only shipped sources are advertised.
+    if (preset.sourceWorkflowFile && shippedFilePaths.has(preset.sourceWorkflowFile)) {
+      lines.push(`- editable source: \`${preset.sourceWorkflowFile}\``);
+    }
+
+    if (preset.modelKeys.length === 0) {
+      lines.push("- models: none pinned — pick any compatible checkpoint you already have.");
+    } else {
+      lines.push("- models:");
+
+      for (const key of preset.modelKeys) {
+        const model = manifest.models.find((entry) => entry.key === key);
+
+        if (!model) {
+          continue;
+        }
+
+        const accepted = model.acceptedModelNames?.length
+          ? ` (also accepts ${model.acceptedModelNames.map((entry) => `\`${entry}\``).join(", ")})`
+          : "";
+        lines.push(`  - \`${model.modelName}\` → \`${model.targetPath}/\`${accepted}`);
+      }
+    }
+
+    lines.push(
+      `- custom nodes: ${preset.customNodePackages.length > 0 ? preset.customNodePackages.join(", ") : "none"}`
+    );
+    lines.push("");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function renderReadme() {
+  return `# OpenLayer ComfyUI Setup Pack — ${manifest.pluginVersion}
+
+This pack gets a machine that already runs ComfyUI to the point where OpenLayer works.
+
+**It contains no model weights.** The models are tens of gigabytes, and two of them are
+licence-restricted, so shipping them here would be both impractical and wrong. What you get is the
+exact list of what to install, where each file goes, the workflows themselves, and a downloader.
+You will need an internet connection.
+
+## What is in here
+
+| Path | What it is |
+| --- | --- |
+| \`REQUIREMENTS.md\` | Human-readable: every model, its exact target folder, and every custom node repo |
+| \`requirements.json\` | The same information, machine-readable |
+| \`Install-OpenLayerModels.ps1\` | Downloads the models into the right folders, skipping ones you already have |
+| \`workflows/api/\` | The workflows OpenLayer actually submits |
+| \`workflows/source/\` | The same graphs in ComfyUI's editable format, for inspection |
+
+## 1. Install the custom nodes
+
+See the Custom nodes section of \`REQUIREMENTS.md\`. Clone each repository into
+\`ComfyUI/custom_nodes/\` and restart ComfyUI.
+
+## 2. Download the models
+
+\`\`\`powershell
+./Install-OpenLayerModels.ps1 -ComfyUIRoot "C:\\path\\to\\ComfyUI"
+\`\`\`
+
+Add \`-WhatIf\` first to see what it would fetch without downloading anything. Files that already
+exist are skipped, so it is safe to re-run after an interrupted download.
+
+Licence-restricted models are skipped unless you pass \`-AcceptLicenseRestrictedModels\`. Read the
+terms linked in \`REQUIREMENTS.md\` before you do.
+
+If your ComfyUI uses \`extra_model_paths.yaml\` to keep models on another drive, point
+\`-ComfyUIRoot\` at the root that owns the folders you want written, or move the files yourself
+using the folder table in \`REQUIREMENTS.md\`.
+
+## 3. Start ComfyUI on port ${manifest.comfyui.defaultPort}
+
+OpenLayer defaults to \`http://127.0.0.1:${manifest.comfyui.defaultPort}\` so it does not collide with another plugin
+already using ComfyUI on 8188.
+
+\`\`\`powershell
+python main.py --listen 127.0.0.1 --port ${manifest.comfyui.defaultPort}
+\`\`\`
+
+If you already run ComfyUI on 8188 for something else, start a second instance on
+${manifest.comfyui.defaultPort} rather than moving the first one. OpenLayer can also be pointed at a different port
+from its Settings screen.
+
+## 4. Check it from OpenLayer
+
+1. Open the OpenLayer panel in Photoshop.
+2. Click **Check ComfyUI**. It should report the server version.
+3. Open **Settings → Check Workflow Health**. Every preset whose models you installed should read
+   as ready. Anything still missing is named explicitly, with the folder it belongs in.
+
+## Regenerating this pack
+
+It is generated from OpenLayer's preset registry, so it cannot drift from the plugin:
+
+\`\`\`powershell
+npm run setup-pack
+\`\`\`
+
+Generated ${manifest.generatedAt} for OpenLayer ${manifest.pluginVersion}.
+`;
+}
+
+const DOWNLOADER = String.raw`<#
+.SYNOPSIS
+    Downloads the ComfyUI models OpenLayer needs, into the folders ComfyUI reads them from.
+
+.DESCRIPTION
+    Reads requirements.json (generated from OpenLayer's preset registry) and fetches each model
+    into its target folder under the given ComfyUI root. Files that already exist are skipped,
+    so an interrupted run can simply be repeated.
+
+    Licence-restricted models are skipped unless -AcceptLicenseRestrictedModels is passed.
+    Models published as a repository folder rather than a single file are reported with
+    instructions instead of being downloaded, because fetching one file of such a model
+    produces a broken install that looks complete.
+
+.EXAMPLE
+    ./Install-OpenLayerModels.ps1 -ComfyUIRoot "C:\ComfyUI" -WhatIf
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ComfyUIRoot,
+
+    [switch] $AcceptLicenseRestrictedModels,
+
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'requirements.json')
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $ComfyUIRoot)) {
+    throw "ComfyUI root not found: $ComfyUIRoot"
+}
+
+if (-not (Test-Path -LiteralPath $ManifestPath)) {
+    throw "requirements.json not found: $ManifestPath"
+}
+
+$manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+
+Write-Host ""
+Write-Host "OpenLayer $($manifest.pluginVersion) - ComfyUI model setup"
+Write-Host "ComfyUI root: $ComfyUIRoot"
+Write-Host ""
+
+$downloaded = 0
+$skipped = 0
+$gatedSkipped = 0
+$manual = 0
+$failed = @()
+
+foreach ($model in $manifest.models) {
+    $targetDir = Join-Path $ComfyUIRoot ($model.targetPath -replace '/', '\')
+    $targetFile = Join-Path $targetDir $model.modelName
+
+    if ($model.layout -eq 'repo-folder') {
+        if (Test-Path -LiteralPath $targetFile) {
+            Write-Host "[have] $($model.modelName)"
+            $skipped++
+        }
+        else {
+            Write-Host "[manual] $($model.modelName) is a repository folder, not a single file."
+            Write-Host "         git clone $($model.sourcePageUrl) ""$targetFile"""
+            $manual++
+        }
+
+        continue
+    }
+
+    if (Test-Path -LiteralPath $targetFile) {
+        $existing = (Get-Item -LiteralPath $targetFile).Length
+
+        if ($model.sizeBytes -and $existing -ne $model.sizeBytes) {
+            Write-Warning "$($model.modelName) exists but is $existing bytes, expected $($model.sizeBytes). Leaving it alone - delete it and re-run to replace."
+        }
+        else {
+            Write-Host "[have] $($model.modelName)"
+        }
+
+        $skipped++
+        continue
+    }
+
+    if ($model.licenseGate -and -not $AcceptLicenseRestrictedModels) {
+        Write-Host "[licence] $($model.modelName) - $($model.licenseGate.name)"
+        Write-Host "          $($model.licenseGate.summary)"
+        Write-Host "          Terms: $($model.licenseGate.url)"
+        Write-Host "          Re-run with -AcceptLicenseRestrictedModels to download it."
+        $gatedSkipped++
+        continue
+    }
+
+    if (-not $model.downloadUrl) {
+        Write-Host "[manual] $($model.modelName) has no direct download. See $($model.sourcePageUrl)"
+        $manual++
+        continue
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($targetFile, "Download $($model.modelName)")) {
+        continue
+    }
+
+    if (-not (Test-Path -LiteralPath $targetDir)) {
+        New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+    }
+
+    $partial = "$targetFile.partial"
+    Write-Host "[get]  $($model.modelName) -> $($model.targetPath)/"
+
+    try {
+        # Downloading to .partial first means an interrupted run never leaves a
+        # truncated file that looks installed to both this script and ComfyUI.
+        Invoke-WebRequest -Uri $model.downloadUrl -OutFile $partial -UseBasicParsing
+
+        if ($model.sizeBytes) {
+            $actual = (Get-Item -LiteralPath $partial).Length
+
+            if ($actual -ne $model.sizeBytes) {
+                Remove-Item -LiteralPath $partial -Force
+                throw "size mismatch: got $actual bytes, expected $($model.sizeBytes)"
+            }
+        }
+
+        Move-Item -LiteralPath $partial -Destination $targetFile -Force
+        $downloaded++
+    }
+    catch {
+        if (Test-Path -LiteralPath $partial) {
+            Remove-Item -LiteralPath $partial -Force
+        }
+
+        Write-Warning "Failed: $($model.modelName) - $($_.Exception.Message)"
+        $failed += $model.modelName
+    }
+}
+
+Write-Host ""
+Write-Host "Downloaded: $downloaded   Already present: $skipped   Licence-gated: $gatedSkipped   Manual: $manual"
+
+if ($manifest.customNodes.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Custom nodes still to install into $ComfyUIRoot\custom_nodes:"
+
+    foreach ($node in $manifest.customNodes) {
+        Write-Host "  git clone $($node.repoUrl)"
+    }
+}
+
+if ($failed.Count -gt 0) {
+    Write-Host ""
+    Write-Warning "These did not download: $($failed -join ', '). Re-run to retry."
+    exit 1
+}
+`;
+
+async function collectWorkflowFiles() {
+  const entries = [];
+
+  for (const folder of ["api", "source"]) {
+    const dir = resolve(root, "src/workflows", folder);
+    const names = await readdir(dir);
+
+    for (const name of names) {
+      entries.push({
+        path: `workflows/${folder}/${name}`,
+        data: await readFile(join(dir, name))
+      });
+    }
+  }
+
+  return entries;
+}
+
+const workflowEntries = await collectWorkflowFiles();
+const shippedFilePaths = new Set(workflowEntries.map((entry) => entry.path));
+
+// A runnable preset without its API workflow would produce a pack that cannot
+// run that preset, so this is fatal rather than a warning.
+const missingWorkflows = manifest.presets
+  .map((preset) => preset.workflowFile)
+  .filter((file) => !shippedFilePaths.has(file));
+
+if (missingWorkflows.length > 0) {
+  throw new Error(`Setup pack is missing workflow files for: ${missingWorkflows.join(", ")}`);
+}
+
+// Missing GUI sources are only a documentation gap — the presets still run —
+// but they are worth reporting rather than silently papering over.
+const missingSources = manifest.presets
+  .map((preset) => preset.sourceWorkflowFile)
+  .filter((file) => file && !shippedFilePaths.has(file));
+
+if (missingSources.length > 0) {
+  console.warn(
+    `  note: ${missingSources.length} preset(s) name a GUI source workflow that was never exported ` +
+      `(${missingSources.join(", ")}); omitted from REQUIREMENTS.md`
+  );
+}
+
+const zipEntries = [
+  { path: "README.md", data: renderReadme() },
+  { path: "REQUIREMENTS.md", data: renderRequirementsMarkdown() },
+  { path: "requirements.json", data: `${JSON.stringify(manifest, null, 2)}\n` },
+  { path: "Install-OpenLayerModels.ps1", data: DOWNLOADER },
+  ...workflowEntries
+];
+
+await mkdir(packagesDir, { recursive: true });
+const zipPath = resolve(packagesDir, `openlayer-comfyui-setup-${version}.zip`);
+await rm(zipPath, { force: true });
+await writeZip(zipPath, zipEntries);
+
+console.log(`Created ${zipPath}`);
+console.log(
+  `  ${zipEntries.length} files | ${manifest.totals.presets} presets | ${manifest.totals.models} models ` +
+    `(${formatBytes(manifest.totals.knownDownloadBytes)}) | ${manifest.customNodes.length} custom node packages`
+);
+console.log(`  workflows: ${workflowEntries.map((entry) => basename(entry.path)).length} files`);

--- a/scripts/lib/zipWriter.mjs
+++ b/scripts/lib/zipWriter.mjs
@@ -1,0 +1,129 @@
+import { deflateRawSync } from "node:zlib";
+import { writeFile } from "node:fs/promises";
+
+/**
+ * A minimal, spec-correct ZIP writer.
+ *
+ * Why not `Compress-Archive`, which `scripts/package.mjs` uses? Because Windows
+ * PowerShell 5.1 runs on .NET Framework, which stores entry paths with
+ * backslashes. The ZIP specification requires forward slashes, and the existing
+ * release zips carry 40 such entries. Windows tooling tolerates it; other
+ * unzippers are entitled not to. The setup pack goes to strangers' machines and
+ * gets opened by whatever they have, so it is written correctly here instead.
+ */
+
+const CRC_TABLE = (() => {
+  const table = new Int32Array(256);
+
+  for (let index = 0; index < 256; index += 1) {
+    let value = index;
+
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = value & 1 ? (value >>> 1) ^ 0xedb88320 : value >>> 1;
+    }
+
+    table[index] = value;
+  }
+
+  return table;
+})();
+
+function crc32(buffer) {
+  let crc = -1;
+
+  for (let index = 0; index < buffer.length; index += 1) {
+    crc = (crc >>> 8) ^ CRC_TABLE[(crc ^ buffer[index]) & 0xff];
+  }
+
+  return (crc ^ -1) >>> 0;
+}
+
+/** MS-DOS date/time, the only timestamp a base ZIP header can hold. */
+function toDosDateTime(date) {
+  const year = Math.max(date.getFullYear(), 1980);
+
+  return {
+    time: (date.getHours() << 11) | (date.getMinutes() << 5) | (Math.floor(date.getSeconds() / 2) & 0x1f),
+    date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate()
+  };
+}
+
+/**
+ * @param {string} zipPath destination file
+ * @param {{ path: string, data: Buffer | string }[]} entries archive members;
+ *   `path` must already be the desired in-archive path, using forward slashes
+ * @param {Date} [modifiedAt]
+ */
+export async function writeZip(zipPath, entries, modifiedAt = new Date()) {
+  const { time, date } = toDosDateTime(modifiedAt);
+  const localParts = [];
+  const centralParts = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const normalizedPath = entry.path.split("\\").join("/");
+
+    if (normalizedPath.startsWith("/") || normalizedPath.includes("..")) {
+      throw new Error(`Refusing to write unsafe zip entry path: ${entry.path}`);
+    }
+
+    const nameBuffer = Buffer.from(normalizedPath, "utf8");
+    const raw = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data, "utf8");
+    const compressed = deflateRawSync(raw, { level: 9 });
+    // Deflate can grow tiny or already-compressed payloads. Storing those
+    // uncompressed keeps the archive smaller and stays valid either way.
+    const useDeflate = compressed.length < raw.length;
+    const payload = useDeflate ? compressed : raw;
+    const checksum = crc32(raw);
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4); // version needed
+    localHeader.writeUInt16LE(0x0800, 6); // UTF-8 filename flag
+    localHeader.writeUInt16LE(useDeflate ? 8 : 0, 8);
+    localHeader.writeUInt16LE(time, 10);
+    localHeader.writeUInt16LE(date, 12);
+    localHeader.writeUInt32LE(checksum, 14);
+    localHeader.writeUInt32LE(payload.length, 18);
+    localHeader.writeUInt32LE(raw.length, 22);
+    localHeader.writeUInt16LE(nameBuffer.length, 26);
+    localHeader.writeUInt16LE(0, 28); // extra field length
+
+    localParts.push(localHeader, nameBuffer, payload);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4); // version made by
+    centralHeader.writeUInt16LE(20, 6); // version needed
+    centralHeader.writeUInt16LE(0x0800, 8);
+    centralHeader.writeUInt16LE(useDeflate ? 8 : 0, 10);
+    centralHeader.writeUInt16LE(time, 12);
+    centralHeader.writeUInt16LE(date, 14);
+    centralHeader.writeUInt32LE(checksum, 16);
+    centralHeader.writeUInt32LE(payload.length, 20);
+    centralHeader.writeUInt32LE(raw.length, 24);
+    centralHeader.writeUInt16LE(nameBuffer.length, 28);
+    centralHeader.writeUInt16LE(0, 30); // extra field length
+    centralHeader.writeUInt16LE(0, 32); // comment length
+    centralHeader.writeUInt16LE(0, 34); // disk number
+    centralHeader.writeUInt16LE(0, 36); // internal attributes
+    centralHeader.writeUInt32LE(0, 38); // external attributes
+    centralHeader.writeUInt32LE(offset, 42);
+
+    centralParts.push(centralHeader, nameBuffer);
+    offset += localHeader.length + nameBuffer.length + payload.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const endRecord = Buffer.alloc(22);
+  endRecord.writeUInt32LE(0x06054b50, 0);
+  endRecord.writeUInt16LE(0, 4); // disk number
+  endRecord.writeUInt16LE(0, 6); // central directory start disk
+  endRecord.writeUInt16LE(entries.length, 8);
+  endRecord.writeUInt16LE(entries.length, 10);
+  endRecord.writeUInt32LE(centralDirectory.length, 12);
+  endRecord.writeUInt32LE(offset, 16);
+  endRecord.writeUInt16LE(0, 20); // comment length
+
+  await writeFile(zipPath, Buffer.concat([...localParts, centralDirectory, endRecord]));
+}

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -342,7 +342,11 @@ const PROMPT_FROM_LAYER_FLORENCE2_NODES = {
   modelLoader: "39",
   loadImage: "42",
   florenceRun: "38",
-  showText: "45"
+  // Florence2Run is not an OUTPUT_NODE, so the graph needs one or ComfyUI
+  // refuses to queue it and no caption ever reaches history. PreviewAny is
+  // core (comfy_extras.nodes_preview_any) and publishes the same
+  // {"ui": {"text": [...]}} shape the pysssss ShowText node did.
+  textPreview: "41"
 } as const;
 
 const UPSCALE_BASIC_NODES = {
@@ -1031,7 +1035,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     requiredModels: [FLORENCE2_PROMPTGEN_MODEL],
     injections: PROMPT_FROM_LAYER_FLORENCE2_INJECTIONS,
     compatibilityNote:
-      "prompt-from-layer-florence2 uses comfyui-florence2 plus ShowText from comfyui-custom-scripts. It returns text from ComfyUI history instead of an image.",
+      "prompt-from-layer-florence2 needs only comfyui-florence2. The caption is published by core ComfyUI's PreviewAny node, so it returns text from ComfyUI history instead of an image.",
     requiredNodes: [
       {
         id: PROMPT_FROM_LAYER_FLORENCE2_NODES.modelLoader,
@@ -1049,9 +1053,9 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
         requiredInputs: ["image", "florence2_model", "text_input", "task", "fill_mask"]
       },
       {
-        id: PROMPT_FROM_LAYER_FLORENCE2_NODES.showText,
-        classType: "ShowText|pysssss",
-        requiredInputs: ["text"]
+        id: PROMPT_FROM_LAYER_FLORENCE2_NODES.textPreview,
+        classType: "PreviewAny",
+        requiredInputs: ["source"]
       }
     ]
   },
@@ -1789,6 +1793,20 @@ export function getWorkflowPreset(presetId: string): WorkflowPresetDefinition {
 
 export function isWorkflowPreset(presetId: string): presetId is WorkflowPreset {
   return WORKFLOW_PRESETS.some((preset) => preset.id === presetId);
+}
+
+/**
+ * ComfyUI node classes that publish text into a history entry's `outputs`.
+ * Both shapes seen here return `{"ui": {"text": [...]}}`; `PreviewAny` is core,
+ * `ShowText|pysssss` is the comfyui-custom-scripts node OpenLayer used to
+ * require and is still accepted so hand-edited workflows keep working.
+ */
+const TEXT_OUTPUT_NODE_CLASS_TYPES = ["PreviewAny", "ShowText|pysssss"] as const;
+
+export function getPresetTextOutputNodeId(preset: WorkflowPresetDefinition): string | undefined {
+  return preset.requiredNodes.find((node) =>
+    TEXT_OUTPUT_NODE_CLASS_TYPES.some((classType) => node.classType === classType)
+  )?.id;
 }
 
 export type RecommendedPresetSettings = {

--- a/src/comfy/setupManifest.ts
+++ b/src/comfy/setupManifest.ts
@@ -1,0 +1,257 @@
+import {
+  WorkflowModelFolder,
+  WorkflowModelLicenseGate,
+  WorkflowPresetDefinition,
+  WorkflowRequiredModel
+} from "./types";
+import { WORKFLOW_PRESETS, listRunnableWorkflowPresets } from "./presetRegistry";
+import { getModelTargetFolder, getModelTargetPath, getRequiredModelKey, listPresetRequiredModels } from "./modelFolders";
+
+/**
+ * The setup manifest: everything a bare ComfyUI install needs before OpenLayer
+ * works, derived entirely from the preset registry.
+ *
+ * This module is the single producer of that answer. The setup pack generator
+ * (`scripts/build-setup-pack.mjs`) serialises it to `requirements.json` and
+ * renders it as `REQUIREMENTS.md`; the in-panel Setup tab is meant to read the
+ * same structure and check it against a live server. Nothing downstream may
+ * restate a model name, a folder, or a node repository — restating is how a
+ * setup guide drifts from the software it describes.
+ */
+
+/**
+ * ComfyUI node classes that do NOT ship with core ComfyUI, and where to get
+ * them. Anything absent from this map is treated as core, which is safe only
+ * because `tests/comfy/workflowFiles.test.ts` freezes the full set of node
+ * classes the presets require — adding a custom node without adding it here
+ * fails that test.
+ */
+export const CUSTOM_NODE_PACKAGES: Record<string, { name: string; repoUrl: string }> = {
+  LineArtPreprocessor: {
+    name: "comfyui_controlnet_aux",
+    repoUrl: "https://github.com/Fannovel16/comfyui_controlnet_aux"
+  },
+  Florence2ModelLoader: {
+    name: "ComfyUI-Florence2",
+    repoUrl: "https://github.com/kijai/ComfyUI-Florence2"
+  },
+  Florence2Run: {
+    name: "ComfyUI-Florence2",
+    repoUrl: "https://github.com/kijai/ComfyUI-Florence2"
+  },
+  "ShowText|pysssss": {
+    name: "ComfyUI-Custom-Scripts",
+    repoUrl: "https://github.com/pythongosssss/ComfyUI-Custom-Scripts"
+  }
+};
+
+/** The port OpenLayer talks to by default, kept off 8188 on purpose. */
+export const DEFAULT_COMFYUI_PORT = 8190;
+
+export type SetupManifestModel = {
+  /** Stable identity: `<folder>/<file or directory name>`. */
+  key: string;
+  modelName: string;
+  label: string;
+  kind: string;
+  loaderNode: string;
+  loaderInput: string;
+  targetFolder: WorkflowModelFolder;
+  /** Install path relative to the ComfyUI root. */
+  targetPath: string;
+  downloadUrl?: string;
+  sourcePageUrl?: string;
+  sizeBytes?: number;
+  layout: "file" | "repo-folder";
+  licenseGate?: WorkflowModelLicenseGate;
+  acceptedModelNames?: string[];
+  setupHint?: string;
+  usedByPresets: string[];
+};
+
+export type SetupManifestCustomNode = {
+  name: string;
+  repoUrl: string;
+  classTypes: string[];
+  usedByPresets: string[];
+};
+
+export type SetupManifestPreset = {
+  id: string;
+  label: string;
+  mode: string;
+  status: string;
+  description: string;
+  workflowFile: string;
+  sourceWorkflowFile?: string;
+  modelKeys: string[];
+  customNodePackages: string[];
+};
+
+export type SetupManifest = {
+  /** Schema version for the file the panel will one day read. */
+  schemaVersion: 1;
+  pluginVersion: string;
+  generatedAt: string;
+  comfyui: {
+    defaultPort: number;
+  };
+  presets: SetupManifestPreset[];
+  models: SetupManifestModel[];
+  customNodes: SetupManifestCustomNode[];
+  totals: {
+    presets: number;
+    models: number;
+    /** Sum of known file sizes; repo-folder models contribute nothing. */
+    knownDownloadBytes: number;
+    licenseGatedModels: number;
+  };
+};
+
+export type BuildSetupManifestOptions = {
+  pluginVersion: string;
+  /** Defaults to the runnable presets: a `todo` preset has no workflow to ship. */
+  presets?: readonly WorkflowPresetDefinition[];
+  /** Injectable so generated output can be byte-stable in tests. */
+  generatedAt?: string;
+};
+
+function toManifestModel(model: WorkflowRequiredModel, usedByPresets: string[]): SetupManifestModel {
+  return {
+    key: getRequiredModelKey(model),
+    modelName: model.modelName,
+    label: model.label,
+    kind: model.kind,
+    loaderNode: model.objectInfoNode,
+    loaderInput: model.inputName,
+    targetFolder: getModelTargetFolder(model),
+    targetPath: getModelTargetPath(model),
+    downloadUrl: model.downloadUrl,
+    sourcePageUrl: model.sourcePageUrl,
+    sizeBytes: model.downloadSizeBytes,
+    layout: model.downloadLayout ?? "file",
+    licenseGate: model.licenseGate,
+    acceptedModelNames: model.acceptedModelNames ? [...model.acceptedModelNames] : undefined,
+    setupHint: model.setupHint,
+    usedByPresets
+  };
+}
+
+export function getCustomNodePackagesForPreset(preset: WorkflowPresetDefinition): string[] {
+  const names = new Set<string>();
+
+  for (const node of preset.requiredNodes) {
+    const custom = CUSTOM_NODE_PACKAGES[node.classType];
+
+    if (custom) {
+      names.add(custom.name);
+    }
+  }
+
+  return [...names].sort();
+}
+
+export function buildSetupManifest(options: BuildSetupManifestOptions): SetupManifest {
+  const presets = options.presets ?? listRunnableWorkflowPresets();
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+
+  const modelsByKey = new Map<string, SetupManifestModel>();
+  const nodesByName = new Map<string, SetupManifestCustomNode>();
+  const manifestPresets: SetupManifestPreset[] = [];
+
+  for (const preset of presets) {
+    const modelKeys: string[] = [];
+
+    for (const model of listPresetRequiredModels(preset)) {
+      const key = getRequiredModelKey(model);
+      modelKeys.push(key);
+
+      const existing = modelsByKey.get(key);
+
+      if (existing) {
+        existing.usedByPresets.push(preset.id);
+      } else {
+        modelsByKey.set(key, toManifestModel(model, [preset.id]));
+      }
+    }
+
+    for (const node of preset.requiredNodes) {
+      const custom = CUSTOM_NODE_PACKAGES[node.classType];
+
+      if (!custom) {
+        continue;
+      }
+
+      const existing = nodesByName.get(custom.name);
+
+      if (existing) {
+        if (!existing.classTypes.includes(node.classType)) {
+          existing.classTypes.push(node.classType);
+        }
+
+        if (!existing.usedByPresets.includes(preset.id)) {
+          existing.usedByPresets.push(preset.id);
+        }
+      } else {
+        nodesByName.set(custom.name, {
+          name: custom.name,
+          repoUrl: custom.repoUrl,
+          classTypes: [node.classType],
+          usedByPresets: [preset.id]
+        });
+      }
+    }
+
+    manifestPresets.push({
+      id: preset.id,
+      label: preset.label,
+      mode: preset.mode,
+      status: preset.status,
+      description: preset.description,
+      workflowFile: preset.workflowFile,
+      sourceWorkflowFile: preset.sourceWorkflowFile,
+      modelKeys: modelKeys.sort(),
+      customNodePackages: getCustomNodePackagesForPreset(preset)
+    });
+  }
+
+  const models = [...modelsByKey.values()].sort((left, right) => left.key.localeCompare(right.key));
+  const customNodes = [...nodesByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+
+  return {
+    schemaVersion: 1,
+    pluginVersion: options.pluginVersion,
+    generatedAt,
+    comfyui: {
+      defaultPort: DEFAULT_COMFYUI_PORT
+    },
+    presets: manifestPresets,
+    models,
+    customNodes,
+    totals: {
+      presets: manifestPresets.length,
+      models: models.length,
+      knownDownloadBytes: models.reduce((total, model) => total + (model.sizeBytes ?? 0), 0),
+      licenseGatedModels: models.filter((model) => model.licenseGate).length
+    }
+  };
+}
+
+/** Every preset in the registry, including `todo` ones, for diagnostics. */
+export function listAllPresetIds(): string[] {
+  return WORKFLOW_PRESETS.map((preset) => preset.id);
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes <= 0) {
+    return "unknown";
+  }
+
+  const gigabytes = bytes / 1024 ** 3;
+
+  if (gigabytes >= 1) {
+    return `${gigabytes.toFixed(1)} GB`;
+  }
+
+  return `${Math.round(bytes / 1024 ** 2)} MB`;
+}

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -58,6 +58,7 @@ import {
 } from "../metadata/layerMetadata";
 import { getCheckpointCompatibility } from "../comfy/modelCompatibility";
 import {
+  getPresetTextOutputNodeId,
   getRecommendedPresetSettings,
   getWorkflowPreset,
   listRunnableWorkflowPresets,
@@ -3056,7 +3057,7 @@ export function renderApp(rootElement: HTMLElement) {
         numBeams,
         seed
       });
-      const textOutputNodeId = getTextOutputNodeId(workflowResult.preset);
+      const textOutputNodeId = getPresetTextOutputNodeId(workflowResult.preset);
 
       setPromptLayerStatus(elements, "Running Florence-2 PromptGen...", "idle");
       setPromptLayerDiagnostics(
@@ -4108,10 +4109,6 @@ function createSourceMetaText(source: ExportedSourceImage) {
 
 function getSaveImageNodeId(preset: WorkflowPresetDefinition) {
   return preset.requiredNodes.find((node) => node.classType === "SaveImage")?.id;
-}
-
-function getTextOutputNodeId(preset: WorkflowPresetDefinition) {
-  return preset.requiredNodes.find((node) => node.classType.startsWith("ShowText"))?.id;
 }
 
 function readPromptLayerTask(elements: AppElements) {

--- a/src/workflows/api/prompt-from-layer-florence2.json
+++ b/src/workflows/api/prompt-from-layer-florence2.json
@@ -44,16 +44,16 @@
       "title": "Run Florence-2 PromptGen"
     }
   },
-  "45": {
-    "class_type": "ShowText|pysssss",
+  "41": {
+    "class_type": "PreviewAny",
     "inputs": {
-      "text": [
+      "source": [
         "38",
         2
       ]
     },
     "_meta": {
-      "title": "Show generated prompt text"
+      "title": "Preview generated prompt text"
     }
   }
 }

--- a/src/workflows/source/README.md
+++ b/src/workflows/source/README.md
@@ -30,7 +30,7 @@ The runnable OpenLayer API versions are in `src/workflows/api/`. If the GUI work
 
 `prompt-from-layer-florence2.workflow.json` is the GUI-editable Florence-2 PromptGen workflow for the Prompt from Layer tool.
 
-The runnable API version is in `src/workflows/api/prompt-from-layer-florence2.json`. It uses Florence2ModelLoader, LoadImage, Florence2Run, and ShowText to return caption text through ComfyUI history. If this source workflow is edited in ComfyUI, export a matching API workflow and update `src/comfy/presetRegistry.ts` node mappings before relying on it.
+The runnable API version is in `src/workflows/api/prompt-from-layer-florence2.json`. It uses Florence2ModelLoader, LoadImage, Florence2Run, and core ComfyUI's PreviewAny to return caption text through ComfyUI history. The `ShowText|pysssss` and `SaveText|pysssss` nodes this graph used to carry were removed so the preset needs no `comfyui-custom-scripts` install; PreviewAny was already wired to the same caption output. If this source workflow is edited in ComfyUI, export a matching API workflow and update `src/comfy/presetRegistry.ts` node mappings before relying on it — `tests/comfy/workflowFiles.test.ts` fails if the two drift apart.
 
 ## Flux Fill Notes
 

--- a/src/workflows/source/prompt-from-layer-florence2.workflow.json
+++ b/src/workflows/source/prompt-from-layer-florence2.workflow.json
@@ -85,50 +85,6 @@
       "widgets_values": []
     },
     {
-      "id": 43,
-      "type": "SaveText|pysssss",
-      "pos": [
-        1074.7272137707923,
-        764.6091738797028
-      ],
-      "size": [
-        270,
-        130
-      ],
-      "flags": {},
-      "order": 5,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "text",
-          "type": "STRING",
-          "link": 61
-        }
-      ],
-      "outputs": [
-        {
-          "name": "STRING",
-          "type": "STRING",
-          "links": null
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfyui-custom-scripts",
-        "ver": "1.2.5",
-        "ue_properties": {
-          "widget_ue_connectable": {},
-          "input_ue_unconnectable": {}
-        },
-        "Node name for S&R": "SaveText|pysssss"
-      },
-      "widgets_values": [
-        "input",
-        "file.txt",
-        "append",
-        true
-      ]
-    },
-    {
       "id": 42,
       "type": "LoadImage",
       "pos": [
@@ -217,9 +173,7 @@
           "name": "caption",
           "type": "STRING",
           "links": [
-            59,
-            61,
-            63
+            59
           ]
         },
         {
@@ -249,48 +203,6 @@
         "",
         284075328336101,
         "randomize"
-      ]
-    },
-    {
-      "id": 45,
-      "type": "ShowText|pysssss",
-      "pos": [
-        1032.3334223631023,
-        460.6842525814802
-      ],
-      "size": [
-        307.22540177843143,
-        223.46881422654906
-      ],
-      "flags": {},
-      "order": 6,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "text",
-          "type": "STRING",
-          "link": 63
-        }
-      ],
-      "outputs": [
-        {
-          "name": "STRING",
-          "shape": 6,
-          "type": "STRING",
-          "links": null
-        }
-      ],
-      "properties": {
-        "cnr_id": "comfyui-custom-scripts",
-        "ver": "1.2.5",
-        "ue_properties": {
-          "widget_ue_connectable": {},
-          "input_ue_unconnectable": {}
-        },
-        "Node name for S&R": "ShowText|pysssss"
-      },
-      "widgets_values": [
-        "The image shows a sculpture of a ghostly figure suspended in mid-air, suspended from a skylight above an empty room with concrete floors and white walls. The sculpture is made of white, fluid-like material that appears to be suspended in the air, creating a surreal and eerie atmosphere. On the right side of the image, there is a black and white abstract painting hanging on the wall. The room has a modern, minimalist design with clean lines and a minimalist aesthetic. The image is taken from a low angle, looking up at the sculpture."
       ]
     },
     {
@@ -348,22 +260,6 @@
       38,
       0,
       "IMAGE"
-    ],
-    [
-      61,
-      38,
-      2,
-      43,
-      0,
-      "STRING"
-    ],
-    [
-      63,
-      38,
-      2,
-      45,
-      0,
-      "STRING"
     ]
   ],
   "groups": [],

--- a/tests/comfy/presetRegistry.test.ts
+++ b/tests/comfy/presetRegistry.test.ts
@@ -80,7 +80,7 @@ describe("presetRegistry", () => {
     expect(preset.requiredModels?.some((model) => model.modelName === "Florence-2-base-PromptGen-v2.0")).toBe(true);
     expect(preset.requiredNodes.some((node) => node.classType === "Florence2ModelLoader")).toBe(true);
     expect(preset.requiredNodes.some((node) => node.classType === "Florence2Run")).toBe(true);
-    expect(preset.requiredNodes.some((node) => node.classType === "ShowText|pysssss")).toBe(true);
+    expect(preset.requiredNodes.some((node) => node.classType === "PreviewAny")).toBe(true);
     expect(preset.injections.sourceImage).toEqual({ nodeId: "42", inputName: "image" });
     expect(preset.injections.task).toEqual({ nodeId: "38", inputName: "task" });
     expect(preset.injections.numBeams).toEqual({ nodeId: "38", inputName: "num_beams" });

--- a/tests/comfy/setupManifest.test.ts
+++ b/tests/comfy/setupManifest.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  CUSTOM_NODE_PACKAGES,
+  DEFAULT_COMFYUI_PORT,
+  buildSetupManifest,
+  formatBytes,
+  getCustomNodePackagesForPreset
+} from "../../src/comfy/setupManifest";
+import { getWorkflowPreset, listRunnableWorkflowPresets, listWorkflowPresets } from "../../src/comfy/presetRegistry";
+
+const FIXED_TIMESTAMP = "2026-07-24T00:00:00.000Z";
+
+function build() {
+  return buildSetupManifest({ pluginVersion: "9.9.9", generatedAt: FIXED_TIMESTAMP });
+}
+
+describe("setup manifest", () => {
+  it("covers every runnable preset and no todo ones", () => {
+    const manifest = build();
+    const runnableIds = listRunnableWorkflowPresets().map((preset) => preset.id);
+    const todoIds = listWorkflowPresets()
+      .filter((preset) => preset.status === "todo")
+      .map((preset) => preset.id);
+
+    expect(manifest.presets.map((preset) => preset.id)).toEqual(runnableIds);
+    expect(manifest.totals.presets).toBe(runnableIds.length);
+
+    // A todo preset has no authored workflow JSON, so shipping setup
+    // instructions for it would point at a file that does not exist.
+    for (const id of todoIds) {
+      expect(manifest.presets.map((preset) => preset.id)).not.toContain(id);
+    }
+  });
+
+  it("lists every stable preset by name", () => {
+    const manifest = build();
+    const stableIds = listWorkflowPresets()
+      .filter((preset) => preset.status === "stable")
+      .map((preset) => preset.id);
+
+    expect(stableIds.length).toBeGreaterThan(0);
+
+    for (const id of stableIds) {
+      expect(manifest.presets.map((preset) => preset.id)).toContain(id);
+    }
+  });
+
+  it("gives every model an install path under the ComfyUI models folder", () => {
+    const manifest = build();
+
+    expect(manifest.models.length).toBeGreaterThan(0);
+
+    for (const model of manifest.models) {
+      expect(model.targetPath).toBe(`models/${model.targetFolder}`);
+      expect(model.key).toBe(`${model.targetFolder}/${model.modelName}`);
+      expect(model.usedByPresets.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("points every preset's model keys at models the manifest actually carries", () => {
+    const manifest = build();
+    const knownKeys = new Set(manifest.models.map((model) => model.key));
+
+    for (const preset of manifest.presets) {
+      for (const key of preset.modelKeys) {
+        expect(knownKeys, `${preset.id} references unknown model ${key}`).toContain(key);
+      }
+    }
+  });
+
+  it("attributes shared models to every preset that loads them", () => {
+    const manifest = build();
+    const sharedVae = manifest.models.find((model) => model.key === "vae/ae.safetensors");
+
+    expect(sharedVae).toBeDefined();
+    expect(sharedVae?.usedByPresets).toContain("inpaint-flux-fill-basic");
+    expect(sharedVae?.usedByPresets).toContain("txt2img-z-image-turbo");
+  });
+
+  it("requires only the two custom node packages that are left", () => {
+    const manifest = build();
+
+    expect(manifest.customNodes.map((node) => node.name)).toEqual([
+      "comfyui_controlnet_aux",
+      "ComfyUI-Florence2"
+    ]);
+
+    for (const node of manifest.customNodes) {
+      expect(node.repoUrl).toMatch(/^https:\/\/github\.com\//);
+      expect(node.classTypes.length).toBeGreaterThan(0);
+      expect(node.usedByPresets.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("does not ask anyone to install comfyui-custom-scripts", () => {
+    const manifest = build();
+
+    expect(manifest.customNodes.map((node) => node.name)).not.toContain("ComfyUI-Custom-Scripts");
+
+    for (const preset of manifest.presets) {
+      expect(preset.customNodePackages).not.toContain("ComfyUI-Custom-Scripts");
+    }
+  });
+
+  it("names no custom nodes for presets built entirely from core nodes", () => {
+    expect(getCustomNodePackagesForPreset(getWorkflowPreset("txt2img-basic"))).toEqual([]);
+    expect(getCustomNodePackagesForPreset(getWorkflowPreset("upscale-basic"))).toEqual([]);
+    expect(getCustomNodePackagesForPreset(getWorkflowPreset("sketch2img-linecn-basic"))).toEqual([
+      "comfyui_controlnet_aux"
+    ]);
+  });
+
+  it("keeps every custom node package entry usable as install instructions", () => {
+    for (const [classType, entry] of Object.entries(CUSTOM_NODE_PACKAGES)) {
+      expect(entry.name, `${classType} has no package name`).toBeTruthy();
+      expect(entry.repoUrl).toMatch(/^https:\/\/github\.com\//);
+    }
+  });
+
+  it("totals what a full install costs", () => {
+    const manifest = build();
+
+    expect(manifest.totals.models).toBe(manifest.models.length);
+    expect(manifest.totals.licenseGatedModels).toBe(2);
+    expect(manifest.totals.knownDownloadBytes).toBe(
+      manifest.models.reduce((total, model) => total + (model.sizeBytes ?? 0), 0)
+    );
+    expect(manifest.totals.knownDownloadBytes).toBeGreaterThan(50 * 1024 ** 3);
+  });
+
+  it("is deterministic so a regenerated pack only differs when the registry does", () => {
+    expect(JSON.stringify(build())).toBe(JSON.stringify(build()));
+  });
+
+  it("records the port OpenLayer actually defaults to", () => {
+    expect(build().comfyui.defaultPort).toBe(DEFAULT_COMFYUI_PORT);
+    expect(DEFAULT_COMFYUI_PORT).toBe(8190);
+  });
+});
+
+describe("formatBytes", () => {
+  it("reads naturally at the sizes these models actually are", () => {
+    expect(formatBytes(66961958)).toBe("64 MB");
+    expect(formatBytes(335304388)).toBe("320 MB");
+    expect(formatBytes(12309866400)).toBe("11.5 GB");
+    expect(formatBytes(0)).toBe("unknown");
+  });
+});

--- a/tests/comfy/workflowBuilder.test.ts
+++ b/tests/comfy/workflowBuilder.test.ts
@@ -99,7 +99,7 @@ describe("workflowBuilder", () => {
     expect(result.workflow["38"].inputs.task).toBe("detailed_caption");
     expect(result.workflow["38"].inputs.num_beams).toBe(12);
     expect(result.workflow["38"].inputs.seed).toBe(202607);
-    expect(result.workflow["45"].inputs.text).toEqual(["38", 2]);
+    expect(result.workflow["41"].inputs.source).toEqual(["38", 2]);
   });
 
   it("injects source image and model into upscale-basic", async () => {

--- a/tests/comfy/workflowFiles.test.ts
+++ b/tests/comfy/workflowFiles.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  getPresetTextOutputNodeId,
+  getWorkflowPreset,
+  listRunnableWorkflowPresets,
+  validateWorkflowForPreset
+} from "../../src/comfy/presetRegistry";
+import { ComfyWorkflow, WorkflowPresetDefinition } from "../../src/comfy/types";
+
+const SRC_ROOT = resolve(__dirname, "../../src");
+
+function loadApiWorkflow(preset: WorkflowPresetDefinition): ComfyWorkflow {
+  return JSON.parse(readFileSync(resolve(SRC_ROOT, preset.workflowFile), "utf8")) as ComfyWorkflow;
+}
+
+/**
+ * Every ComfyUI node class used by a runnable preset that does NOT ship with
+ * core ComfyUI, and the repository that provides it. Freezing this list is the
+ * point of the test: a preset that quietly reintroduces a custom-node
+ * dependency is a setup burden pushed onto every user, and it should not be
+ * possible to add one without editing this line.
+ */
+const EXPECTED_CUSTOM_NODE_CLASSES: Record<string, string> = {
+  LineArtPreprocessor: "comfyui_controlnet_aux",
+  Florence2ModelLoader: "ComfyUI-Florence2",
+  Florence2Run: "ComfyUI-Florence2"
+};
+
+describe("shipped API workflow files", () => {
+  const runnablePresets = listRunnableWorkflowPresets();
+
+  it("ships a workflow file for every runnable preset", () => {
+    expect(runnablePresets.length).toBeGreaterThan(0);
+
+    for (const preset of runnablePresets) {
+      expect(() => loadApiWorkflow(preset), `${preset.id} workflow file is missing`).not.toThrow();
+    }
+  });
+
+  it("keeps every runnable preset's node mapping in sync with its workflow JSON", () => {
+    for (const preset of runnablePresets) {
+      const workflow = loadApiWorkflow(preset);
+
+      expect(
+        () => validateWorkflowForPreset(workflow, preset),
+        `${preset.id} registry mapping drifted from its workflow JSON`
+      ).not.toThrow();
+    }
+  });
+
+  it("requires no custom nodes beyond the frozen inventory", () => {
+    const seen = new Set<string>();
+
+    for (const preset of runnablePresets) {
+      for (const node of preset.requiredNodes) {
+        if (node.classType in EXPECTED_CUSTOM_NODE_CLASSES) {
+          seen.add(node.classType);
+        }
+
+        // pysssss-style nodes namespace themselves with a pipe. None should
+        // remain: Prompt from Layer now publishes its caption through core
+        // ComfyUI's PreviewAny instead of ShowText|pysssss.
+        expect(node.classType, `${preset.id} requires a namespaced custom node`).not.toContain("|");
+      }
+    }
+
+    expect([...seen].sort()).toEqual(Object.keys(EXPECTED_CUSTOM_NODE_CLASSES).sort());
+  });
+});
+
+describe("getPresetTextOutputNodeId", () => {
+  it("finds the PreviewAny node that publishes the Florence caption", () => {
+    const preset = getWorkflowPreset("prompt-from-layer-florence2");
+
+    expect(getPresetTextOutputNodeId(preset)).toBe("41");
+  });
+
+  it("returns undefined for presets that produce images rather than text", () => {
+    expect(getPresetTextOutputNodeId(getWorkflowPreset("txt2img-basic"))).toBeUndefined();
+    expect(getPresetTextOutputNodeId(getWorkflowPreset("upscale-basic"))).toBeUndefined();
+  });
+});

--- a/tests/comfy/workflowFiles.test.ts
+++ b/tests/comfy/workflowFiles.test.ts
@@ -7,6 +7,7 @@ import {
   listRunnableWorkflowPresets,
   validateWorkflowForPreset
 } from "../../src/comfy/presetRegistry";
+import { CUSTOM_NODE_PACKAGES } from "../../src/comfy/setupManifest";
 import { ComfyWorkflow, WorkflowPresetDefinition } from "../../src/comfy/types";
 
 const SRC_ROOT = resolve(__dirname, "../../src");
@@ -16,17 +17,16 @@ function loadApiWorkflow(preset: WorkflowPresetDefinition): ComfyWorkflow {
 }
 
 /**
- * Every ComfyUI node class used by a runnable preset that does NOT ship with
- * core ComfyUI, and the repository that provides it. Freezing this list is the
- * point of the test: a preset that quietly reintroduces a custom-node
- * dependency is a setup burden pushed onto every user, and it should not be
- * possible to add one without editing this line.
+ * Every ComfyUI node class a runnable preset uses that does NOT ship with core
+ * ComfyUI. Freezing this list is the point of the test: a preset that quietly
+ * reintroduces a custom-node dependency is a setup burden pushed onto every
+ * user, and it should not be possible to add one without editing this line.
+ *
+ * The setup pack treats anything absent from `CUSTOM_NODE_PACKAGES` as core, so
+ * this test also guards that assumption — a new custom node that nobody
+ * registered there would be silently reported as core, and this fails first.
  */
-const EXPECTED_CUSTOM_NODE_CLASSES: Record<string, string> = {
-  LineArtPreprocessor: "comfyui_controlnet_aux",
-  Florence2ModelLoader: "ComfyUI-Florence2",
-  Florence2Run: "ComfyUI-Florence2"
-};
+const EXPECTED_CUSTOM_NODE_CLASSES = ["Florence2ModelLoader", "Florence2Run", "LineArtPreprocessor"];
 
 describe("shipped API workflow files", () => {
   const runnablePresets = listRunnableWorkflowPresets();
@@ -55,7 +55,7 @@ describe("shipped API workflow files", () => {
 
     for (const preset of runnablePresets) {
       for (const node of preset.requiredNodes) {
-        if (node.classType in EXPECTED_CUSTOM_NODE_CLASSES) {
+        if (node.classType in CUSTOM_NODE_PACKAGES) {
           seen.add(node.classType);
         }
 
@@ -66,7 +66,7 @@ describe("shipped API workflow files", () => {
       }
     }
 
-    expect([...seen].sort()).toEqual(Object.keys(EXPECTED_CUSTOM_NODE_CLASSES).sort());
+    expect([...seen].sort()).toEqual(EXPECTED_CUSTOM_NODE_CLASSES);
   });
 });
 

--- a/tests/comfy/workflowFiles.test.ts
+++ b/tests/comfy/workflowFiles.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  getPresetTextOutputNodeId,
+  getWorkflowPreset,
+  listRunnableWorkflowPresets,
+  validateWorkflowForPreset
+} from "../../src/comfy/presetRegistry";
+import { CUSTOM_NODE_PACKAGES } from "../../src/comfy/setupManifest";
+import { ComfyWorkflow, WorkflowPresetDefinition } from "../../src/comfy/types";
+
+const SRC_ROOT = resolve(__dirname, "../../src");
+
+function loadApiWorkflow(preset: WorkflowPresetDefinition): ComfyWorkflow {
+  return JSON.parse(readFileSync(resolve(SRC_ROOT, preset.workflowFile), "utf8")) as ComfyWorkflow;
+}
+
+/**
+ * Every ComfyUI node class a runnable preset uses that does NOT ship with core
+ * ComfyUI. Freezing this list is the point of the test: a preset that quietly
+ * reintroduces a custom-node dependency is a setup burden pushed onto every
+ * user, and it should not be possible to add one without editing this line.
+ *
+ * The setup pack treats anything absent from `CUSTOM_NODE_PACKAGES` as core, so
+ * this test also guards that assumption — a new custom node that nobody
+ * registered there would be silently reported as core, and this fails first.
+ */
+const EXPECTED_CUSTOM_NODE_CLASSES = ["Florence2ModelLoader", "Florence2Run", "LineArtPreprocessor"];
+
+describe("shipped API workflow files", () => {
+  const runnablePresets = listRunnableWorkflowPresets();
+
+  it("ships a workflow file for every runnable preset", () => {
+    expect(runnablePresets.length).toBeGreaterThan(0);
+
+    for (const preset of runnablePresets) {
+      expect(() => loadApiWorkflow(preset), `${preset.id} workflow file is missing`).not.toThrow();
+    }
+  });
+
+  it("keeps every runnable preset's node mapping in sync with its workflow JSON", () => {
+    for (const preset of runnablePresets) {
+      const workflow = loadApiWorkflow(preset);
+
+      expect(
+        () => validateWorkflowForPreset(workflow, preset),
+        `${preset.id} registry mapping drifted from its workflow JSON`
+      ).not.toThrow();
+    }
+  });
+
+  it("requires no custom nodes beyond the frozen inventory", () => {
+    const seen = new Set<string>();
+
+    for (const preset of runnablePresets) {
+      for (const node of preset.requiredNodes) {
+        if (node.classType in CUSTOM_NODE_PACKAGES) {
+          seen.add(node.classType);
+        }
+
+        // pysssss-style nodes namespace themselves with a pipe. None should
+        // remain: Prompt from Layer now publishes its caption through core
+        // ComfyUI's PreviewAny instead of ShowText|pysssss.
+        expect(node.classType, `${preset.id} requires a namespaced custom node`).not.toContain("|");
+      }
+    }
+
+    expect([...seen].sort()).toEqual(EXPECTED_CUSTOM_NODE_CLASSES);
+  });
+});
+
+describe("getPresetTextOutputNodeId", () => {
+  it("finds the PreviewAny node that publishes the Florence caption", () => {
+    const preset = getWorkflowPreset("prompt-from-layer-florence2");
+
+    expect(getPresetTextOutputNodeId(preset)).toBe("41");
+  });
+
+  it("returns undefined for presets that produce images rather than text", () => {
+    expect(getPresetTextOutputNodeId(getWorkflowPreset("txt2img-basic"))).toBeUndefined();
+    expect(getPresetTextOutputNodeId(getWorkflowPreset("upscale-basic"))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Bookkeeping fix, not new work.** #27's commits are not on `main`.

I set #27's base to `feat/model-setup-metadata` so its diff would show only the generator, on the assumption GitHub would retarget it to `main` once #26 merged. It didn't — merging #27 landed the setup pack **into `feat/model-setup-metadata`**, and `main` was merged from a commit before that. So right now:

```
origin/main                     → no src/comfy/setupManifest.ts, no setup-pack script
origin/feat/model-setup-metadata → has both (f39843c, the #27 merge)
```

That's why `npm run setup-pack` would still fail on `main`.

This PR merges the three missing commits into `main`:
- `8f2d231` merge of the Florence branch (already on main via #25 — no-op)
- `d41c565` the setup pack generator
- `f39843c` the #27 merge commit

My mistake in how I stacked the PRs; a stacked PR needs its base merged *first*, and these went in the other order. Nothing to re-review — this is exactly the code you already approved in #27.

### Verify after merging
```bash
git checkout main && git pull && npm test && npm run setup-pack
```
Expect **316 tests** (not 303) and `packages/openlayer-comfyui-setup-0.6.0.zip`.