### PR TITLE
Release v0.7.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.7.0-alpha - 2026-07-25
+
+Release focused on getting previews out of the cramped side panel and getting a new machine to a working ComfyUI without guesswork.
+
+### Added
+
+- Added a second dockable Photoshop panel, **OpenLayer Preview**, showing the current generation at whatever size you drag it to. It mirrors every preview surface — Text to Image, Image to Image, Sketch to Image, Inpaint, Outpaint, Upscale, and Live Painting — with a tool badge that marks frames still arriving, a 1:1 / Fit toggle, and a checkerboard backdrop so transparent results read correctly.
+- Added a generated ComfyUI setup pack, `npm run setup-pack`, producing `packages/openlayer-comfyui-setup-<version>.zip`: the workflows, an exact per-model requirements list, and a PowerShell downloader that fetches each model into the folder ComfyUI actually reads it from. Generated from the preset registry, so it cannot drift from the presets it describes.
+- Added download URLs, verified sizes, and derived install folders for all 13 models the runnable presets need. Every URL was checked with a live request, and where the model was already installed locally the served size matched the working file byte for byte.
+- Added licence gating for the two Flux weights. The downloader refuses to fetch them without an explicit acknowledgement and prints the non-commercial terms first.
+
+### Changed
+
+- Prompt from Layer no longer needs the `comfyui-custom-scripts` custom-node pack. Its caption is now published by core ComfyUI's `PreviewAny`, leaving `comfyui-florence2` as the only requirement for that tool.
+- Moved UXP panel-entrypoint registration into a small standalone script loaded ahead of the application bundle. Adobe's `entrypoints.setup()` throws when called more than about 20ms after plugin start (their PS-57605), which a deferred bundle can never satisfy.
+- The build now asserts that early script is present, undeferred, and ahead of the bundle, because a missing one fails as a silently blank panel in Photoshop rather than a build error.
+- Bumped plugin, package, visible UI, and landing page metadata to `0.7.0` / `v0.7.0-alpha`.
+
+### Fixed
+
+- Fixed the separated preview panel opening blank and refusing to resize. It was never being initialised, so Photoshop collapsed it to its minimum size.
+- Fixed a preview listener that threw on its first render being able to break whatever attached it.
+
+### Known limitations
+
+- The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the list and the downloader instead — an internet connection is required.
+- The preview panel always follows whichever tool published most recently. Pinning it to one tool is designed but not built.
+- Four presets name an editable GUI workflow that was never exported. The setup pack reports them and omits them rather than advertising files it does not contain.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+- CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
+
 ## v0.6.0-alpha - 2026-07-13
 
 UXP interface release focused on a denser Photoshop-native workflow, dependable progress feedback, and final real-panel rendering fixes.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,14 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.6.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows and the refreshed compact Photoshop UXP interface, not for production work yet.
+`v0.7.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows, the separated preview panel, and the ComfyUI setup pack, not for production work yet.
 
-New in `v0.6.0-alpha`:
+New in `v0.7.0-alpha`:
 
-- Redesigned the Home dashboard into a compact Adobe-style tool launcher with clearer available, experimental, and unavailable states.
-- Added sticky tool headers and a determinate ComfyUI progress bar driven by numeric generation progress.
-- Added collapsible Advanced settings, status tones, toggle feedback, import success feedback, and compact experimental-info controls.
-- Standardized form gutters and panel spacing across tool screens.
-- Hardened header spacing, progress geometry, typography, preview zoom, and long textarea behavior for the real Photoshop UXP renderer.
-- Enlarged prompt editors and made the Prompt from Layer generated-text field three times taller without unreliable auto-grow behavior.
-- Removed obsolete `control_after_generate` fields from bundled workflow JSON files.
+- Added **OpenLayer Preview**, a second dockable Photoshop panel that shows the current generation at whatever size you drag it to. It mirrors every tool — including Live Painting — and keeps the small in-panel previews as they are.
+- Added a generated ComfyUI setup pack (`npm run setup-pack`) with the workflows, an exact per-model requirements list, and a downloader that puts each model in the folder ComfyUI actually reads it from.
+- Added verified download URLs and install folders for all 13 models the runnable presets need, plus licence gating on the two Flux weights.
+- Prompt from Layer no longer needs the `comfyui-custom-scripts` custom-node pack.
 
 Included in this alpha:
 
@@ -87,9 +84,11 @@ The earlier card-based dashboard established OpenLayer's honest available/experi
 
 </details>
 
-v0.6.0-alpha tester focus:
+v0.7.0-alpha tester focus:
 
-- Confirm the compact dashboard, sticky tool headers, progress bar, Advanced settings, long prompt entry, and unavailable-tool dimming in Photoshop UXP.
+- Open **Plugins > OpenLayer Preview**, dock or float it, and confirm it follows every tool you generate with, including Live Painting.
+- Run `npm run setup-pack` and check the folder table in the generated `REQUIREMENTS.md` against your own ComfyUI install.
+- Confirm Prompt from Layer still returns a caption now that `comfyui-custom-scripts` is no longer required.
 - Confirm Text to Image, Image to Image, Z_image_Turbo, and experimental Flux1-dev fp8 Text to Image generation.
 - Confirm Prompt from Layer with the local Florence-2 PromptGen workflow.
 - Confirm Upscale with a local pixel/model upscale model such as `4x-UltraSharp.pth`.
@@ -98,7 +97,7 @@ v0.6.0-alpha tester focus:
 - Confirm inpaint-basic and Flux Fill Inpaint retain the v0.5.5 upload filename and alignment fixes, including Import to Layers.
 - Confirm Cancel Generation on both a running prompt and a queued prompt when ComfyUI is busy.
 
-Known v0.6.0-alpha boundaries:
+Known v0.7.0-alpha boundaries:
 
 - Image to Image is an early foundation path, not a full production workflow yet.
 - Sketch to Image is limited to the first SD 1.x LINECN starter workflow.
@@ -121,7 +120,9 @@ Known v0.6.0-alpha boundaries:
 - Outpaint is experimental and currently uses `outpaint-flux-fill-basic` with `flux1-fill-dev.safetensors`, `clip_l.safetensors`, `t5xxl_fp16.safetensors` or the accepted T5 fp8 fallback, and `ae.safetensors`.
 - Upscale currently uses a simple pixel/model upscale path. It does not use prompts, latent upscale, tiled diffusion, or creative enhancement.
 - Upscale needs ComfyUI's `UpscaleModelLoader` and `ImageUpscaleWithModel` nodes plus an installed upscale model such as `4x-UltraSharp.pth` or `RealESRGAN_x4plus.pth`.
-- The v0.6.0 release focuses on the compact UXP interface. Generation and Photoshop integration behavior should remain compatible with v0.5.5.
+- The separated preview panel always follows whichever tool generated most recently. Pinning it to a single tool is designed but not built.
+- The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the requirements list and a downloader instead. An internet connection is required.
+- The v0.7.0 release focuses on the preview panel and ComfyUI setup. Generation and Photoshop integration behavior should remain compatible with v0.6.0.
 - Layer, canvas, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
 - Live sampler previews require ComfyUI to be started with `--preview-method auto`, and the preview panel may flicker between steps until a future UI polish pass.
 - Classic v0.4 theme preserves the older visual feel, but it does not duplicate every old layout detail.
@@ -251,7 +252,7 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.6.0-alpha.zip
+packages/openlayer-v0.7.0-alpha.zip
 ```
 
 ## Loading In UXP Developer Tool
@@ -378,7 +379,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.6.0-alpha test result:
+Use this quick pass before reporting a v0.7.0-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
       "operatingSystem": "Windows, macOS",
       "applicationCategory": "DesignApplication",
       "applicationSubCategory": "Adobe Photoshop plugin",
-      "softwareVersion": "0.6.0-alpha",
+      "softwareVersion": "0.7.0-alpha",
       "description": "Open-source Photoshop UXP plugin that connects to a local ComfyUI server for AI image generation: text to image, image to image, sketch to image, inpaint, outpaint, and upscale with Stable Diffusion, SDXL, and Flux models.",
       "url": "https://mehran-ahmadi.com/OpenLayer/",
       "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases",
@@ -64,7 +64,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.6.0 · free &amp; open source</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.7.0 · free &amp; open source</p>
           <h1 id="hero-title">Local AI layers,<br><span class="grad">inside Photoshop.</span></h1>
           <p class="hero-lede">
             OpenLayer connects Photoshop to <strong>your own ComfyUI server</strong>.
@@ -91,14 +91,15 @@
 
       <section class="intro" aria-labelledby="intro-title">
         <div class="section-inner">
-          <p class="eyebrow">v0.6 artist-first interface</p>
+          <p class="eyebrow">v0.7 artist-first interface</p>
           <h2 id="intro-title">Local generation that now feels at home inside Photoshop.</h2>
           <p class="intro-lede">
             OpenLayer starts with dependable local workflows — text to image, image to image,
             sketch to image, experimental inpaint and outpaint, pixel upscale, lossless PNG
             source capture, live previews, diagnostics, and clean import into the active document.
-            v0.6 adds a denser Adobe-style launcher, sticky tool headers, real generation progress,
-            clearer availability states, and UXP-safe prompt editing without hiding the experimental edges.
+            v0.7 adds a second dockable panel that shows the current generation at any size, and a
+            generated ComfyUI setup pack that tells a new machine exactly which models it needs and which
+            folder each one belongs in — without hiding the experimental edges.
           </p>
         </div>
       </section>
@@ -175,7 +176,7 @@
       <section id="showcase" class="section" aria-labelledby="showcase-title">
         <div class="section-inner">
           <div class="section-heading">
-            <p class="eyebrow">Current build · v0.6.0</p>
+            <p class="eyebrow">Interface shots · v0.6</p>
             <h2 id="showcase-title">Proof from the real Photoshop panel</h2>
             <p class="section-lede">Each view below is a real local workflow, compressed for the web and loaded only when it approaches the viewport.</p>
           </div>
@@ -305,16 +306,16 @@ npm run build</code></pre>
           </div>
           <div class="status-grid">
             <article class="status-card status-card-ready">
-              <h3>v0.6 interface is ready to test</h3>
-              <p>The compact dashboard, sticky headers, real progress track, larger prompt fields, and unavailable-tool states have passed a real Photoshop UXP smoke test.</p>
+              <h3>Separated preview panel is ready to test</h3>
+              <p>A second dockable panel shows the current generation at any size, mirroring every tool including Live Painting. It has passed a real Photoshop UXP smoke test.</p>
             </article>
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.6.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.7.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
-              <p>v0.6.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
+              <p>v0.7.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
             </article>
             <article class="status-card">
               <h3>Flux Fill is experimental</h3>
@@ -335,11 +336,13 @@ npm run build</code></pre>
               <li>GPU-aware recommendations are advisory only. OpenLayer does not auto-switch models or workflows yet.</li>
               <li>Layer, canvas, and mask capture is limited to 16 megapixels until a downscale option is added.</li>
               <li>Inpaint and Outpaint should be tested on duplicate layers first.</li>
-              <li>Prompt from Layer requires the local Florence-2 PromptGen model plus text-output custom nodes.</li>
+              <li>Prompt from Layer requires the local Florence-2 PromptGen model and the comfyui-florence2 nodes. The custom-scripts pack is no longer needed.</li>
               <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.6.0 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.7.0 keeps the shared metadata foundation and session-history wiring.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
+              <li>The separated preview panel follows whichever tool generated most recently. Pinning it to one tool is future work.</li>
+              <li>The ComfyUI setup pack ships the requirements list and a downloader, not the model weights. An internet connection is required.</li>
             </ul>
           </details>
         </div>
@@ -363,6 +366,10 @@ npm run build</code></pre>
             <article>
               <h3>v0.6 · Compact UXP interface</h3>
               <p>A denser dashboard, sticky headers, determinate progress, Advanced settings, clearer availability, and prompt fields hardened in the real Photoshop renderer.</p>
+            </article>
+            <article>
+              <h3>v0.7 · Preview panel and guided setup</h3>
+              <p>A separated dockable preview panel mirroring every tool, a generated ComfyUI setup pack with verified model download locations, and one fewer custom-node dependency.</p>
             </article>
             <article>
               <h3>Next · Reliability and artist control</h3>
@@ -390,7 +397,7 @@ npm run build</code></pre>
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.6.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.7.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a>
       </p>

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -20,7 +20,7 @@ Use this checklist before publishing an OpenLayer alpha release.
 - Confirm `README.md` release version.
 - Confirm `CHANGELOG.md` release section.
 - Confirm `docs/index.html` landing page version.
-- Confirm the package name matches the release, for example `openlayer-v0.6.0-alpha.zip`.
+- Confirm the package name matches the release, for example `openlayer-v0.7.0-alpha.zip`.
 
 ## Public Alpha Truth Check
 
@@ -35,7 +35,7 @@ Use this checklist before publishing an OpenLayer alpha release.
 
 ## GitHub Release
 
-- Create a git tag, for example `v0.6.0-alpha`.
+- Create a git tag, for example `v0.7.0-alpha`.
 - Create a GitHub Release from the tag.
 - Mark the release as a pre-release.
 - Attach the package zip from `packages/`.

--- a/docs/setup-development.md
+++ b/docs/setup-development.md
@@ -13,7 +13,7 @@ npm run package
 
 `npm run build` writes the production plugin to `dist` and copies UXP assets such as `manifest.json` and workflow JSON files.
 
-`npm run package` derives the alpha label from `package.json` and zips `dist` into `packages/openlayer-v0.6.0-alpha.zip` for this release.
+`npm run package` derives the alpha label from `package.json` and zips `dist` into `packages/openlayer-v0.7.0-alpha.zip` for this release.
 
 ## ComfyUI Workflow Development
 

--- a/docs/testing-v0.1-alpha.md
+++ b/docs/testing-v0.1-alpha.md
@@ -31,7 +31,7 @@ npm run package
 Expected result:
 
 - A package is created in `packages`.
-- For this version, the package should be named `openlayer-v0.6.0-alpha.zip`.
+- For this version, the package should be named `openlayer-v0.7.0-alpha.zip`.
 
 If this fails:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlayer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlayer",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.openlayer.photoshop",
   "name": "OpenLayer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "index.html",
   "host": [
     {

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -1,7 +1,7 @@
 import { OpenLayerTheme } from "../utils/preferences";
 
 export const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-export const APP_VERSION = "0.6.0";
+export const APP_VERSION = "0.7.0";
 export const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 export const HISTORY_LIMIT = 5;
 export const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];


### PR DESCRIPTION
Release prep for **v0.7.0-alpha**. Four commits, one per task, so any of them can be reverted alone.

**0.7.0, not 0.7.2.** There is no 0.7.0 or 0.7.1 in the tags, the GitHub releases, or the CHANGELOG, so 0.7.2 would have left two versions unaccounted for. Confirmed with you before stamping.

| Commit | What |
|---|---|
| `b347971` | Version bump ×4 — `package.json`, `package-lock.json`, `src/manifest.json`, `APP_VERSION` |
| `7e1017a` | CHANGELOG section in the house format |
| `5a4e4f8` | README + setup/release/testing docs |
| `828333f` | Landing page (`docs/index.html`) |

### What's in the release
- **OpenLayer Preview** — second dockable panel, mirrors all seven preview surfaces including Live Painting, 1:1/Fit toggle, checkerboard stage.
- **ComfyUI setup pack** — `npm run setup-pack`, generated from the preset registry so it can't drift from the presets.
- **Verified model metadata** — download URLs, sizes and derived install folders for all 13 models; licence gating on the two Flux weights.
- **One fewer dependency** — Prompt from Layer no longer needs `comfyui-custom-scripts`.

### Two judgement calls worth your eyes

**1. Screenshots are still labelled v0.6, on purpose.** They're genuine v0.6 captures in `assets/v060/`. Relabelling them would make the page claim to show a build it doesn't. I also changed the showcase heading from "Current build · v0.6.0" to "Interface shots · v0.6", since "current build" would now be false.

**That leaves the headline feature with no picture** — there's no screenshot of the preview panel anywhere on the landing page. Capturing one needs a real Photoshop, so I noted it instead of faking it. You have the panel open already; if you drop a capture into `docs/assets/` I'll wire it into the showcase.

**2. One `v0.6.0` reference survives in the README** — the compatibility line, which has to name the previous version to mean anything.

### Validation
`npm run typecheck` ✅ · `npm test` ✅ **329/329** · `npm run build` ✅ · all four version stamps confirmed at `0.7.0`, including the one that reaches `dist/manifest.json` · working tree clean, no `dist/` tracked.

### Smoke checklist
1. Rebuild and **remove + re-add** the plugin in UXP DT (manifest version changed).
2. Panel footer should read **OpenLayer v0.7.0** — that's the `APP_VERSION` stamp landing.
3. One generation end to end with the preview panel open, to confirm nothing in the bump disturbed rendering.
4. `npm run setup-pack` — should emit `packages/openlayer-comfyui-setup-0.7.0.zip` with the new version in its README and `requirements.json`.
5. Open `docs/index.html` in a browser: hero badge, footer, and roadmap should all read v0.7, and the roadmap should have a v0.7 entry with "Next" no longer promising the preview panel.

### After merge
```bash
npm run package
```
→ `packages/openlayer-v0.7.0-alpha.zip`, then tag `v0.7.0-alpha` and attach it plus the setup pack to a GitHub Release. Say the word and I'll do the tag and release notes.