### PR TITLE
Check GUI source workflows against their API twins

### DIFF
--- a/scripts/build-setup-pack.mjs
+++ b/scripts/build-setup-pack.mjs
@@ -29,7 +29,7 @@ const version = packageJson.version;
  * cannot load it directly (extensionless relative imports), so bundle it with
  * the Vite already in devDependencies rather than adding a build dependency.
  */
-async function loadSetupManifestModule() {
+async function loadBundledModule(entry, fileName) {
   const outDir = await mkdtemp(join(tmpdir(), "openlayer-setup-pack-"));
 
   await build({
@@ -40,19 +40,26 @@ async function loadSetupManifestModule() {
       emptyOutDir: true,
       minify: false,
       lib: {
-        entry: resolve(root, "src/comfy/setupManifest.ts"),
+        entry: resolve(root, entry),
         formats: ["es"],
-        fileName: () => "setupManifest.mjs"
+        fileName: () => fileName
       }
     }
   });
 
-  const module = await import(pathToFileURL(join(outDir, "setupManifest.mjs")).href);
+  const module = await import(pathToFileURL(join(outDir, fileName)).href);
   await rm(outDir, { recursive: true, force: true });
   return module;
 }
 
-const { buildSetupManifest, formatBytes } = await loadSetupManifestModule();
+const { buildSetupManifest, formatBytes } = await loadBundledModule(
+  "src/comfy/setupManifest.ts",
+  "setupManifest.mjs"
+);
+const { compareWorkflowToSource, formatEquivalenceReport } = await loadBundledModule(
+  "src/comfy/workflowSourceEquivalence.ts",
+  "workflowSourceEquivalence.mjs"
+);
 const manifest = buildSetupManifest({ pluginVersion: version });
 
 function renderRequirementsMarkdown() {
@@ -138,8 +145,16 @@ function renderRequirementsMarkdown() {
 
     // Several presets name a source workflow the repository never exported.
     // Listing one that is not in the zip sends people looking for a file that
-    // does not exist, so only shipped sources are advertised.
-    if (preset.sourceWorkflowFile && shippedFilePaths.has(preset.sourceWorkflowFile)) {
+    // does not exist, so only shipped sources are advertised — and only ones
+    // that still describe the same graph as the API workflow beside them. An
+    // "editable source" that opens a different graph is worse than no source at
+    // all: it is a file people would edit, export, and wonder why nothing
+    // changed.
+    if (
+      preset.sourceWorkflowFile &&
+      shippedFilePaths.has(preset.sourceWorkflowFile) &&
+      !mismatchedSourcePaths.has(preset.sourceWorkflowFile)
+    ) {
       lines.push(`- editable source: \`${preset.sourceWorkflowFile}\``);
     }
 
@@ -440,6 +455,36 @@ if (missingSources.length > 0) {
     `  note: ${missingSources.length} preset(s) name a GUI source workflow that was never exported ` +
       `(${missingSources.join(", ")}); omitted from REQUIREMENTS.md`
   );
+}
+
+/**
+ * Every shipped source is checked against the API workflow it claims to be the
+ * editable version of. Until this existed, nothing compared the two formats,
+ * and the pack advertised at least one source describing a different graph
+ * entirely.
+ *
+ * A mismatch is a warning rather than a build failure: the presets still run —
+ * the API workflows are what OpenLayer submits — so refusing to build the pack
+ * would withhold a working setup over a documentation defect. The source is
+ * dropped from REQUIREMENTS.md instead, which is the same treatment a missing
+ * one gets.
+ */
+const mismatchedSourcePaths = new Set();
+
+for (const preset of manifest.presets) {
+  if (!preset.sourceWorkflowFile || !shippedFilePaths.has(preset.sourceWorkflowFile)) {
+    continue;
+  }
+
+  const apiWorkflow = JSON.parse(await readFile(resolve(root, "src", preset.workflowFile), "utf8"));
+  const sourceGraph = JSON.parse(await readFile(resolve(root, "src", preset.sourceWorkflowFile), "utf8"));
+  const report = compareWorkflowToSource(apiWorkflow, sourceGraph);
+
+  if (!report.equivalent) {
+    mismatchedSourcePaths.add(preset.sourceWorkflowFile);
+    console.warn(`  ${formatEquivalenceReport(preset.id, report)}`);
+    console.warn(`  note: omitting ${preset.sourceWorkflowFile} from REQUIREMENTS.md until it is re-exported`);
+  }
 }
 
 const zipEntries = [

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -1256,6 +1256,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     mode: "inpaint",
     description: "Experimental Flux Fill inpainting workflow using a diffusion model stack.",
     workflowFile: "workflows/api/inpaint-flux-fill-basic.json",
+    sourceWorkflowFile: "workflows/source/inpaint-flux-fill-basic.workflow.json",
     status: "stable",
     recommendedSettings: { steps: 20, cfg: 30 },
     supportedModelFamilies: ["flux"],

--- a/src/comfy/workflowSourceEquivalence.ts
+++ b/src/comfy/workflowSourceEquivalence.ts
@@ -1,0 +1,302 @@
+import { ComfyWorkflow } from "./types";
+
+/**
+ * Checks that a GUI-editable workflow (`src/workflows/source/*.workflow.json`)
+ * still describes the same graph as the API workflow OpenLayer actually submits
+ * (`src/workflows/api/*.json`).
+ *
+ * Nothing compared these before. `build-setup-pack.mjs` noticed a *missing*
+ * source and `workflowFiles.test.ts` compares the API JSON against the preset
+ * registry, but no check existed between the two workflow formats — so the
+ * setup pack could, and did, advertise an "editable source" describing a
+ * different graph from the one the plugin runs.
+ *
+ * ## What is compared, and what deliberately is not
+ *
+ * **Structure**: which node classes are present, how many of each, and how they
+ * are wired together. That is the part where drift is a real defect — a node
+ * added, removed, or rewired changes what the graph does.
+ *
+ * **Not values.** Widget values are compared by nothing here, on purpose.
+ * OpenLayer injects prompts, seeds, dimensions, model names, steps, CFG and
+ * denoise at submit time, so the numbers sitting in both files are placeholders
+ * that were never required to agree; a vendor's demo graph legitimately ships
+ * 9 steps where OpenLayer's preset default is 4. Comparing them would produce a
+ * stream of false failures, and false failures are how a check gets switched
+ * off. It would also require knowing each node class's widget order, which is
+ * only discoverable from a running ComfyUI's `/object_info` — a dependency this
+ * has no business acquiring to answer a structural question.
+ *
+ * ## Why node ids are ignored
+ *
+ * The two formats do not agree on ids and were never going to. ComfyUI assigns
+ * ids as nodes are created, so a graph rebuilt in the editor gets fresh ones —
+ * `upscale-basic` is hand-authored with ids 1-4 against the API's 9-12, while
+ * `prompt-from-layer-florence2` is a real export whose ids match. Both are
+ * legitimate. Everything below therefore compares *class-typed* nodes and
+ * edges, never identities.
+ */
+
+/** GUI-only annotation nodes. They never reach an API export. */
+const ANNOTATION_NODE_TYPES = new Set(["Note", "MarkdownNote"]);
+
+/**
+ * Nodes that rewrite topology rather than compute anything. A Reroute is a
+ * visual waypoint that the API export collapses, so a graph containing one
+ * cannot have its edges compared naively — the source would show
+ * `A -> Reroute -> B` where the API shows `A -> B`. Their presence downgrades
+ * the check to inventory-only rather than producing a false failure.
+ */
+const PASSTHROUGH_NODE_TYPES = new Set(["Reroute", "RerouteNode", "PrimitiveNode"]);
+
+/**
+ * litegraph node modes. 0 is "always"; a muted (2) or bypassed (4) node does not
+ * execute and is absent from an API export, so it must be absent here too.
+ *
+ * The two are not equivalent beyond that. A muted node breaks the chain it sits
+ * in, while a **bypassed** node passes its input straight through to its output,
+ * so the API export shows the neighbours wired directly to each other. Dropping
+ * a bypassed node and its links therefore invents a missing connection: the
+ * Z-Image source bypasses a LoRA loader between UNETLoader and
+ * ModelSamplingAuraFlow, and the first run of this check duly reported that edge
+ * as absent when the graphs actually agree.
+ *
+ * Rather than reimplement litegraph's type-matching pass-through rules, a
+ * bypassed node downgrades the comparison to inventory-only, the same as a
+ * reroute. The alternative is a false difference, and false differences are how
+ * a check gets ignored and then deleted.
+ */
+const MODE_ALWAYS = 0;
+const MODE_BYPASS = 4;
+
+type SourceNodeInput = {
+  name?: string;
+  link?: number | null;
+};
+
+export type SourceWorkflowNode = {
+  id?: number;
+  type?: string;
+  mode?: number;
+  inputs?: SourceNodeInput[];
+};
+
+/** `[linkId, originNodeId, originSlot, targetNodeId, targetSlot, dataType]` */
+export type SourceWorkflowLink = [number, number, number, number, number, string?];
+
+export type SourceWorkflowSubgraph = {
+  id?: string;
+  name?: string;
+  nodes?: SourceWorkflowNode[];
+};
+
+export type SourceWorkflowGraph = {
+  nodes?: SourceWorkflowNode[];
+  links?: SourceWorkflowLink[];
+  definitions?: {
+    subgraphs?: SourceWorkflowSubgraph[];
+  };
+};
+
+export type WorkflowEquivalenceReport = {
+  equivalent: boolean;
+  /** Every structural disagreement, each naming the class and the counts. */
+  differences: string[];
+  /** Why part of the comparison was skipped, when it was. */
+  notes: string[];
+};
+
+function countByKey(keys: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const key of keys) {
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+function diffCounts(
+  apiCounts: Map<string, number>,
+  sourceCounts: Map<string, number>,
+  describe: (key: string, apiCount: number, sourceCount: number) => string
+): string[] {
+  const differences: string[] = [];
+
+  for (const key of [...new Set([...apiCounts.keys(), ...sourceCounts.keys()])].sort()) {
+    const apiCount = apiCounts.get(key) ?? 0;
+    const sourceCount = sourceCounts.get(key) ?? 0;
+
+    if (apiCount !== sourceCount) {
+      differences.push(describe(key, apiCount, sourceCount));
+    }
+  }
+
+  return differences;
+}
+
+function collectApiNodes(workflow: ComfyWorkflow) {
+  return Object.entries(workflow).map(([id, node]) => ({ id, classType: node.class_type, inputs: node.inputs }));
+}
+
+function collectApiEdges(workflow: ComfyWorkflow): string[] {
+  const edges: string[] = [];
+
+  for (const [, node] of Object.entries(workflow)) {
+    for (const [inputName, value] of Object.entries(node.inputs ?? {})) {
+      // A connected input is `[originNodeId, originSlot]`; anything else is a
+      // literal widget value, which this does not look at.
+      if (!Array.isArray(value) || value.length < 2) {
+        continue;
+      }
+
+      const [originId, originSlot] = value as [string, number];
+      const originClass = workflow[String(originId)]?.class_type ?? "<missing node>";
+      edges.push(`${originClass}:${originSlot} -> ${node.class_type}.${inputName}`);
+    }
+  }
+
+  return edges;
+}
+
+/**
+ * Expands one level of ComfyUI subgraphs.
+ *
+ * A subgraph appears at the top level as a single node whose `type` is the
+ * subgraph's UUID, with the real nodes living in `definitions.subgraphs`. The
+ * API export flattens it, so a source using one would otherwise look almost
+ * empty next to its API twin — `txt2img-z-image-turbo` is exactly this: three
+ * notes, a SaveImage, and one subgraph holding the other nine nodes.
+ */
+function expandSubgraphs(graph: SourceWorkflowGraph): { nodes: SourceWorkflowNode[]; expanded: string[] } {
+  const definitions = graph.definitions?.subgraphs ?? [];
+  const byId = new Map(definitions.filter((entry) => entry.id).map((entry) => [entry.id as string, entry]));
+  const nodes: SourceWorkflowNode[] = [];
+  const expanded: string[] = [];
+
+  for (const node of graph.nodes ?? []) {
+    const definition = node.type ? byId.get(node.type) : undefined;
+
+    if (!definition) {
+      nodes.push(node);
+      continue;
+    }
+
+    expanded.push(definition.name ?? (definition.id as string));
+    nodes.push(...(definition.nodes ?? []));
+  }
+
+  return { nodes, expanded };
+}
+
+function isComparableNode(node: SourceWorkflowNode): boolean {
+  const type = node.type ?? "";
+
+  if (!type || ANNOTATION_NODE_TYPES.has(type)) {
+    return false;
+  }
+
+  // A muted or bypassed node does not run, so the API export does not contain it.
+  return (node.mode ?? MODE_ALWAYS) === MODE_ALWAYS;
+}
+
+function collectSourceEdges(nodes: SourceWorkflowNode[], links: SourceWorkflowLink[]): string[] {
+  const byId = new Map(nodes.filter((node) => node.id !== undefined).map((node) => [node.id as number, node]));
+  const edges: string[] = [];
+
+  for (const link of links) {
+    const [, originId, originSlot, targetId, targetSlot] = link;
+    const origin = byId.get(originId);
+    const target = byId.get(targetId);
+
+    // A link touching a node that was filtered out (an annotation, or something
+    // muted) has no counterpart in the API export and is not a difference.
+    if (!origin || !target) {
+      continue;
+    }
+
+    const inputName = target.inputs?.[targetSlot]?.name ?? `#${targetSlot}`;
+    edges.push(`${origin.type}:${originSlot} -> ${target.type}.${inputName}`);
+  }
+
+  return edges;
+}
+
+/**
+ * Compares an API workflow against its GUI-editable source.
+ *
+ * The report is deliberately verbose: a check that says only "these differ" is
+ * one nobody can act on, so every difference names the node class and both
+ * counts.
+ */
+export function compareWorkflowToSource(
+  apiWorkflow: ComfyWorkflow,
+  sourceGraph: SourceWorkflowGraph
+): WorkflowEquivalenceReport {
+  const notes: string[] = [];
+  const { nodes: flattened, expanded } = expandSubgraphs(sourceGraph);
+
+  if (expanded.length > 0) {
+    notes.push(`expanded ${expanded.length} subgraph(s): ${expanded.join(", ")}`);
+  }
+
+  const comparableNodes = flattened.filter(isComparableNode);
+  const apiNodes = collectApiNodes(apiWorkflow);
+
+  const differences = diffCounts(
+    countByKey(apiNodes.map((node) => node.classType)),
+    countByKey(comparableNodes.map((node) => node.type as string)),
+    (classType, apiCount, sourceCount) =>
+      apiCount > sourceCount
+        ? `node ${classType}: the API workflow has ${apiCount}, the source has ${sourceCount}`
+        : `node ${classType}: the source has ${sourceCount}, the API workflow has ${apiCount}`
+  );
+
+  const hasPassthrough = comparableNodes.some((node) => PASSTHROUGH_NODE_TYPES.has(node.type ?? ""));
+  const hasBypassed = flattened.some((node) => node.mode === MODE_BYPASS);
+
+  if (hasPassthrough) {
+    notes.push("connections not compared: the source contains reroute/primitive nodes the API export collapses");
+  } else if (hasBypassed) {
+    notes.push("connections not compared: the source contains bypassed nodes, which pass their input through to their output");
+  } else if (expanded.length > 0) {
+    // Links inside a subgraph are numbered in their own space and cross the
+    // boundary through the subgraph's own input/output slots, so they cannot be
+    // matched against a flattened API export without modelling that boundary.
+    notes.push("connections not compared: the source uses subgraphs, whose links cross a boundary the API export flattens");
+  } else {
+    differences.push(
+      ...diffCounts(
+        countByKey(collectApiEdges(apiWorkflow)),
+        countByKey(collectSourceEdges(comparableNodes, sourceGraph.links ?? [])),
+        (edge, apiCount, sourceCount) =>
+          `connection ${edge}: the API workflow has ${apiCount}, the source has ${sourceCount}`
+      )
+    );
+  }
+
+  return {
+    equivalent: differences.length === 0,
+    differences,
+    notes
+  };
+}
+
+/** One-line summary suitable for a build log or a test failure message. */
+export function formatEquivalenceReport(label: string, report: WorkflowEquivalenceReport): string {
+  if (report.equivalent) {
+    return `${label}: source matches the API workflow${report.notes.length > 0 ? ` (${report.notes.join("; ")})` : ""}`;
+  }
+
+  const lines = [`${label}: source does NOT match the API workflow`];
+
+  for (const difference of report.differences) {
+    lines.push(`  - ${difference}`);
+  }
+
+  for (const note of report.notes) {
+    lines.push(`  note: ${note}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/workflows/source/README.md
+++ b/src/workflows/source/README.md
@@ -17,6 +17,49 @@ When adding a new workflow:
 
 Do not enable a preset in OpenLayer until its API workflow exists and passes local node validation.
 
+## The API file is canonical
+
+The API workflow is what OpenLayer submits and what `presetRegistry.ts` maps node ids against. The
+source beside it is a **reference for humans**, not an input to anything the plugin does.
+
+That direction matters when editing. Re-exporting an API workflow from an edited source renumbers
+every node id, which silently breaks the registry's injection targets. If a graph genuinely needs to
+change: edit it in ComfyUI, export **both** files, and update the registry's node ids to match the
+new API export.
+
+## What checks these against each other
+
+- `tests/comfy/workflowSourceEquivalence.test.ts` compares each **source against its API twin**.
+- `tests/comfy/workflowFiles.test.ts` compares each **API workflow against the preset registry**
+  mapping. It does not look at source files.
+
+The equivalence check compares **structure**: which node classes are present, how many of each, and
+how they are wired. It ignores node ids, because the two formats never agreed on them — `upscale-basic`
+is hand-authored with ids 1-4 against the API's 9-12, while `prompt-from-layer-florence2` is a real
+export whose ids match, and both are fine.
+
+It deliberately ignores **widget values**. OpenLayer injects prompts, seeds, dimensions, model names,
+steps, CFG and denoise at submit time, so the numbers in both files are placeholders that were never
+required to agree. Comparing them would fail constantly for no defect, and a check that cries wolf
+gets switched off.
+
+Connections are not compared when a source uses subgraphs, reroute/primitive nodes, or bypassed
+nodes — each of those is collapsed or rewritten by the API export, so comparing edges naively would
+report differences that are not there. Node inventory is still compared in all three cases, and the
+report says which limitation applied.
+
+`npm run setup-pack` runs the same check and refuses to advertise a source that fails it. A file
+people would open, edit, and export from is worse than no file at all if it describes a different
+graph.
+
+### Known mismatch
+
+`img2img-z-image-turbo.workflow.json` does **not** match its API workflow. It is the vendor's Z-Image
+*text-to-image* demo — `EmptySD3LatentImage`, `ConditioningZeroOut`, a bypassed LoRA loader — rather
+than the image-to-image graph OpenLayer submits, which loads an image and VAE-encodes it. It is
+recorded in `KNOWN_MISMATCHES` in the equivalence test and omitted from the setup pack's
+`REQUIREMENTS.md` until someone exports the real graph.
+
 ## Z_image_Turbo Notes
 
 This source folder includes the user-provided Z_image_Turbo GUI workflows as references:
@@ -30,7 +73,7 @@ The runnable OpenLayer API versions are in `src/workflows/api/`. If the GUI work
 
 `prompt-from-layer-florence2.workflow.json` is the GUI-editable Florence-2 PromptGen workflow for the Prompt from Layer tool.
 
-The runnable API version is in `src/workflows/api/prompt-from-layer-florence2.json`. It uses Florence2ModelLoader, LoadImage, Florence2Run, and core ComfyUI's PreviewAny to return caption text through ComfyUI history. The `ShowText|pysssss` and `SaveText|pysssss` nodes this graph used to carry were removed so the preset needs no `comfyui-custom-scripts` install; PreviewAny was already wired to the same caption output. If this source workflow is edited in ComfyUI, export a matching API workflow and update `src/comfy/presetRegistry.ts` node mappings before relying on it — `tests/comfy/workflowFiles.test.ts` fails if the two drift apart.
+The runnable API version is in `src/workflows/api/prompt-from-layer-florence2.json`. It uses Florence2ModelLoader, LoadImage, Florence2Run, and core ComfyUI's PreviewAny to return caption text through ComfyUI history. The `ShowText|pysssss` and `SaveText|pysssss` nodes this graph used to carry were removed so the preset needs no `comfyui-custom-scripts` install; PreviewAny was already wired to the same caption output. If this source workflow is edited in ComfyUI, export a matching API workflow and update `src/comfy/presetRegistry.ts` node mappings before relying on it.
 
 ## Flux Fill Notes
 

--- a/tests/comfy/workflowSourceEquivalence.test.ts
+++ b/tests/comfy/workflowSourceEquivalence.test.ts
@@ -1,0 +1,242 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { listWorkflowPresets } from "../../src/comfy/presetRegistry";
+import {
+  compareWorkflowToSource,
+  formatEquivalenceReport,
+  SourceWorkflowGraph
+} from "../../src/comfy/workflowSourceEquivalence";
+import { ComfyWorkflow } from "../../src/comfy/types";
+
+const SRC_ROOT = resolve(__dirname, "../../src");
+
+/**
+ * Sources that do not match their API workflow, with the reason. Each entry is
+ * a defect waiting on a re-export, not an exemption — the test asserts these
+ * still mismatch, so fixing one fails here and forces the entry to be deleted
+ * rather than left behind as a stale excuse.
+ */
+const KNOWN_MISMATCHES: Record<string, string> = {
+  "img2img-z-image-turbo":
+    "The shipped source is the vendor's Z-Image *text-to-image* demo (EmptySD3LatentImage, " +
+    "ConditioningZeroOut, a bypassed LoRA loader) rather than the image-to-image graph OpenLayer " +
+    "submits (LoadImage + VAEEncode, two CLIPTextEncode). Needs a real export; tracked as v0.8 Task 5."
+};
+
+function loadPair(presetId: string, workflowFile: string, sourceWorkflowFile: string) {
+  return {
+    api: JSON.parse(readFileSync(resolve(SRC_ROOT, workflowFile), "utf8")) as ComfyWorkflow,
+    source: JSON.parse(readFileSync(resolve(SRC_ROOT, sourceWorkflowFile), "utf8")) as SourceWorkflowGraph,
+    presetId
+  };
+}
+
+const pairs = listWorkflowPresets()
+  .filter((preset) => preset.sourceWorkflowFile)
+  .filter((preset) => existsSync(resolve(SRC_ROOT, preset.sourceWorkflowFile as string)))
+  .filter((preset) => existsSync(resolve(SRC_ROOT, preset.workflowFile)))
+  .map((preset) => loadPair(preset.id, preset.workflowFile, preset.sourceWorkflowFile as string));
+
+describe("GUI source workflows match the API workflows OpenLayer submits", () => {
+  it("has pairs to check", () => {
+    expect(pairs.length).toBeGreaterThan(0);
+  });
+
+  for (const pair of pairs.filter((entry) => !(entry.presetId in KNOWN_MISMATCHES))) {
+    it(`${pair.presetId} source matches its API workflow`, () => {
+      const report = compareWorkflowToSource(pair.api, pair.source);
+
+      // The formatted report is the failure message on purpose: "workflows
+      // differ" is not something anyone can act on.
+      expect(report.equivalent, formatEquivalenceReport(pair.presetId, report)).toBe(true);
+    });
+  }
+
+  for (const [presetId, reason] of Object.entries(KNOWN_MISMATCHES)) {
+    const pair = pairs.find((entry) => entry.presetId === presetId);
+
+    it(`${presetId} is still the known mismatch it is recorded as`, () => {
+      if (!pair) {
+        throw new Error(`${presetId} has no source/API pair; delete its KNOWN_MISMATCHES entry`);
+      }
+
+      const report = compareWorkflowToSource(pair.api, pair.source);
+
+      // Deliberately inverted. When the source is re-exported this fails, which
+      // is the reminder to remove the entry above.
+      expect(
+        report.equivalent,
+        `${presetId} now matches its API workflow — remove it from KNOWN_MISMATCHES. Reason recorded: ${reason}`
+      ).toBe(false);
+    });
+  }
+
+  it("accounts for every source workflow on disk", () => {
+    // A source file no preset names is shipped in the setup pack, documented in
+    // the source README, advertised in REQUIREMENTS.md by nothing, and checked
+    // here by nothing. inpaint-flux-fill-basic was exactly that until its
+    // sourceWorkflowFile was added to the registry.
+    const onDisk = readdirSync(resolve(SRC_ROOT, "workflows/source"))
+      .filter((name) => name.endsWith(".workflow.json"))
+      .sort();
+    const referenced = pairs
+      .map((pair) => `${pair.presetId}.workflow.json`)
+      .sort();
+
+    expect(onDisk, "a source workflow on disk that no preset's sourceWorkflowFile names").toEqual(referenced);
+  });
+});
+
+describe("the comparator itself", () => {
+  const api: ComfyWorkflow = {
+    "4": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "x.safetensors" } },
+    "6": { class_type: "CLIPTextEncode", inputs: { text: "hello", clip: ["4", 1] } },
+    "9": { class_type: "SaveImage", inputs: { filename_prefix: "OpenLayer", images: ["6", 0] } }
+  };
+
+  const source: SourceWorkflowGraph = {
+    nodes: [
+      { id: 1, type: "CheckpointLoaderSimple", inputs: [] },
+      { id: 2, type: "CLIPTextEncode", inputs: [{ name: "clip" }] },
+      { id: 3, type: "SaveImage", inputs: [{ name: "images" }] }
+    ],
+    links: [
+      [10, 1, 1, 2, 0, "CLIP"],
+      [11, 2, 0, 3, 0, "IMAGE"]
+    ]
+  };
+
+  it("matches graphs whose node ids disagree", () => {
+    // The API file uses 4/6/9, the source 1/2/3. Both are legitimate: ComfyUI
+    // renumbers whenever a graph is rebuilt.
+    expect(compareWorkflowToSource(api, source).equivalent).toBe(true);
+  });
+
+  it("ignores widget values, which OpenLayer injects at submit time", () => {
+    const retuned: ComfyWorkflow = {
+      ...api,
+      "6": { class_type: "CLIPTextEncode", inputs: { text: "something else entirely", clip: ["4", 1] } }
+    };
+
+    expect(compareWorkflowToSource(retuned, source).equivalent).toBe(true);
+  });
+
+  it("names the class and both counts when a node is missing from the source", () => {
+    const withExtra: ComfyWorkflow = {
+      ...api,
+      "11": { class_type: "VAEEncode", inputs: { pixels: ["6", 0] } }
+    };
+
+    const report = compareWorkflowToSource(withExtra, source);
+
+    expect(report.equivalent).toBe(false);
+    expect(report.differences).toContain("node VAEEncode: the API workflow has 1, the source has 0");
+  });
+
+  it("reports a node the source has and the API workflow does not", () => {
+    const withExtra: SourceWorkflowGraph = {
+      ...source,
+      nodes: [...(source.nodes ?? []), { id: 4, type: "LoraLoaderModelOnly", inputs: [] }]
+    };
+
+    const report = compareWorkflowToSource(api, withExtra);
+
+    expect(report.differences).toContain("node LoraLoaderModelOnly: the source has 1, the API workflow has 0");
+  });
+
+  it("ignores annotation nodes, which never reach an API export", () => {
+    const annotated: SourceWorkflowGraph = {
+      ...source,
+      nodes: [...(source.nodes ?? []), { id: 5, type: "MarkdownNote" }, { id: 6, type: "Note" }]
+    };
+
+    expect(compareWorkflowToSource(api, annotated).equivalent).toBe(true);
+  });
+
+  it("ignores muted and bypassed nodes, which do not execute", () => {
+    const withBypassed: SourceWorkflowGraph = {
+      ...source,
+      nodes: [
+        ...(source.nodes ?? []),
+        { id: 7, type: "LoraLoaderModelOnly", mode: 4, inputs: [] },
+        { id: 8, type: "UNETLoader", mode: 2, inputs: [] }
+      ]
+    };
+
+    expect(compareWorkflowToSource(api, withBypassed).equivalent).toBe(true);
+  });
+
+  it("does not invent a missing connection around a bypassed node", () => {
+    // A bypassed node passes its input through to its output, so the API export
+    // shows its neighbours wired directly together. Dropping the node and its
+    // links would report that direct edge as missing. Found by running this
+    // against the real Z-Image source, which bypasses a LoRA loader between
+    // UNETLoader and ModelSamplingAuraFlow.
+    const bridged: SourceWorkflowGraph = {
+      nodes: [
+        { id: 1, type: "CheckpointLoaderSimple", inputs: [] },
+        { id: 2, type: "LoraLoaderModelOnly", mode: 4, inputs: [{ name: "model" }] },
+        { id: 3, type: "CLIPTextEncode", inputs: [{ name: "clip" }] },
+        { id: 4, type: "SaveImage", inputs: [{ name: "images" }] }
+      ],
+      links: [
+        [10, 1, 1, 2, 0, "CLIP"],
+        [11, 2, 0, 3, 0, "CLIP"],
+        [12, 3, 0, 4, 0, "IMAGE"]
+      ]
+    };
+
+    const report = compareWorkflowToSource(api, bridged);
+
+    expect(report.differences).toEqual([]);
+    expect(report.notes.join(" ")).toContain("bypassed nodes");
+  });
+
+  it("catches a rewired connection even when every node is present", () => {
+    // The failure mode the inventory check alone would miss, and the one that
+    // matters most: inpaint-basic wiring SaveImage to the VAEDecode instead of
+    // the composite would look plausible and be wrong.
+    const rewired: SourceWorkflowGraph = {
+      ...source,
+      links: [
+        [10, 1, 1, 2, 0, "CLIP"],
+        [11, 1, 0, 3, 0, "IMAGE"]
+      ]
+    };
+
+    const report = compareWorkflowToSource(api, rewired);
+
+    expect(report.equivalent).toBe(false);
+    expect(report.differences.join("\n")).toContain("connection CLIPTextEncode:0 -> SaveImage.images");
+  });
+
+  it("expands a subgraph rather than reporting its contents as missing", () => {
+    const subgraphSource: SourceWorkflowGraph = {
+      nodes: [
+        { id: 1, type: "9b9009e4-2d3d-445f-9be5-6063f465757e" },
+        { id: 2, type: "SaveImage", inputs: [{ name: "images" }] }
+      ],
+      links: [],
+      definitions: {
+        subgraphs: [
+          {
+            id: "9b9009e4-2d3d-445f-9be5-6063f465757e",
+            name: "Text to Image(Z-Image-Base)",
+            nodes: [
+              { id: 10, type: "CheckpointLoaderSimple", inputs: [] },
+              { id: 11, type: "CLIPTextEncode", inputs: [{ name: "clip" }] }
+            ]
+          }
+        ]
+      }
+    };
+
+    const report = compareWorkflowToSource(api, subgraphSource);
+
+    expect(report.equivalent).toBe(true);
+    expect(report.notes.join(" ")).toContain("Text to Image(Z-Image-Base)");
+    // Links inside a subgraph cross a boundary the API export flattens.
+    expect(report.notes.join(" ")).toContain("connections not compared");
+  });
+});


### PR DESCRIPTION
Task 4 of the v0.8 plan. Builds the gate that has to exist **before** Task 5 exports anything, so those four files land against a real check instead of on trust.

## The premise was wrong, and that's why this matters

The plan assumed `build-setup-pack.mjs` "already detects drift". It detects **absence** — a missing API file is fatal, a missing source is a warning. Nothing compared the two *formats*. `workflowFiles.test.ts` compares API JSON against the preset registry, not against sources. And `src/workflows/source/README.md` claimed a test caught source/API drift. **It did not.** That claim is now corrected.

## Three real problems, found on the first run

**1. `img2img-z-image-turbo.workflow.json` is not an img2img graph.** It's the vendor's Z-Image *text-to-image* demo:

```
node CLIPTextEncode:      API has 2, source has 1
node ConditioningZeroOut: source has 1, API has 0
node EmptySD3LatentImage: source has 1, API has 0
node LoadImage:           API has 1, source has 0
node VAEEncode:           API has 1, source has 0
```

The API workflow loads an image and VAE-encodes it; the source generates from an empty latent. **This has been shipping in the v0.7 setup pack as that preset's "editable source"** — a file someone would open, edit, export from, and wonder why nothing changed. It's now recorded in `KNOWN_MISMATCHES` and omitted from `REQUIREMENTS.md`. The test asserts it *still* mismatches, so a future re-export fails and forces the record to be deleted rather than left as a stale excuse.

**2. `inpaint-flux-fill-basic.workflow.json` was an orphan.** On disk, documented in the README, shipped in the zip — but no preset's `sourceWorkflowFile` named it, so `REQUIREMENTS.md` never mentioned it and nothing could check it. One-line registry fix; it matches.

**3. A bug in the checker itself.** Bypassed nodes don't execute, so they're correctly absent from an API export — but a bypassed node passes its input *through*, so dropping it invents a missing edge between neighbours the API wires directly. The first run reported `UNETLoader -> ModelSamplingAuraFlow` as absent from a graph that has it. Bypassed nodes now downgrade to inventory-only comparison, as reroutes and subgraphs already did.

## Design: structure, not values

**Compared:** node classes, their counts, and how they're wired.

**Not compared: widget values** — a deliberate change from my plan. OpenLayer injects prompts, seeds, dimensions, models, steps, CFG and denoise at submit time, so the numbers in both files are placeholders that were never required to agree (a vendor demo ships 9 steps where a preset default is 4). Comparing them would fail constantly for no defect, and would require knowing each node class's widget order — discoverable only from a running ComfyUI. **This removes the `/object_info` dependency the plan assumed.**

**Node ids ignored**, because the formats never agreed on them: `upscale-basic` is hand-authored with ids 1-4 against the API's 9-12, while `prompt-from-layer-florence2` is a real export whose ids match. Both are legitimate.

Connections are skipped (inventory still compared, with a note saying why) when a source uses subgraphs, reroutes, or bypassed nodes — all three are collapsed or rewritten by the API export. **Subgraphs are expanded one level**, which is how `txt2img-z-image-turbo` verifies: its real nodes live in a `definitions.subgraphs` entry named "Text to Image(Z-Image-Base)" with only a SaveImage and three notes at the top level.

## Setup pack

`npm run setup-pack` runs the same check and won't advertise a source that fails it — same treatment a missing one gets. A mismatch is a **warning, not a build failure**: the presets still run, since API workflows are what OpenLayer submits, and refusing to build would withhold a working setup over a documentation defect.

## Validation

- `npm test` — **45 files, 347 tests** (up from 44/329; 18 new)
- `npm run typecheck`, `npm run build` — clean
- `npm run setup-pack` — builds, reports the mismatch with the actionable node list above
- Lint-clean against #32's config

**7 of 8 real pairs verified equivalent.** Comparator unit tests cover: id-independence, value-independence, missing node, extra node, annotation nodes, muted/bypassed nodes, the bypass edge case, a rewired connection, and subgraph expansion.

The rewired-connection test is the one that matters most for Task 5 — it's the `inpaint-basic` trap where `SaveImage` reads from the VAEDecode instead of the composite, which looks plausible and is wrong.

## Smoke test

**None.** No plugin code runs this — the module is used only by the test and the build script. Nothing in `src/ui`, `src/photoshop`, or the bundle path changed except one registry line adding a source reference.

If you want a 30-second sanity check: run `npm run setup-pack` and read the warning block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
