### PR TITLE
Bump the version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlayer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlayer",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.openlayer.photoshop",
   "name": "OpenLayer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "index.html",
   "host": [
     {

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -1,7 +1,7 @@
 import { OpenLayerTheme } from "../utils/preferences";
 
 export const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-export const APP_VERSION = "0.7.0";
+export const APP_VERSION = "0.8.0";
 export const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 export const HISTORY_LIMIT = 5;
 export const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];


### PR DESCRIPTION
Task 1 of the v0.8 plan. Opens the v0.8 line by moving every version surface at once, per `docs/release-checklist.md`.

## What changed

| File | Field |
| --- | --- |
| `package.json` | `version` |
| `package-lock.json` | root `version` **and** `packages[""].version` |
| `src/manifest.json` | `version` |
| `src/ui/appConstants.ts` | `APP_VERSION` |

Nothing else. No plugin behaviour, no markup, no workflow, no CI change.

## Validation

- `npm run typecheck` — clean
- `npm test` — 44 files, 329 tests passing
- `npm run build` — clean
- `npm run package` — produced `packages/openlayer-v0.8.0-alpha.zip`
- `dist/manifest.json` reads `0.8.0` and the built bundle contains the `0.8.0` string
- No `0.7.0` left in any of the four files

## Smoke test (~2 minutes)

1. Load `dist/manifest.json` in Adobe UXP Developer Tool.
2. Open Photoshop → Plugins → OpenLayer.
3. Panel footer reads **OpenLayer v0.8.0 · Developer: Mehran Ahmadi 2026**.
4. Settings screen → the diagnostics line reads **Diagnostics ready for v0.8.0**, and the Version row in the info block reads **v0.8.0**.
5. Settings → **Copy Diagnostics** → paste anywhere → the first lines include `Version: v0.8.0`.

No manifest entrypoint change, so UXP DT Reload is enough — you do not need to remove and re-add the plugin.

## Note on the branch

`release/v0.8.0` opens now because the checklist wants the bump early, and it will be reused at the end of v0.8 for the changelog, README, and landing-page commits. The tasks in between (ESLint, preview pinning, workflows, the App.ts slices) will branch off `main` individually, matching how v0.7.0 was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
