### PR TITLE
Pin the preview panel to one tool

### DIFF
--- a/docs/PREVIEW_PANEL.md
+++ b/docs/PREVIEW_PANEL.md
@@ -83,7 +83,32 @@ and a per-mount registry would strand one object URL per remount.
 CSS is deliberately self-contained — this panel renders outside the `.app-shell` theme root, so none
 of the compact theme's `!important` rules reach it (ORCHESTRATION §3).
 
-## Remaining step
+## Follow / pin — built in v0.8
 
-**Follow / pin** — the panel always follows whichever tool published last. A "pin to tool" dropdown
-is designed but unbuilt; nobody has asked for it yet.
+The panel follows whichever tool published last by default, and a header dropdown pins it to one
+tool instead. The case it exists for: iterating on an Inpaint, starting a Text to Image run to
+compare against, and losing the large panel to the new run.
+
+Pinning is a **retention** change, not a filter. The hub keeps one slot per tool alongside the
+most-recent pointer, and the panel resolves `pinned ? latestForTool(pin) : latest()` on every
+notification. Two behaviours fall out of that and are worth keeping:
+
+- Pinning to a tool that has not run this session shows an empty state naming that tool, not
+  whatever image happened to be on screen. A preview labelled with the wrong tool is worse than no
+  preview.
+- The panel is still notified when *other* tools publish; it simply re-resolves and finds nothing
+  new. The hub therefore holds no notion of who is looking at what.
+
+`PREVIEW_TOOLS` in `previewHub.ts` is the single source for both the `PreviewToolId` union and the
+dropdown, so a tool cannot be wired to publish without becoming pinnable, and the dropdown cannot
+offer a tool that never publishes. Prompt from Layer is deliberately absent — it produces caption
+text, not an image. A test freezes that inventory.
+
+The publication carries `toolId` and no label; the artist-facing string is derived from the id. The
+earlier `toolLabel` field let a publisher pass a display string that disagreed with the identity the
+pin matches on.
+
+The choice persists in `localStorage` under `openlayer.previewPanel.pin.v1` — its own key, not part
+of `OpenLayerPreferences`, which is written wholesale from the settings form and would clobber a
+field no form control owns. A stored id is validated against `PREVIEW_TOOLS` on read, so a pin left
+by an older build cannot strand the panel on a tool that no longer exists.

--- a/src/styles.css
+++ b/src/styles.css
@@ -7363,6 +7363,29 @@ body,
   color: #e0913a;
 }
 
+/* Pin control. Styled from scratch for the same reason as everything else in
+   this block: the panel renders outside .app-shell, so it inherits none of the
+   compact theme's select styling. Given a fixed max-width so a long tool name
+   cannot squeeze the badge out of the header on a narrow panel. */
+.openlayer-preview-panel-pin {
+  max-width: 132px;
+  flex: 0 1 auto;
+  padding: 2px 6px;
+  border: 1px solid #4a4a4a;
+  border-radius: 3px;
+  margin-left: auto;
+  background: #383838;
+  color: #d7dde6;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+}
+
+.openlayer-preview-panel-pin:hover {
+  border-color: #5f5f5f;
+  background: #424242;
+}
+
 .openlayer-preview-panel-fit {
   flex: 0 0 auto;
   padding: 3px 9px;

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -307,7 +307,7 @@ export function renderApp(rootElement: HTMLElement) {
     urls: objectUrls,
     panel: elements.previewPanel,
     hub: previewHub,
-    toolLabel: "Text to Image",
+    toolId: "text-to-image",
     emptyText: "No result yet",
     resultAlt: "Generated OpenLayer preview",
     liveAlt: "Live ComfyUI generation preview"
@@ -316,7 +316,7 @@ export function renderApp(rootElement: HTMLElement) {
     urls: objectUrls,
     panel: elements.imageResultPreviewPanel,
     hub: previewHub,
-    toolLabel: "Image to Image",
+    toolId: "image-to-image",
     emptyText: "No Image to Image result yet",
     resultAlt: "Generated Image to Image preview",
     liveAlt: "Live ComfyUI Image to Image preview"
@@ -325,7 +325,7 @@ export function renderApp(rootElement: HTMLElement) {
     urls: objectUrls,
     panel: elements.sketchResultPreviewPanel,
     hub: previewHub,
-    toolLabel: "Sketch to Image",
+    toolId: "sketch-to-image",
     emptyText: "No Sketch to Image result yet",
     resultAlt: "Generated Sketch to Image preview",
     liveAlt: "Live ComfyUI Sketch to Image preview"
@@ -334,7 +334,7 @@ export function renderApp(rootElement: HTMLElement) {
     urls: objectUrls,
     panel: elements.inpaintResultPreviewPanel,
     hub: previewHub,
-    toolLabel: "Inpaint",
+    toolId: "inpaint",
     emptyText: "No Inpaint result yet",
     resultAlt: "Generated Inpaint preview",
     liveAlt: "Live ComfyUI Inpaint preview"
@@ -343,7 +343,7 @@ export function renderApp(rootElement: HTMLElement) {
     urls: objectUrls,
     panel: elements.outpaintResultPreviewPanel,
     hub: previewHub,
-    toolLabel: "Outpaint",
+    toolId: "outpaint",
     emptyText: "No Outpaint result yet",
     resultAlt: "Generated Outpaint preview",
     liveAlt: "Live ComfyUI Outpaint preview"
@@ -352,7 +352,7 @@ export function renderApp(rootElement: HTMLElement) {
     urls: objectUrls,
     panel: elements.upscaleResultPreviewPanel,
     hub: previewHub,
-    toolLabel: "Upscale",
+    toolId: "upscale",
     emptyText: "No Upscale result yet",
     resultAlt: "Generated Upscale preview",
     liveAlt: "Live ComfyUI Upscale preview"
@@ -3397,7 +3397,7 @@ export function renderApp(rootElement: HTMLElement) {
     // It runs after the in-panel image is updated, so the primary surface is
     // never waiting on the mirror.
     previewHub.publish({
-      toolLabel: "Live Painting",
+      toolId: "live-painting",
       kind: options.kind ?? "live",
       blob
     });

--- a/src/ui/previewHub.ts
+++ b/src/ui/previewHub.ts
@@ -10,16 +10,57 @@
  * mint and own its own URL, and nothing has to reason about the other's
  * lifetime.
  *
- * Only the latest publication is retained. That is deliberate rather than lazy:
- * a panel the artist opens *after* a generation finishes still has something to
+ * The latest publication is retained. That is deliberate rather than lazy: a
+ * panel the artist opens *after* a generation finishes still has something to
  * show, which is the difference between a preview panel and a live-only feed.
+ *
+ * It is retained **per tool** as well as overall, which is what lets the panel
+ * be pinned. Pinning to Inpaint and then generating in Text to Image has to
+ * leave the panel showing Inpaint's last result, and pinning to a tool that has
+ * not run yet has to show the empty state rather than whatever happened to be
+ * on screen. Both fall out of keeping one slot per tool.
  */
 
 export type PreviewPublicationKind = "live" | "result";
 
+/**
+ * Every tool that can put an image on a preview surface, in dashboard order.
+ *
+ * This is the single source for both the `PreviewToolId` union and the panel's
+ * pin dropdown, so a tool cannot be wired to publish without also being
+ * pinnable, and the dropdown cannot offer a tool that never publishes.
+ *
+ * Prompt from Layer is deliberately absent: it produces caption text, not an
+ * image, and has no result preview panel. Offering it as a pin target would
+ * mean a choice that can only ever show "nothing yet".
+ */
+export const PREVIEW_TOOLS = [
+  { id: "text-to-image", label: "Text to Image" },
+  { id: "image-to-image", label: "Image to Image" },
+  { id: "sketch-to-image", label: "Sketch to Image" },
+  { id: "inpaint", label: "Inpaint" },
+  { id: "outpaint", label: "Outpaint" },
+  { id: "upscale", label: "Upscale" },
+  { id: "live-painting", label: "Live Painting" }
+] as const;
+
+export type PreviewToolId = (typeof PREVIEW_TOOLS)[number]["id"];
+
+export function isPreviewToolId(value: unknown): value is PreviewToolId {
+  return PREVIEW_TOOLS.some((tool) => tool.id === value);
+}
+
+export function getPreviewToolLabel(toolId: PreviewToolId): string {
+  return PREVIEW_TOOLS.find((tool) => tool.id === toolId)?.label ?? "OpenLayer";
+}
+
 export type PreviewPublication = {
-  /** Artist-facing tool name, e.g. "Inpaint". */
-  toolLabel: string;
+  /**
+   * Which tool published. The artist-facing label is derived from this rather
+   * than carried alongside it, so a publisher cannot pass a label that
+   * disagrees with the id the pin matches on.
+   */
+  toolId: PreviewToolId;
   kind: PreviewPublicationKind;
   blob: Blob;
 };
@@ -28,19 +69,31 @@ export type PreviewHubListener = (publication: PreviewPublication | null) => voi
 
 export type PreviewHub = {
   publish: (publication: PreviewPublication) => void;
-  /** Drops the retained publication and tells every listener the surface is empty. */
+  /** Drops every retained publication and tells listeners the surface is empty. */
   clear: () => void;
   latest: () => PreviewPublication | null;
+  /**
+   * The given tool's most recent publication, or null if it has not published
+   * this session. A pinned panel resolves through this, which is why pinning to
+   * an idle tool shows the empty state instead of another tool's image.
+   */
+  latestForTool: (toolId: PreviewToolId) => PreviewPublication | null;
   /**
    * Subscribes and immediately replays the current publication, so a listener
    * attaching late renders the right thing without a separate initial read.
    * Returns an unsubscribe function.
+   *
+   * Listeners are notified on every publication regardless of tool, and a
+   * pinned surface re-resolves through `latestForTool` rather than filtering
+   * the delivered value. That keeps the hub free of any notion of who is
+   * looking at what.
    */
   subscribe: (listener: PreviewHubListener) => () => void;
 };
 
 export function createPreviewHub(): PreviewHub {
   const listeners = new Set<PreviewHubListener>();
+  const byTool = new Map<PreviewToolId, PreviewPublication>();
   let latest: PreviewPublication | null = null;
 
   // One broken listener must not stop the others from updating, and must never
@@ -64,17 +117,20 @@ export function createPreviewHub(): PreviewHub {
   return {
     publish(publication) {
       latest = publication;
+      byTool.set(publication.toolId, publication);
       notify();
     },
     clear() {
-      if (!latest) {
+      if (!latest && byTool.size === 0) {
         return;
       }
 
       latest = null;
+      byTool.clear();
       notify();
     },
     latest: () => latest,
+    latestForTool: (toolId) => byTool.get(toolId) ?? null,
     subscribe(listener) {
       listeners.add(listener);
       deliver(listener);

--- a/src/ui/previewPanel.ts
+++ b/src/ui/previewPanel.ts
@@ -1,6 +1,15 @@
 import { createObjectUrlRegistry } from "./objectUrlRegistry";
 import { createOwnedObjectUrl } from "./previewState";
-import { PreviewHub, PreviewPublication, previewHub as sharedPreviewHub } from "./previewHub";
+import {
+  getPreviewToolLabel,
+  isPreviewToolId,
+  PREVIEW_TOOLS,
+  PreviewHub,
+  PreviewPublication,
+  previewHub as sharedPreviewHub,
+  PreviewToolId
+} from "./previewHub";
+import { loadPreviewPanelPin, savePreviewPanelPin } from "../utils/preferences";
 
 /**
  * The separated `openlayerPreview` panel: a large, resizable surface showing the
@@ -28,6 +37,8 @@ const KIND_LABEL: Record<PreviewPublication["kind"], string> = {
   result: "result"
 };
 
+const DEFAULT_EMPTY_MESSAGE = "Previews appear here while you generate.";
+
 export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = sharedPreviewHub) {
   // A remount must not leave the previous subscription feeding a detached node.
   unsubscribe?.();
@@ -44,18 +55,38 @@ export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = s
   const badge = document.createElement("span");
   badge.className = "openlayer-preview-panel-badge";
 
+  // Pin control. "Follow active tool" is the default and the v0.7 behaviour;
+  // choosing a tool freezes the panel on that tool's output, which is the point
+  // — an artist iterating on an Inpaint should not lose the panel to a Text to
+  // Image run started to compare against.
+  const pinSelect = document.createElement("select");
+  pinSelect.className = "openlayer-preview-panel-pin";
+  pinSelect.title = "Choose which tool this panel shows";
+
+  const followOption = document.createElement("option");
+  followOption.value = "";
+  followOption.textContent = "Follow active tool";
+  pinSelect.append(followOption);
+
+  for (const tool of PREVIEW_TOOLS) {
+    const option = document.createElement("option");
+    option.value = tool.id;
+    option.textContent = tool.label;
+    pinSelect.append(option);
+  }
+
   const fitButton = document.createElement("button");
   fitButton.type = "button";
   fitButton.className = "openlayer-preview-panel-fit";
 
-  header.append(badge, fitButton);
+  header.append(badge, pinSelect, fitButton);
 
   const stage = document.createElement("div");
   stage.className = "openlayer-preview-panel-stage";
 
   const emptyMessage = document.createElement("span");
   emptyMessage.className = "openlayer-preview-panel-empty";
-  emptyMessage.textContent = "Previews appear here while you generate.";
+  emptyMessage.textContent = DEFAULT_EMPTY_MESSAGE;
 
   // One persistent img, reused across live frames. Rebuilding it per frame
   // flickers between sampler steps — the same fix the in-panel preview needed.
@@ -83,13 +114,29 @@ export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = s
 
   applyFitMode();
 
-  const render = (publication: PreviewPublication | null) => {
+  // Restored from the last session, but only if it still names a tool that
+  // exists — a stale id from an older build must not leave the panel pinned to
+  // something that can never publish again.
+  const storedPin = loadPreviewPanelPin();
+  let pinnedToolId: PreviewToolId | null = isPreviewToolId(storedPin) ? storedPin : null;
+  pinSelect.value = pinnedToolId ?? "";
+
+  const resolve = (): PreviewPublication | null =>
+    pinnedToolId ? hub.latestForTool(pinnedToolId) : hub.latest();
+
+  const render = () => {
+    const publication = resolve();
+
     if (!publication) {
       ownedUrl.release();
       image.hidden = true;
       image.removeAttribute("src");
+      emptyMessage.textContent = pinnedToolId
+        ? `No ${getPreviewToolLabel(pinnedToolId)} preview yet this session.`
+        : DEFAULT_EMPTY_MESSAGE;
       emptyMessage.hidden = false;
-      badge.textContent = "";
+      badge.textContent = pinnedToolId ? `${getPreviewToolLabel(pinnedToolId)} · pinned` : "";
+      badge.classList.remove("is-live");
       fitButton.hidden = true;
       return;
     }
@@ -97,13 +144,24 @@ export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = s
     emptyMessage.hidden = true;
     image.hidden = false;
     fitButton.hidden = false;
-    badge.textContent = `${publication.toolLabel} · ${KIND_LABEL[publication.kind]}`;
+    badge.textContent = `${getPreviewToolLabel(publication.toolId)} · ${KIND_LABEL[publication.kind]}`;
     badge.classList.toggle("is-live", publication.kind === "live");
     // createFrom revokes the previous URL before returning the new one, so a
     // whole live sequence keeps exactly one alive.
     image.src = ownedUrl.createFrom(publication.blob);
   };
 
+  pinSelect.addEventListener("change", () => {
+    const value = pinSelect.value;
+    pinnedToolId = isPreviewToolId(value) ? value : null;
+    savePreviewPanelPin(pinnedToolId ?? "");
+    // Re-resolve immediately rather than waiting for the next publication: the
+    // artist expects the panel to answer the moment they choose.
+    render();
+  });
+
+  // Every publication re-renders, whoever sent it; a pinned panel simply
+  // re-resolves and finds nothing new for its tool.
   unsubscribe = hub.subscribe(render);
 
   if (!teardownRegistered) {

--- a/src/ui/previewState.ts
+++ b/src/ui/previewState.ts
@@ -1,5 +1,5 @@
 import { ObjectUrlRegistry } from "./objectUrlRegistry";
-import { PreviewHub } from "./previewHub";
+import { PreviewHub, PreviewToolId } from "./previewHub";
 
 // One owned object-URL slot. Whatever URL it holds is revoked when a new one
 // takes its place or the slot is released, so a panel can never leak the URL of
@@ -106,14 +106,16 @@ export function createResultPreviewPanel(options: {
   // not this panel's owned URL, so both surfaces own their own URLs and A5 does
   // not depend on which panel tears down first.
   hub?: PreviewHub;
-  toolLabel?: string;
+  toolId?: PreviewToolId;
 }): ResultPreviewPanel {
   const publish = (kind: "live" | "result", blob: Blob) => {
-    if (!options.hub) {
+    // Both or neither: a hub with no tool id could not be pinned to anything,
+    // and an id with no hub has nowhere to go.
+    if (!options.hub || !options.toolId) {
       return;
     }
 
-    options.hub.publish({ toolLabel: options.toolLabel ?? "OpenLayer", kind, blob });
+    options.hub.publish({ toolId: options.toolId, kind, blob });
   };
 
   const resultUrl = createOwnedObjectUrl(options.urls);

--- a/src/utils/preferences.ts
+++ b/src/utils/preferences.ts
@@ -64,6 +64,56 @@ export function clearOpenLayerPreferences() {
   }
 }
 
+/**
+ * The preview panel's pinned tool, stored under its own key rather than inside
+ * OpenLayerPreferences.
+ *
+ * Two reasons to keep it separate. OpenLayerPreferences is written wholesale
+ * from the settings form and sanitised against it, so a field no form control
+ * owns would be a standing invitation to clobber; and the preview panel is a
+ * different entrypoint that may render with no settings screen ever having been
+ * opened. Both panels share one JavaScript context, so plain localStorage
+ * reaches it either way.
+ *
+ * The value is an opaque string here — this module has no business knowing
+ * which tools exist. The panel validates it against the tool list on read.
+ */
+const PREVIEW_PANEL_PIN_KEY = "openlayer.previewPanel.pin.v1";
+
+export function loadPreviewPanelPin(): string {
+  const storage = getStorage();
+
+  if (!storage) {
+    return "";
+  }
+
+  try {
+    return storage.getItem(PREVIEW_PANEL_PIN_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function savePreviewPanelPin(toolId: string) {
+  const storage = getStorage();
+
+  if (!storage) {
+    return false;
+  }
+
+  try {
+    if (toolId) {
+      storage.setItem(PREVIEW_PANEL_PIN_KEY, toolId);
+    } else {
+      storage.removeItem(PREVIEW_PANEL_PIN_KEY);
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getStorage(): Storage | null {
   try {
     return typeof localStorage === "undefined" ? null : localStorage;

--- a/tests/ui/previewHub.test.ts
+++ b/tests/ui/previewHub.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPreviewHub, PreviewPublication } from "../../src/ui/previewHub";
+import {
+  createPreviewHub,
+  getPreviewToolLabel,
+  isPreviewToolId,
+  PREVIEW_TOOLS,
+  PreviewPublication,
+  PreviewToolId
+} from "../../src/ui/previewHub";
 import { createObjectUrlRegistry } from "../../src/ui/objectUrlRegistry";
 import { createResultPreviewPanel } from "../../src/ui/previewState";
 
@@ -21,14 +28,14 @@ function installFakeDom() {
   };
 }
 
-function publication(toolLabel: string, kind: PreviewPublication["kind"], marker: string): PreviewPublication {
-  return { toolLabel, kind, blob: blob(marker) };
+function publication(toolId: PreviewToolId, kind: PreviewPublication["kind"], marker: string): PreviewPublication {
+  return { toolId, kind, blob: blob(marker) };
 }
 
 describe("previewHub", () => {
   it("replays the current publication to a listener that subscribes late", () => {
     const hub = createPreviewHub();
-    hub.publish(publication("Inpaint", "result", "a"));
+    hub.publish(publication("inpaint", "result", "a"));
 
     const listener = vi.fn();
     hub.subscribe(listener);
@@ -36,7 +43,7 @@ describe("previewHub", () => {
     // The point of retaining the latest publication: a preview panel the artist
     // opens after a generation finishes still has something to show.
     expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener.mock.calls[0][0]).toMatchObject({ toolLabel: "Inpaint", kind: "result" });
+    expect(listener.mock.calls[0][0]).toMatchObject({ toolId: "inpaint", kind: "result" });
   });
 
   it("replays null when nothing has been published", () => {
@@ -51,9 +58,9 @@ describe("previewHub", () => {
     const listener = vi.fn();
     hub.subscribe(listener);
 
-    hub.publish(publication("Text to Image", "live", "frame-1"));
-    hub.publish(publication("Text to Image", "live", "frame-2"));
-    hub.publish(publication("Text to Image", "result", "final"));
+    hub.publish(publication("text-to-image", "live", "frame-1"));
+    hub.publish(publication("text-to-image", "live", "frame-2"));
+    hub.publish(publication("text-to-image", "result", "final"));
 
     expect(hub.latest()?.blob).toEqual(blob("final"));
     expect(hub.latest()?.kind).toBe("result");
@@ -67,10 +74,10 @@ describe("previewHub", () => {
     hub.subscribe(first);
     hub.subscribe(second);
 
-    hub.publish(publication("Upscale", "result", "x"));
+    hub.publish(publication("upscale", "result", "x"));
 
-    expect(first).toHaveBeenLastCalledWith(expect.objectContaining({ toolLabel: "Upscale" }));
-    expect(second).toHaveBeenLastCalledWith(expect.objectContaining({ toolLabel: "Upscale" }));
+    expect(first).toHaveBeenLastCalledWith(expect.objectContaining({ toolId: "upscale" }));
+    expect(second).toHaveBeenLastCalledWith(expect.objectContaining({ toolId: "upscale" }));
   });
 
   it("stops notifying after unsubscribe", () => {
@@ -79,7 +86,7 @@ describe("previewHub", () => {
     const unsubscribe = hub.subscribe(listener);
     unsubscribe();
 
-    hub.publish(publication("Outpaint", "result", "x"));
+    hub.publish(publication("outpaint", "result", "x"));
 
     expect(listener).toHaveBeenCalledTimes(1);
   });
@@ -92,7 +99,7 @@ describe("previewHub", () => {
     hub.clear();
     expect(listener).toHaveBeenCalledTimes(1);
 
-    hub.publish(publication("Inpaint", "result", "x"));
+    hub.publish(publication("inpaint", "result", "x"));
     hub.clear();
 
     expect(hub.latest()).toBeNull();
@@ -109,15 +116,15 @@ describe("previewHub", () => {
     hub.subscribe(listener);
 
     for (let frame = 0; frame < 30; frame += 1) {
-      hub.publish(publication("Live Painting", "live", `frame-${frame}`));
+      hub.publish(publication("live-painting", "live", `frame-${frame}`));
     }
 
-    expect(hub.latest()).toMatchObject({ toolLabel: "Live Painting", kind: "live" });
+    expect(hub.latest()).toMatchObject({ toolId: "live-painting", kind: "live" });
     expect(hub.latest()?.blob).toEqual(blob("frame-29"));
 
-    hub.publish(publication("Live Painting", "result", "refined"));
+    hub.publish(publication("live-painting", "result", "refined"));
 
-    expect(hub.latest()).toMatchObject({ toolLabel: "Live Painting", kind: "result" });
+    expect(hub.latest()).toMatchObject({ toolId: "live-painting", kind: "result" });
     expect(hub.latest()?.blob).toEqual(blob("refined"));
     expect(listener).toHaveBeenCalledTimes(32);
   });
@@ -131,8 +138,109 @@ describe("previewHub", () => {
     hub.subscribe(healthy);
 
     // A preview surface must never be able to break the generation that fed it.
-    expect(() => hub.publish(publication("Inpaint", "result", "x"))).not.toThrow();
-    expect(healthy).toHaveBeenLastCalledWith(expect.objectContaining({ toolLabel: "Inpaint" }));
+    expect(() => hub.publish(publication("inpaint", "result", "x"))).not.toThrow();
+    expect(healthy).toHaveBeenLastCalledWith(expect.objectContaining({ toolId: "inpaint" }));
+  });
+});
+
+describe("per-tool retention (what pinning resolves through)", () => {
+  // The preview panel resolves exactly this way: pinned ? latestForTool(pin) :
+  // latest(). These cover the resolution; the select element itself is verified
+  // in Photoshop, since this suite deliberately runs without a DOM.
+  const resolve = (hub: ReturnType<typeof createPreviewHub>, pin: PreviewToolId | null) =>
+    pin ? hub.latestForTool(pin) : hub.latest();
+
+  it("keeps one slot per tool, so a pinned tool survives another tool publishing", () => {
+    const hub = createPreviewHub();
+    hub.publish(publication("inpaint", "result", "inpaint-final"));
+    hub.publish(publication("text-to-image", "result", "t2i-final"));
+
+    // The whole point of the feature: iterating on an Inpaint must not lose the
+    // panel to a Text to Image run started to compare against.
+    expect(resolve(hub, "inpaint")?.blob).toEqual(blob("inpaint-final"));
+    expect(resolve(hub, null)?.blob).toEqual(blob("t2i-final"));
+  });
+
+  it("shows nothing for a tool that has not published this session", () => {
+    const hub = createPreviewHub();
+    hub.publish(publication("inpaint", "result", "inpaint-final"));
+
+    // Not the most recent image, which would be a lie about which tool made it.
+    expect(resolve(hub, "upscale")).toBeNull();
+    expect(hub.latestForTool("upscale")).toBeNull();
+  });
+
+  it("advances the pinned tool's slot when that tool publishes again", () => {
+    const hub = createPreviewHub();
+    hub.publish(publication("outpaint", "live", "frame-1"));
+    hub.publish(publication("text-to-image", "live", "other-tool"));
+    hub.publish(publication("outpaint", "result", "outpaint-final"));
+
+    expect(resolve(hub, "outpaint")).toMatchObject({ toolId: "outpaint", kind: "result" });
+    expect(resolve(hub, "outpaint")?.blob).toEqual(blob("outpaint-final"));
+  });
+
+  it("empties every per-tool slot on clear, not just the most recent", () => {
+    // disposeAppResources calls clear(); a preview panel left open must not keep
+    // showing a result from a closed session, pinned or not.
+    const hub = createPreviewHub();
+    hub.publish(publication("inpaint", "result", "a"));
+    hub.publish(publication("upscale", "result", "b"));
+
+    hub.clear();
+
+    expect(hub.latest()).toBeNull();
+    expect(hub.latestForTool("inpaint")).toBeNull();
+    expect(hub.latestForTool("upscale")).toBeNull();
+  });
+
+  it("notifies a pinned listener even when another tool published", () => {
+    // The panel re-resolves on every notification rather than filtering, so it
+    // has to be told about publications that are not its own.
+    const hub = createPreviewHub();
+    const listener = vi.fn();
+    hub.subscribe(listener);
+
+    hub.publish(publication("text-to-image", "result", "x"));
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("PREVIEW_TOOLS inventory", () => {
+  it("lists every tool that publishes a preview, and nothing that does not", () => {
+    // Frozen on purpose, the same way toolDescriptors freezes its tables: a tool
+    // wired to publish without being added here would not be pinnable, and a
+    // tool listed here that never publishes is a dropdown entry that can only
+    // ever show "nothing yet". Prompt from Layer produces caption text and is
+    // correctly absent.
+    expect(PREVIEW_TOOLS.map((tool) => tool.id)).toEqual([
+      "text-to-image",
+      "image-to-image",
+      "sketch-to-image",
+      "inpaint",
+      "outpaint",
+      "upscale",
+      "live-painting"
+    ]);
+    expect(PREVIEW_TOOLS.map((tool) => tool.id)).not.toContain("prompt-from-layer");
+  });
+
+  it("gives every tool a label for the badge and the dropdown", () => {
+    for (const tool of PREVIEW_TOOLS) {
+      expect(getPreviewToolLabel(tool.id)).toBe(tool.label);
+      expect(tool.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects a stored pin that no longer names a real tool", () => {
+    // A pin persisted by an older build must not leave the panel stuck on
+    // something that can never publish again.
+    expect(isPreviewToolId("inpaint")).toBe(true);
+    expect(isPreviewToolId("prompt-from-layer")).toBe(false);
+    expect(isPreviewToolId("a-tool-that-was-removed")).toBe(false);
+    expect(isPreviewToolId("")).toBe(false);
+    expect(isPreviewToolId(null)).toBe(false);
   });
 });
 
@@ -167,7 +275,7 @@ describe("result preview panels mirroring to the hub", () => {
       resultAlt: "result",
       liveAlt: "live",
       hub,
-      toolLabel: "Inpaint"
+      toolId: "inpaint"
     });
 
     return { hub, resultPanel, urls, created, revoked };
@@ -190,10 +298,10 @@ describe("result preview panels mirroring to the hub", () => {
     const { hub, resultPanel } = setup();
 
     resultPanel.showProgress("Generating", blob("frame"));
-    expect(hub.latest()).toMatchObject({ toolLabel: "Inpaint", kind: "live" });
+    expect(hub.latest()).toMatchObject({ toolId: "inpaint", kind: "live" });
 
     resultPanel.showResult(blob("final"));
-    expect(hub.latest()).toMatchObject({ toolLabel: "Inpaint", kind: "result" });
+    expect(hub.latest()).toMatchObject({ toolId: "inpaint", kind: "result" });
   });
 
   it("does not mirror textual progress or a cleared result", () => {

--- a/tests/utils/previewPanelPin.test.ts
+++ b/tests/utils/previewPanelPin.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPreviewPanelPin, savePreviewPanelPin } from "../../src/utils/preferences";
+
+/**
+ * The preview panel's pinned tool is the one preference written from outside the
+ * settings screen, and the panel it belongs to is a second UXP entrypoint. Both
+ * facts make the storage-unavailable paths worth covering: if localStorage is
+ * missing or throws in the host, pinning has to degrade to "not persisted"
+ * rather than taking the panel down with it.
+ */
+
+type StorageStub = Storage | undefined;
+
+function setStorage(value: StorageStub) {
+  (globalThis as { localStorage?: StorageStub }).localStorage = value;
+}
+
+function createMemoryStorage() {
+  const entries = new Map<string, string>();
+
+  return {
+    entries,
+    storage: {
+      getItem: (key: string) => entries.get(key) ?? null,
+      setItem: (key: string, value: string) => void entries.set(key, value),
+      removeItem: (key: string) => void entries.delete(key)
+    } as unknown as Storage
+  };
+}
+
+const originalLocalStorage = (globalThis as { localStorage?: StorageStub }).localStorage;
+
+afterEach(() => {
+  setStorage(originalLocalStorage);
+});
+
+describe("preview panel pin persistence", () => {
+  it("round-trips a pinned tool", () => {
+    const { storage } = createMemoryStorage();
+    setStorage(storage);
+
+    expect(savePreviewPanelPin("inpaint")).toBe(true);
+    expect(loadPreviewPanelPin()).toBe("inpaint");
+  });
+
+  it("removes the key when the pin is cleared, rather than storing an empty string", () => {
+    const { entries, storage } = createMemoryStorage();
+    setStorage(storage);
+
+    savePreviewPanelPin("upscale");
+    savePreviewPanelPin("");
+
+    expect(entries.size).toBe(0);
+    expect(loadPreviewPanelPin()).toBe("");
+  });
+
+  it("reads as unpinned when nothing was ever stored", () => {
+    setStorage(createMemoryStorage().storage);
+
+    expect(loadPreviewPanelPin()).toBe("");
+  });
+
+  it("degrades to unpinned when the host exposes no storage", () => {
+    setStorage(undefined);
+
+    expect(loadPreviewPanelPin()).toBe("");
+    expect(savePreviewPanelPin("inpaint")).toBe(false);
+  });
+
+  it("survives storage that throws on access", () => {
+    setStorage({
+      getItem: () => {
+        throw new Error("storage is not available");
+      },
+      setItem: () => {
+        throw new Error("storage is not available");
+      },
+      removeItem: () => {
+        throw new Error("storage is not available");
+      }
+    } as unknown as Storage);
+
+    expect(() => loadPreviewPanelPin()).not.toThrow();
+    expect(loadPreviewPanelPin()).toBe("");
+    expect(savePreviewPanelPin("inpaint")).toBe(false);
+  });
+});


### PR DESCRIPTION
Task 3 of the v0.8 plan. Closes the v0.7.0 known limitation: *"The preview panel always follows whichever tool published most recently. Pinning it to one tool is designed but not built."*

## What it does

A header dropdown on the **OpenLayer Preview** panel: **Follow active tool** (default, unchanged v0.7 behaviour) plus the 7 tools that publish previews. Pinning freezes the panel on that tool's output.

The case it exists for: iterating on an Inpaint, starting a Text to Image run to compare against, and losing the large panel to the new run.

## Design: retention, not filtering

The hub keeps **one slot per tool** beside the most-recent pointer, and the panel resolves `pinned ? latestForTool(pin) : latest()` on every notification.

Filtering the delivered publication would look identical in the common case and give the wrong answer in the one that matters: **pin to a tool that hasn't run this session**, and a filtering panel leaves another tool's image on screen under that tool's pin. Resolving through a per-tool slot makes it an empty state naming the tool. A preview labelled with the wrong tool is worse than no preview.

The hub still holds no notion of who is looking at what — it notifies everyone, and pinned surfaces re-resolve.

## `toolLabel` → `toolId`

Publications now carry a `toolId`; the artist-facing string is derived from it. A label passed alongside an id is a label that can disagree with the identity the pin matches on. `PREVIEW_TOOLS` in [previewHub.ts](src/ui/previewHub.ts) is now the single source for the id union, the dropdown, and the badge — typecheck forces all 7 publish sites to name a valid tool.

**Prompt from Layer is deliberately not in the list** (my plan said 8 tools; it's 7). It produces caption text and has no result preview panel, so pinning to it could only ever show "nothing yet".

## Persistence

`localStorage`, key `openlayer.previewPanel.pin.v1` — its own key, **not** part of `OpenLayerPreferences`, which is written wholesale from the settings form and would clobber a field no form control owns. A stored id is validated against `PREVIEW_TOOLS` on read, so a pin from an older build can't strand the panel. Every storage path degrades to "not persisted" rather than throwing — this is UXP, where `localStorage` may not exist.

## Validation

- `npm test` — **45 files, 342 tests** (up from 44/329; 13 new)
- `npm run typecheck`, `npm run build` — clean
- Lint-clean against #32's config (checked by temporarily borrowing `eslint.config.js` from that branch; the only errors reported are the 3 dead imports #32 already removes)

New tests cover: per-tool retention across another tool publishing, empty for an idle tool, the pinned slot advancing, `clear()` emptying every slot (not just the most recent), pinned listeners still being notified, the frozen `PREVIEW_TOOLS` inventory, stale-pin rejection, and all five persistence paths including storage-throws.

## ⚠️ Smoke test — the one real unknown is the `<select>`

This panel renders outside `.app-shell`, so it inherits none of the compact theme's control styling and the dropdown is dressed from scratch. **If it renders badly or won't open in-host, say so** — the fallback is a cycle button (`Following · Inpaint ▸`), which is a swap of the control, not a rethink of the plumbing.

1. Open both panels. Generate in **Text to Image** → badge reads `Text to Image · generating`, then `· result`.
2. Pin to **Inpaint**. Generate in Text to Image again → **the panel must not change.**
3. Run an Inpaint generation → panel updates live, badge amber while generating, `· result` after.
4. Pin to **Upscale** (not run this session) → empty state reading *"No Upscale preview yet this session."*, badge reads `Upscale · pinned`. **Not** a stale Inpaint image.
5. Back to **Follow active tool** → the next generation from any tool takes over.
6. Start **Live Painting**, pin to Live Painting, paint → frames mirror; refine → badge flips to `· result`.
7. Toggle **1:1 / Fit** while pinned; drag-resize the panel.
8. Close the preview panel mid-generation, reopen → shows the pinned tool's last frame.
9. **Reload the plugin → the pin is still set.**

No manifest change, so UXP DT **Reload** is enough — no remove-and-re-add.

## Merge order

Branches off `main`, so it's independent of #31 and #32 and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
