### PR TITLE
Extract statusBars.ts, and stop Text to Image writing every tool's status bar

### DIFF
--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -200,9 +200,33 @@ import {
   RECOMMENDED_SKETCH_CHECKPOINT
 } from "./appConstants";
 import { AppElements, createAppMarkup, getAppElements } from "./appMarkup";
-
-
-type StatusTone = "idle" | "ready" | "error";
+import {
+  applyDeterminateProgress,
+  flashImported,
+  setDiagnostics,
+  setError,
+  setImageDiagnostics,
+  setImageError,
+  setImageStatus,
+  setInpaintDiagnostics,
+  setInpaintError,
+  setInpaintStatus,
+  setOutpaintDiagnostics,
+  setOutpaintError,
+  setOutpaintStatus,
+  setPromptLayerDiagnostics,
+  setPromptLayerError,
+  setPromptLayerStatus,
+  setSketchDiagnostics,
+  setSketchError,
+  setSketchStatus,
+  setStatus,
+  setStatusProgress,
+  setUpscaleDiagnostics,
+  setUpscaleError,
+  setUpscaleStatus,
+  StatusTone
+} from "./statusBars";
 
 
 type HistoryEntry = {
@@ -248,12 +272,6 @@ type OutpaintExpansionSource = Readonly<{
 }>;
 type AppOutpaintImportContext = InpaintImportContext<OutpaintExpansionSource, AppGeneratedImageResult>;
 type LiveGeneratedImageResult = DocumentContextBound<{ blob: Blob }>;
-
-const statusProgressTimers = new WeakMap<HTMLElement, number>();
-// Remembers the last real step percentage per progress bar so percent-less
-// status updates (e.g. the history poll tick) cannot reset a determinate bar
-// back to the indeterminate warm-up animation mid-run.
-const statusProgressLastPercent = new WeakMap<HTMLElement, number>();
 
 export function renderApp(rootElement: HTMLElement) {
   let currentView: AppView = "home";
@@ -3645,353 +3663,6 @@ function setCancelGenerationVisible(elements: AppElements, isVisible: boolean) {
     cancelButton.hidden = !isVisible;
     setActionDisabled(cancelButton, !isVisible);
   }
-}
-
-function setStatusProgress(progressElement: HTMLElement, status: string, tone: StatusTone) {
-  const normalizedStatus = status.trim().toLowerCase();
-  const isBusy =
-    tone === "idle" &&
-    normalizedStatus !== "ready" &&
-    normalizedStatus !== "ready." &&
-    !normalizedStatus.includes("complete") &&
-    !normalizedStatus.includes("copied") &&
-    !normalizedStatus.includes("saved") &&
-    !normalizedStatus.includes("reset") &&
-    !normalizedStatus.includes("cancel");
-
-  const fill = progressElement.firstElementChild as HTMLElement | null;
-  const resolved = resolveStatusProgress(status, isBusy, statusProgressLastPercent.get(progressElement) ?? null);
-
-  if (!resolved.isBusy) {
-    const existingTimer = statusProgressTimers.get(progressElement);
-    if (existingTimer) {
-      window.clearInterval(existingTimer);
-      statusProgressTimers.delete(progressElement);
-    }
-
-    statusProgressLastPercent.delete(progressElement);
-    progressElement.hidden = true;
-    progressElement.className = "status-progress";
-    progressElement.style.removeProperty("--ol-progress");
-
-    if (fill) {
-      fill.style.marginLeft = "";
-      fill.style.width = "";
-    }
-    progressElement.removeAttribute("data-progress-offset");
-    progressElement.removeAttribute("data-progress-label");
-    return;
-  }
-
-  const stickyPercent = resolved.percent;
-
-  progressElement.hidden = false;
-  progressElement.className = `status-progress is-active${stickyPercent !== null ? " is-determinate" : ""}`;
-
-  if (stickyPercent !== null) {
-    renderDeterminateProgress(progressElement, stickyPercent);
-    return;
-  }
-
-  progressElement.style.removeProperty("--ol-progress");
-
-  progressElement.removeAttribute("data-progress-label");
-
-  if (statusProgressTimers.get(progressElement)) {
-    return;
-  }
-
-  let offset = -42;
-  const timer = window.setInterval(() => {
-    offset = offset >= 110 ? -42 : offset + 7;
-    progressElement.setAttribute("data-progress-offset", String(offset));
-
-    if (fill) {
-      fill.style.marginLeft = `${offset}%`;
-      fill.style.width = "42%";
-    }
-  }, 120);
-
-  statusProgressTimers.set(progressElement, timer);
-}
-
-function renderDeterminateProgress(progressElement: HTMLElement, percent: number) {
-  const fill = progressElement.firstElementChild as HTMLElement | null;
-  const existingTimer = statusProgressTimers.get(progressElement);
-
-  if (existingTimer) {
-    window.clearInterval(existingTimer);
-    statusProgressTimers.delete(progressElement);
-  }
-
-  statusProgressLastPercent.set(progressElement, percent);
-  progressElement.hidden = false;
-  progressElement.className = "status-progress is-active is-determinate";
-  // The determinate fill width is driven by a CSS variable so it beats the
-  // legacy "width: 42% !important" indeterminate rule without inline hacks.
-  progressElement.style.setProperty("--ol-progress", `${percent}%`);
-
-  if (fill) {
-    fill.style.marginLeft = "";
-    fill.style.width = "";
-  }
-
-  progressElement.removeAttribute("data-progress-offset");
-  progressElement.setAttribute("data-progress-label", `${percent}%`);
-}
-
-// Dedicated numeric progress entry point driven by the ComfyUI WebSocket
-// progress channel, independent of the human-readable status text.
-function applyDeterminateProgress(progressElement: HTMLElement, value: number, max: number) {
-  if (!Number.isFinite(value) || !Number.isFinite(max) || max <= 0) {
-    return;
-  }
-
-  renderDeterminateProgress(progressElement, Math.max(0, Math.min(100, Math.round((value / max) * 100))));
-}
-
-export type StatusProgressState = {
-  isBusy: boolean;
-  // null while busy = indeterminate warm-up animation; a number = determinate fill.
-  percent: number | null;
-};
-
-// Pure resolver for the progress bar. Keeps a determinate bar determinate once
-// real step progress has arrived: percent-less status updates (the history
-// poll tick, "Retrieving image...") hold the last known percent instead of
-// collapsing the bar back to the indeterminate warm-up animation.
-export function resolveStatusProgress(
-  status: string,
-  isBusy: boolean,
-  lastPercent: number | null
-): StatusProgressState {
-  if (!isBusy) {
-    return { isBusy: false, percent: null };
-  }
-
-  const parsedPercent = readProgressPercent(status);
-  const percent = parsedPercent ?? lastPercent;
-
-  return { isBusy: true, percent: percent ?? null };
-}
-
-function readProgressPercent(status: string) {
-  const percentMatch = status.match(/(\d{1,3})(?:\.\d+)?\s*%/);
-
-  if (percentMatch) {
-    return clampProgressPercent(Number(percentMatch[1]));
-  }
-
-  const stepMatch = status.match(/step\s+(\d+)\s+of\s+(\d+)/i);
-
-  if (stepMatch) {
-    const value = Number(stepMatch[1]);
-    const max = Number(stepMatch[2]);
-
-    if (Number.isFinite(value) && Number.isFinite(max) && max > 0) {
-      return clampProgressPercent(Math.round((value / max) * 100));
-    }
-  }
-
-  const fractionMatch = status.match(/\b(\d+)\s*\/\s*(\d+)\b/);
-
-  if (fractionMatch) {
-    const value = Number(fractionMatch[1]);
-    const max = Number(fractionMatch[2]);
-
-    if (Number.isFinite(value) && Number.isFinite(max) && max > 0) {
-      return clampProgressPercent(Math.round((value / max) * 100));
-    }
-  }
-
-  return null;
-}
-
-function clampProgressPercent(value: number) {
-  if (!Number.isFinite(value)) {
-    return null;
-  }
-
-  return Math.max(0, Math.min(100, value));
-}
-
-function flashImported(statusTextElement: HTMLElement) {
-  const target = (statusTextElement.closest(".status-bar") as HTMLElement | null) ?? statusTextElement;
-  target.classList.remove("ol-import-flash");
-  void target.offsetWidth;
-  target.classList.add("ol-import-flash");
-  window.setTimeout(() => target.classList.remove("ol-import-flash"), 900);
-}
-
-function applyStatusPill(pill: HTMLElement, status: string, tone: StatusTone) {
-  if (tone === "error") {
-    pill.textContent = "Error";
-    pill.className = "status-pill error";
-    return;
-  }
-
-  if (tone === "ready") {
-    pill.textContent = "Ready";
-    pill.className = "status-pill ready";
-    return;
-  }
-
-  const normalized = status.trim().toLowerCase();
-  const isWorking =
-    normalized !== "" &&
-    normalized !== "ready" &&
-    normalized !== "ready." &&
-    !normalized.includes("complete") &&
-    !normalized.includes("copied") &&
-    !normalized.includes("saved") &&
-    !normalized.includes("reset") &&
-    !normalized.includes("cancelled");
-
-  if (isWorking) {
-    pill.textContent = "Working";
-    pill.className = "status-pill working";
-    return;
-  }
-
-  pill.textContent = "Ready";
-  pill.className = "status-pill idle";
-}
-
-function updateHomeStatus(elements: AppElements, status: string, tone: StatusTone) {
-  elements.homeStatusText.textContent = tone === "ready" ? "Ready" : tone === "error" ? "Error" : status.replace(/\.$/, "");
-  // The text color defaults to the success green; only an error overrides it,
-  // so Ready and in-progress statuses keep their familiar look.
-  elements.homeStatusText.classList.toggle("is-error", tone === "error");
-  elements.homeStatusDot.className = `home-status-dot ${tone}`;
-}
-
-function applyToolStatus(
-  elements: AppElements,
-  text: HTMLElement,
-  pill: HTMLElement,
-  progress: HTMLElement,
-  status: string,
-  tone: StatusTone
-) {
-  text.textContent = status;
-  applyStatusPill(pill, status, tone);
-  setStatusProgress(progress, status, tone);
-  updateHomeStatus(elements, status, tone);
-}
-
-// The Text to Image status doubles as the global one: it broadcasts to every
-// tool's status bar plus the settings screen. The per-tool setters below touch
-// only their own bar and the home indicator.
-function setStatus(elements: AppElements, status: string, tone: StatusTone) {
-  elements.statusText.textContent = status;
-  applyStatusPill(elements.statusPill, status, tone);
-  setStatusProgress(elements.statusProgress, status, tone);
-  applyToolStatus(elements, elements.imgStatusText, elements.imgStatusPill, elements.imgStatusProgress, status, tone);
-  applyToolStatus(elements, elements.sketchStatusText, elements.sketchStatusPill, elements.sketchStatusProgress, status, tone);
-  applyToolStatus(elements, elements.inpaintStatusText, elements.inpaintStatusPill, elements.inpaintStatusProgress, status, tone);
-  applyToolStatus(elements, elements.outpaintStatusText, elements.outpaintStatusPill, elements.outpaintStatusProgress, status, tone);
-  applyToolStatus(elements, elements.upscaleStatusText, elements.upscaleStatusPill, elements.upscaleStatusProgress, status, tone);
-  applyToolStatus(elements, elements.promptLayerStatusText, elements.promptLayerStatusPill, elements.promptLayerStatusProgress, status, tone);
-  applyToolStatus(elements, elements.settingsStatusText, elements.settingsStatusPill, elements.settingsStatusProgress, status, tone);
-}
-
-function setImageStatus(elements: AppElements, status: string, tone: StatusTone) {
-  applyToolStatus(elements, elements.imgStatusText, elements.imgStatusPill, elements.imgStatusProgress, status, tone);
-}
-
-function setSketchStatus(elements: AppElements, status: string, tone: StatusTone) {
-  applyToolStatus(elements, elements.sketchStatusText, elements.sketchStatusPill, elements.sketchStatusProgress, status, tone);
-}
-
-function setInpaintStatus(elements: AppElements, status: string, tone: StatusTone) {
-  applyToolStatus(elements, elements.inpaintStatusText, elements.inpaintStatusPill, elements.inpaintStatusProgress, status, tone);
-}
-
-function setOutpaintStatus(elements: AppElements, status: string, tone: StatusTone) {
-  applyToolStatus(elements, elements.outpaintStatusText, elements.outpaintStatusPill, elements.outpaintStatusProgress, status, tone);
-}
-
-function setUpscaleStatus(elements: AppElements, status: string, tone: StatusTone) {
-  applyToolStatus(elements, elements.upscaleStatusText, elements.upscaleStatusPill, elements.upscaleStatusProgress, status, tone);
-}
-
-function setPromptLayerStatus(elements: AppElements, status: string, tone: StatusTone) {
-  applyToolStatus(elements, elements.promptLayerStatusText, elements.promptLayerStatusPill, elements.promptLayerStatusProgress, status, tone);
-}
-
-function applyToolError(errorMessage: HTMLElement, message: string) {
-  errorMessage.textContent = message;
-  errorMessage.hidden = !message;
-}
-
-function setError(elements: AppElements, message: string) {
-  applyToolError(elements.errorMessage, message);
-  applyToolError(elements.settingsErrorMessage, message);
-}
-
-function setImageError(elements: AppElements, message: string) {
-  applyToolError(elements.imgErrorMessage, message);
-}
-
-function setSketchError(elements: AppElements, message: string) {
-  applyToolError(elements.sketchErrorMessage, message);
-}
-
-function setInpaintError(elements: AppElements, message: string) {
-  applyToolError(elements.inpaintErrorMessage, message);
-}
-
-function setOutpaintError(elements: AppElements, message: string) {
-  applyToolError(elements.outpaintErrorMessage, message);
-}
-
-function setUpscaleError(elements: AppElements, message: string) {
-  applyToolError(elements.upscaleErrorMessage, message);
-}
-
-function setPromptLayerError(elements: AppElements, message: string) {
-  applyToolError(elements.promptLayerErrorMessage, message);
-}
-
-function setDiagnostics(elements: AppElements, message: string) {
-  elements.diagnosticsText.textContent = message;
-  elements.imgDiagnosticsText.textContent = message;
-  elements.sketchDiagnosticsText.textContent = message;
-  elements.inpaintDiagnosticsText.textContent = message;
-  elements.outpaintDiagnosticsText.textContent = message;
-  elements.upscaleDiagnosticsText.textContent = message;
-  elements.promptLayerDiagnosticsText.textContent = message;
-  elements.settingsDiagnosticsText.textContent = message;
-}
-
-function setImageDiagnostics(elements: AppElements, message: string) {
-  elements.imgDiagnosticsText.textContent = message;
-  elements.settingsDiagnosticsText.textContent = message;
-}
-
-function setSketchDiagnostics(elements: AppElements, message: string) {
-  elements.sketchDiagnosticsText.textContent = message;
-  elements.settingsDiagnosticsText.textContent = message;
-}
-
-function setInpaintDiagnostics(elements: AppElements, message: string) {
-  elements.inpaintDiagnosticsText.textContent = message;
-  elements.settingsDiagnosticsText.textContent = message;
-}
-
-function setOutpaintDiagnostics(elements: AppElements, message: string) {
-  elements.outpaintDiagnosticsText.textContent = message;
-  elements.settingsDiagnosticsText.textContent = message;
-}
-
-function setUpscaleDiagnostics(elements: AppElements, message: string) {
-  elements.upscaleDiagnosticsText.textContent = message;
-  elements.settingsDiagnosticsText.textContent = message;
-}
-
-function setPromptLayerDiagnostics(elements: AppElements, message: string) {
-  elements.promptLayerDiagnosticsText.textContent = message;
-  elements.settingsDiagnosticsText.textContent = message;
 }
 
 function updateNegativePromptDisclosure(elements: AppElements, isOpen: boolean) {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -205,6 +205,7 @@ import {
   flashImported,
   setDiagnostics,
   setError,
+  setGlobalStatus,
   setImageDiagnostics,
   setImageError,
   setImageStatus,
@@ -220,8 +221,8 @@ import {
   setSketchDiagnostics,
   setSketchError,
   setSketchStatus,
-  setStatus,
   setStatusProgress,
+  setTextToImageStatus,
   setUpscaleDiagnostics,
   setUpscaleError,
   setUpscaleStatus,
@@ -637,7 +638,7 @@ export function renderApp(rootElement: HTMLElement) {
     setDiagnostics(elements, `Panel theme set to ${getThemeLabel(readThemeSelection(elements))}.`);
   });
 
-  setStatus(elements, "Ready.", "idle");
+  setGlobalStatus(elements, "Ready.", "idle");
   setView(currentView);
   setError(elements, "");
   syncBusy();
@@ -735,7 +736,7 @@ export function renderApp(rootElement: HTMLElement) {
   });
 
   async function loadInitialCheckpoints() {
-    setStatus(elements, "Loading ComfyUI models...", "idle");
+    setGlobalStatus(elements, "Loading ComfyUI models...", "idle");
 
     try {
       const client = new ComfyClient(elements.serverUrl.value);
@@ -751,11 +752,11 @@ export function renderApp(rootElement: HTMLElement) {
       updateInpaintCheckpointCompatibility(elements, inpaintSource);
       updateOutpaintCheckpointCompatibility(elements, outpaintSource);
       updateUpscaleCompatibility(elements, upscaleSource);
-      setStatus(elements, "ComfyUI is online. Models loaded.", "ready");
+      setGlobalStatus(elements, "ComfyUI is online. Models loaded.", "ready");
       savePreferencesFromElements(elements);
       updateSettingsReport(elements);
     } catch (caughtError) {
-      setStatus(elements, "Ready.", "idle");
+      setGlobalStatus(elements, "Ready.", "idle");
       setError(elements, `Using fallback model list. ${getErrorMessage(caughtError)}`);
       updateSettingsReport(elements);
     }
@@ -764,7 +765,7 @@ export function renderApp(rootElement: HTMLElement) {
   async function handleCheckComfy() {
     setDiagnostics(elements, "Check ComfyUI pressed.");
     setError(elements, "");
-    setStatus(elements, "Checking ComfyUI...", "idle");
+    setGlobalStatus(elements, "Checking ComfyUI...", "idle");
 
     try {
       const client = new ComfyClient(elements.serverUrl.value);
@@ -780,11 +781,11 @@ export function renderApp(rootElement: HTMLElement) {
       updateInpaintCheckpointCompatibility(elements, inpaintSource);
       updateOutpaintCheckpointCompatibility(elements, outpaintSource);
       updateUpscaleCompatibility(elements, upscaleSource);
-      setStatus(elements, "ComfyUI is online. Models loaded.", "ready");
+      setGlobalStatus(elements, "ComfyUI is online. Models loaded.", "ready");
       savePreferencesFromElements(elements);
       updateSettingsReport(elements);
     } catch (caughtError) {
-      setStatus(elements, "ComfyUI check failed.", "error");
+      setGlobalStatus(elements, "ComfyUI check failed.", "error");
       setError(elements, getErrorMessage(caughtError));
       updateSettingsReport(elements);
     }
@@ -793,14 +794,14 @@ export function renderApp(rootElement: HTMLElement) {
   async function handleFindComfyPort() {
     setDiagnostics(elements, "Scanning common local ComfyUI ports...");
     setError(elements, "");
-    setStatus(elements, "Looking for ComfyUI...", "idle");
+    setGlobalStatus(elements, "Looking for ComfyUI...", "idle");
 
     const foundUrl = await findActiveComfyUrl(elements.serverUrl.value, (message) => {
       setDiagnostics(elements, message);
     });
 
     if (!foundUrl) {
-      setStatus(elements, "No active ComfyUI port found.", "error");
+      setGlobalStatus(elements, "No active ComfyUI port found.", "error");
       setError(elements, "OpenLayer could not find ComfyUI on the common local ports. Start ComfyUI and try again.");
       updateSettingsReport(elements);
       return;
@@ -822,10 +823,10 @@ export function renderApp(rootElement: HTMLElement) {
       updateOutpaintCheckpointCompatibility(elements, outpaintSource);
       updateUpscaleCompatibility(elements, upscaleSource);
       savePreferencesFromElements(elements);
-      setStatus(elements, `Found ComfyUI at ${foundUrl}.`, "ready");
+      setGlobalStatus(elements, `Found ComfyUI at ${foundUrl}.`, "ready");
       setDiagnostics(elements, `Active ComfyUI server selected: ${foundUrl}.`);
     } catch (caughtError) {
-      setStatus(elements, `Found ${foundUrl}, but model loading failed.`, "error");
+      setGlobalStatus(elements, `Found ${foundUrl}, but model loading failed.`, "error");
       setError(elements, getErrorMessage(caughtError));
     } finally {
       updateSettingsReport(elements);
@@ -835,7 +836,7 @@ export function renderApp(rootElement: HTMLElement) {
   async function handleDetectHardware() {
     setDiagnostics(elements, "Detecting GPU and installed model families through ComfyUI...");
     setError(elements, "");
-    setStatus(elements, "Detecting GPU...", "idle");
+    setGlobalStatus(elements, "Detecting GPU...", "idle");
 
     try {
       const client = new ComfyClient(elements.serverUrl.value);
@@ -844,12 +845,12 @@ export function renderApp(rootElement: HTMLElement) {
       hardwareReport = createHardwareRecommendationReport(systemStats, inventory, listWorkflowPresets());
 
       renderHardwareReport(elements, hardwareReport);
-      setStatus(elements, "GPU recommendations ready.", "ready");
+      setGlobalStatus(elements, "GPU recommendations ready.", "ready");
       setDiagnostics(elements, formatHardwareReport(hardwareReport));
     } catch (caughtError) {
       hardwareReport = null;
       renderHardwareReport(elements, hardwareReport);
-      setStatus(elements, "GPU detection failed.", "error");
+      setGlobalStatus(elements, "GPU detection failed.", "error");
       setError(elements, getErrorMessage(caughtError));
       setDiagnostics(elements, "Start ComfyUI, confirm the server URL, then run Detect GPU & Recommend Models again.");
     } finally {
@@ -860,7 +861,7 @@ export function renderApp(rootElement: HTMLElement) {
   async function handleCheckWorkflowHealth() {
     setDiagnostics(elements, "Checking workflow health against local ComfyUI...");
     setError(elements, "");
-    setStatus(elements, "Checking workflow health...", "idle");
+    setGlobalStatus(elements, "Checking workflow health...", "idle");
 
     try {
       const presets = listWorkflowPresets();
@@ -875,12 +876,12 @@ export function renderApp(rootElement: HTMLElement) {
 
       workflowHealthReport = report;
       renderWorkflowHealthReport(elements, workflowHealthReport);
-      setStatus(elements, "Workflow health checked.", report.issueCount > 0 ? "idle" : "ready");
+      setGlobalStatus(elements, "Workflow health checked.", report.issueCount > 0 ? "idle" : "ready");
       setDiagnostics(elements, report.summary);
     } catch (caughtError) {
       workflowHealthReport = null;
       renderWorkflowHealthReport(elements, workflowHealthReport);
-      setStatus(elements, "Workflow health check failed.", "error");
+      setGlobalStatus(elements, "Workflow health check failed.", "error");
       setError(elements, getErrorMessage(caughtError));
       setDiagnostics(elements, "Start ComfyUI, confirm the server URL, then run Check Workflow Health again.");
     } finally {
@@ -903,10 +904,10 @@ export function renderApp(rootElement: HTMLElement) {
       }
 
       await clipboard.writeText(reportText);
-      setStatus(elements, "Diagnostics copied.", "ready");
+      setGlobalStatus(elements, "Diagnostics copied.", "ready");
       setDiagnostics(elements, "Copied a compact OpenLayer diagnostics report to the clipboard.");
     } catch {
-      setStatus(elements, "Diagnostics ready to copy.", "ready");
+      setGlobalStatus(elements, "Diagnostics ready to copy.", "ready");
       setDiagnostics(elements, "Clipboard is unavailable here. The diagnostics report is shown below for manual copy.");
     }
   }
@@ -914,7 +915,7 @@ export function renderApp(rootElement: HTMLElement) {
   function handleSaveSettings() {
     const wasSaved = savePreferencesFromElements(elements);
     updateSettingsReport(elements);
-    setStatus(elements, wasSaved ? "Settings saved." : "Settings are active for this session.", "ready");
+    setGlobalStatus(elements, wasSaved ? "Settings saved." : "Settings are active for this session.", "ready");
     setDiagnostics(
       elements,
       wasSaved
@@ -937,7 +938,7 @@ export function renderApp(rootElement: HTMLElement) {
     fillSingleCheckpointSelect(elements.upscaleModel, FALLBACK_UPSCALE_MODELS, FALLBACK_UPSCALE_MODELS[0]);
     updateUpscaleCompatibility(elements, upscaleSource);
     setError(elements, "");
-    setStatus(elements, "Settings reset to OpenLayer defaults.", "ready");
+    setGlobalStatus(elements, "Settings reset to OpenLayer defaults.", "ready");
     setDiagnostics(elements, "Defaults restored. Click Check ComfyUI to reload available models.");
     updateSettingsReport(elements);
   }
@@ -998,7 +999,7 @@ export function renderApp(rootElement: HTMLElement) {
     error: (elements: AppElements, message: string) => void;
     progress?: (elements: AppElements, message: string, blob?: Blob) => void;
   }> = {
-    "text-to-image": { status: setStatus, diagnostics: setDiagnostics, error: setError, progress: setProgressPreview },
+    "text-to-image": { status: setTextToImageStatus, diagnostics: setDiagnostics, error: setError, progress: setProgressPreview },
     "image-to-image": { status: setImageStatus, diagnostics: setImageDiagnostics, error: setImageError, progress: setImageProgressPreview },
     "sketch-to-image": { status: setSketchStatus, diagnostics: setSketchDiagnostics, error: setSketchError, progress: setSketchProgressPreview },
     inpaint: { status: setInpaintStatus, diagnostics: setInpaintDiagnostics, error: setInpaintError, progress: setInpaintProgressPreview },
@@ -1070,7 +1071,7 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleGenerate() {
-    if (blockRegularGenerationDuringLivePainting((message) => setStatus(elements, message, "error"))) {
+    if (blockRegularGenerationDuringLivePainting((message) => setTextToImageStatus(elements, message, "error"))) {
       return;
     }
 
@@ -1078,7 +1079,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     if (!elements.prompt.value.trim()) {
       setError(elements, getErrorMessage(createOpenLayerError("PROMPT_REQUIRED", "Enter a prompt before generating.")));
-      setStatus(elements, "Prompt required.", "error");
+      setTextToImageStatus(elements, "Prompt required.", "error");
       return;
     }
 
@@ -1087,7 +1088,7 @@ export function renderApp(rootElement: HTMLElement) {
     busyTool = "text-to-image";
     isBusy = true;
     syncBusy();
-    setStatus(elements, "Preparing workflow...", "idle");
+    setTextToImageStatus(elements, "Preparing workflow...", "idle");
     setProgressPreview(elements, "Preparing workflow...");
 
     try {
@@ -1119,7 +1120,7 @@ export function renderApp(rootElement: HTMLElement) {
         setDiagnostics(elements, `${compatibility.label} ${compatibility.warning}`);
       }
 
-      setStatus(elements, "Checking selected checkpoint...", "idle");
+      setTextToImageStatus(elements, "Checking selected checkpoint...", "idle");
       setProgressPreview(elements, "Checking selected checkpoint...");
 
       if (!(await client.hasModelForPreset(checkpointName, preset))) {
@@ -1180,11 +1181,11 @@ export function renderApp(rootElement: HTMLElement) {
       }
 
       if (importAutomatically) {
-        setStatus(elements, "Generation complete. Auto-importing...", "idle");
+        setTextToImageStatus(elements, "Generation complete. Auto-importing...", "idle");
         setDiagnostics(elements, `Seed used: ${buildResult.seed}. Auto import is on.`);
         await handleImport("auto");
       } else {
-        setStatus(elements, "Generation complete.", "ready");
+        setTextToImageStatus(elements, "Generation complete.", "ready");
         setDiagnostics(elements, `Seed used: ${buildResult.seed}. Workflow: ${buildResult.preset.id}.`);
       }
 
@@ -1196,7 +1197,7 @@ export function renderApp(rootElement: HTMLElement) {
         return;
       }
 
-      setStatus(elements, "Generation failed.", "error");
+      setTextToImageStatus(elements, "Generation failed.", "error");
       setError(elements, getErrorMessage(caughtError));
       setDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
@@ -1209,7 +1210,7 @@ export function renderApp(rootElement: HTMLElement) {
   function handleClearHistory() {
     clearHistoryEntries(historyEntries, objectUrls);
     renderHistory(elements, historyEntries);
-    setStatus(elements, "History cleared.", "ready");
+    setGlobalStatus(elements, "History cleared.", "ready");
     setDiagnostics(elements, "Recent session history cleared.");
   }
 
@@ -1222,7 +1223,7 @@ export function renderApp(rootElement: HTMLElement) {
     const entry = historyEntries.find((item) => item.id === historyId);
 
     if (!entry) {
-      setStatus(elements, "History item not found.", "error");
+      setGlobalStatus(elements, "History item not found.", "error");
       setError(elements, "That history item is no longer available in this session.");
       return;
     }
@@ -1367,7 +1368,7 @@ export function renderApp(rootElement: HTMLElement) {
     busyTool = "text-to-image";
     isBusy = true;
     syncBusy();
-    setStatus(elements, "Importing image into Photoshop...", "idle");
+    setTextToImageStatus(elements, "Importing image into Photoshop...", "idle");
 
     try {
       const layerName = createLayerName("OpenLayer_Generated");
@@ -1378,11 +1379,11 @@ export function renderApp(rootElement: HTMLElement) {
         originatingDocument: result.originatingDocument,
         layerName,
         onProgress: (message) => {
-          setStatus(elements, message, "idle");
+          setTextToImageStatus(elements, message, "idle");
           setDiagnostics(elements, message);
         }
       });
-      setStatus(elements, `Imported layer: ${importedLayerName}`, "ready");
+      setTextToImageStatus(elements, `Imported layer: ${importedLayerName}`, "ready");
       flashImported(elements.statusText);
       markHistoryImported(elements, historyEntries, result, importedLayerName);
       const metadataMessage = await writeMetadataForImportedResult(historyEntries, result, importedLayerName, (message) => {
@@ -1390,7 +1391,7 @@ export function renderApp(rootElement: HTMLElement) {
       });
       setDiagnostics(elements, `Layer created: ${importedLayerName}. ${metadataMessage}`);
     } catch (caughtError) {
-      setStatus(elements, "Import failed.", "error");
+      setTextToImageStatus(elements, "Import failed.", "error");
       setError(elements, getErrorMessage(caughtError));
     } finally {
       isBusy = false;

--- a/src/ui/statusBars.ts
+++ b/src/ui/statusBars.ts
@@ -256,13 +256,18 @@ function applyToolStatus(
   updateHomeStatus(elements, status, tone);
 }
 
-// The Text to Image status doubles as the global one: it broadcasts to every
-// tool's status bar plus the settings screen. The per-tool setters below touch
-// only their own bar and the home indicator.
-export function setStatus(elements: AppElements, status: string, tone: StatusTone) {
-  elements.statusText.textContent = status;
-  applyStatusPill(elements.statusPill, status, tone);
-  setStatusProgress(elements.statusProgress, status, tone);
+/**
+ * A message that is true for the whole panel: the ComfyUI connection, the
+ * settings screen, the session history. Those are not owned by any one tool, so
+ * they land in every tool's bar plus the settings screen.
+ *
+ * Nothing a single tool is doing may come through here. This used to be the
+ * only fan-out setter *and* Text to Image's own setter, which is why Text to
+ * Image progress ("Preparing workflow...", "Generation complete.") appeared in
+ * the Inpaint and Upscale bars in v0.7. Tool work goes to the tool's own setter.
+ */
+export function setGlobalStatus(elements: AppElements, status: string, tone: StatusTone) {
+  setTextToImageStatus(elements, status, tone);
   applyToolStatus(elements, elements.imgStatusText, elements.imgStatusPill, elements.imgStatusProgress, status, tone);
   applyToolStatus(elements, elements.sketchStatusText, elements.sketchStatusPill, elements.sketchStatusProgress, status, tone);
   applyToolStatus(elements, elements.inpaintStatusText, elements.inpaintStatusPill, elements.inpaintStatusProgress, status, tone);
@@ -270,6 +275,12 @@ export function setStatus(elements: AppElements, status: string, tone: StatusTon
   applyToolStatus(elements, elements.upscaleStatusText, elements.upscaleStatusPill, elements.upscaleStatusProgress, status, tone);
   applyToolStatus(elements, elements.promptLayerStatusText, elements.promptLayerStatusPill, elements.promptLayerStatusProgress, status, tone);
   applyToolStatus(elements, elements.settingsStatusText, elements.settingsStatusPill, elements.settingsStatusProgress, status, tone);
+}
+
+// Text to Image owns the unprefixed status elements, a leftover from when it was
+// the only tool in the panel. It is a per-tool setter like every other one below.
+export function setTextToImageStatus(elements: AppElements, status: string, tone: StatusTone) {
+  applyToolStatus(elements, elements.statusText, elements.statusPill, elements.statusProgress, status, tone);
 }
 
 export function setImageStatus(elements: AppElements, status: string, tone: StatusTone) {

--- a/src/ui/statusBars.ts
+++ b/src/ui/statusBars.ts
@@ -1,0 +1,372 @@
+import { AppElements } from "./appMarkup";
+
+/**
+ * Every status surface in the panel: the status text, the Ready/Working/Error
+ * pill, the progress bar under it, the error line, the diagnostics line, and
+ * the home screen's dot.
+ *
+ * Each of the seven tools owns one status bar, and the setters below are the
+ * only writers. They are grouped here rather than in App.ts because they are
+ * pure DOM writes over `AppElements` — no generation state, no Photoshop, no
+ * closure variables — so the whole group moves as a unit.
+ *
+ * The one piece of real logic is the progress bar. `resolveStatusProgress`
+ * decides busy/idle and determinate/indeterminate from the status text alone,
+ * which is why it is pure and directly tested; `setStatusProgress` is the DOM
+ * half that owns the animation timer and the sticky-percent memory.
+ */
+
+export type StatusTone = "idle" | "ready" | "error";
+
+const statusProgressTimers = new WeakMap<HTMLElement, number>();
+// Remembers the last real step percentage per progress bar so percent-less
+// status updates (e.g. the history poll tick) cannot reset a determinate bar
+// back to the indeterminate warm-up animation mid-run.
+const statusProgressLastPercent = new WeakMap<HTMLElement, number>();
+
+export function setStatusProgress(progressElement: HTMLElement, status: string, tone: StatusTone) {
+  const normalizedStatus = status.trim().toLowerCase();
+  const isBusy =
+    tone === "idle" &&
+    normalizedStatus !== "ready" &&
+    normalizedStatus !== "ready." &&
+    !normalizedStatus.includes("complete") &&
+    !normalizedStatus.includes("copied") &&
+    !normalizedStatus.includes("saved") &&
+    !normalizedStatus.includes("reset") &&
+    !normalizedStatus.includes("cancel");
+
+  const fill = progressElement.firstElementChild as HTMLElement | null;
+  const resolved = resolveStatusProgress(status, isBusy, statusProgressLastPercent.get(progressElement) ?? null);
+
+  if (!resolved.isBusy) {
+    const existingTimer = statusProgressTimers.get(progressElement);
+    if (existingTimer) {
+      window.clearInterval(existingTimer);
+      statusProgressTimers.delete(progressElement);
+    }
+
+    statusProgressLastPercent.delete(progressElement);
+    progressElement.hidden = true;
+    progressElement.className = "status-progress";
+    progressElement.style.removeProperty("--ol-progress");
+
+    if (fill) {
+      fill.style.marginLeft = "";
+      fill.style.width = "";
+    }
+    progressElement.removeAttribute("data-progress-offset");
+    progressElement.removeAttribute("data-progress-label");
+    return;
+  }
+
+  const stickyPercent = resolved.percent;
+
+  progressElement.hidden = false;
+  progressElement.className = `status-progress is-active${stickyPercent !== null ? " is-determinate" : ""}`;
+
+  if (stickyPercent !== null) {
+    renderDeterminateProgress(progressElement, stickyPercent);
+    return;
+  }
+
+  progressElement.style.removeProperty("--ol-progress");
+
+  progressElement.removeAttribute("data-progress-label");
+
+  if (statusProgressTimers.get(progressElement)) {
+    return;
+  }
+
+  let offset = -42;
+  const timer = window.setInterval(() => {
+    offset = offset >= 110 ? -42 : offset + 7;
+    progressElement.setAttribute("data-progress-offset", String(offset));
+
+    if (fill) {
+      fill.style.marginLeft = `${offset}%`;
+      fill.style.width = "42%";
+    }
+  }, 120);
+
+  statusProgressTimers.set(progressElement, timer);
+}
+
+function renderDeterminateProgress(progressElement: HTMLElement, percent: number) {
+  const fill = progressElement.firstElementChild as HTMLElement | null;
+  const existingTimer = statusProgressTimers.get(progressElement);
+
+  if (existingTimer) {
+    window.clearInterval(existingTimer);
+    statusProgressTimers.delete(progressElement);
+  }
+
+  statusProgressLastPercent.set(progressElement, percent);
+  progressElement.hidden = false;
+  progressElement.className = "status-progress is-active is-determinate";
+  // The determinate fill width is driven by a CSS variable so it beats the
+  // legacy "width: 42% !important" indeterminate rule without inline hacks.
+  progressElement.style.setProperty("--ol-progress", `${percent}%`);
+
+  if (fill) {
+    fill.style.marginLeft = "";
+    fill.style.width = "";
+  }
+
+  progressElement.removeAttribute("data-progress-offset");
+  progressElement.setAttribute("data-progress-label", `${percent}%`);
+}
+
+// Dedicated numeric progress entry point driven by the ComfyUI WebSocket
+// progress channel, independent of the human-readable status text.
+export function applyDeterminateProgress(progressElement: HTMLElement, value: number, max: number) {
+  if (!Number.isFinite(value) || !Number.isFinite(max) || max <= 0) {
+    return;
+  }
+
+  renderDeterminateProgress(progressElement, Math.max(0, Math.min(100, Math.round((value / max) * 100))));
+}
+
+export type StatusProgressState = {
+  isBusy: boolean;
+  // null while busy = indeterminate warm-up animation; a number = determinate fill.
+  percent: number | null;
+};
+
+// Pure resolver for the progress bar. Keeps a determinate bar determinate once
+// real step progress has arrived: percent-less status updates (the history
+// poll tick, "Retrieving image...") hold the last known percent instead of
+// collapsing the bar back to the indeterminate warm-up animation.
+export function resolveStatusProgress(
+  status: string,
+  isBusy: boolean,
+  lastPercent: number | null
+): StatusProgressState {
+  if (!isBusy) {
+    return { isBusy: false, percent: null };
+  }
+
+  const parsedPercent = readProgressPercent(status);
+  const percent = parsedPercent ?? lastPercent;
+
+  return { isBusy: true, percent: percent ?? null };
+}
+
+function readProgressPercent(status: string) {
+  const percentMatch = status.match(/(\d{1,3})(?:\.\d+)?\s*%/);
+
+  if (percentMatch) {
+    return clampProgressPercent(Number(percentMatch[1]));
+  }
+
+  const stepMatch = status.match(/step\s+(\d+)\s+of\s+(\d+)/i);
+
+  if (stepMatch) {
+    const value = Number(stepMatch[1]);
+    const max = Number(stepMatch[2]);
+
+    if (Number.isFinite(value) && Number.isFinite(max) && max > 0) {
+      return clampProgressPercent(Math.round((value / max) * 100));
+    }
+  }
+
+  const fractionMatch = status.match(/\b(\d+)\s*\/\s*(\d+)\b/);
+
+  if (fractionMatch) {
+    const value = Number(fractionMatch[1]);
+    const max = Number(fractionMatch[2]);
+
+    if (Number.isFinite(value) && Number.isFinite(max) && max > 0) {
+      return clampProgressPercent(Math.round((value / max) * 100));
+    }
+  }
+
+  return null;
+}
+
+function clampProgressPercent(value: number) {
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  return Math.max(0, Math.min(100, value));
+}
+
+export function flashImported(statusTextElement: HTMLElement) {
+  const target = (statusTextElement.closest(".status-bar") as HTMLElement | null) ?? statusTextElement;
+  target.classList.remove("ol-import-flash");
+  void target.offsetWidth;
+  target.classList.add("ol-import-flash");
+  window.setTimeout(() => target.classList.remove("ol-import-flash"), 900);
+}
+
+function applyStatusPill(pill: HTMLElement, status: string, tone: StatusTone) {
+  if (tone === "error") {
+    pill.textContent = "Error";
+    pill.className = "status-pill error";
+    return;
+  }
+
+  if (tone === "ready") {
+    pill.textContent = "Ready";
+    pill.className = "status-pill ready";
+    return;
+  }
+
+  const normalized = status.trim().toLowerCase();
+  const isWorking =
+    normalized !== "" &&
+    normalized !== "ready" &&
+    normalized !== "ready." &&
+    !normalized.includes("complete") &&
+    !normalized.includes("copied") &&
+    !normalized.includes("saved") &&
+    !normalized.includes("reset") &&
+    !normalized.includes("cancelled");
+
+  if (isWorking) {
+    pill.textContent = "Working";
+    pill.className = "status-pill working";
+    return;
+  }
+
+  pill.textContent = "Ready";
+  pill.className = "status-pill idle";
+}
+
+function updateHomeStatus(elements: AppElements, status: string, tone: StatusTone) {
+  elements.homeStatusText.textContent = tone === "ready" ? "Ready" : tone === "error" ? "Error" : status.replace(/\.$/, "");
+  // The text color defaults to the success green; only an error overrides it,
+  // so Ready and in-progress statuses keep their familiar look.
+  elements.homeStatusText.classList.toggle("is-error", tone === "error");
+  elements.homeStatusDot.className = `home-status-dot ${tone}`;
+}
+
+function applyToolStatus(
+  elements: AppElements,
+  text: HTMLElement,
+  pill: HTMLElement,
+  progress: HTMLElement,
+  status: string,
+  tone: StatusTone
+) {
+  text.textContent = status;
+  applyStatusPill(pill, status, tone);
+  setStatusProgress(progress, status, tone);
+  updateHomeStatus(elements, status, tone);
+}
+
+// The Text to Image status doubles as the global one: it broadcasts to every
+// tool's status bar plus the settings screen. The per-tool setters below touch
+// only their own bar and the home indicator.
+export function setStatus(elements: AppElements, status: string, tone: StatusTone) {
+  elements.statusText.textContent = status;
+  applyStatusPill(elements.statusPill, status, tone);
+  setStatusProgress(elements.statusProgress, status, tone);
+  applyToolStatus(elements, elements.imgStatusText, elements.imgStatusPill, elements.imgStatusProgress, status, tone);
+  applyToolStatus(elements, elements.sketchStatusText, elements.sketchStatusPill, elements.sketchStatusProgress, status, tone);
+  applyToolStatus(elements, elements.inpaintStatusText, elements.inpaintStatusPill, elements.inpaintStatusProgress, status, tone);
+  applyToolStatus(elements, elements.outpaintStatusText, elements.outpaintStatusPill, elements.outpaintStatusProgress, status, tone);
+  applyToolStatus(elements, elements.upscaleStatusText, elements.upscaleStatusPill, elements.upscaleStatusProgress, status, tone);
+  applyToolStatus(elements, elements.promptLayerStatusText, elements.promptLayerStatusPill, elements.promptLayerStatusProgress, status, tone);
+  applyToolStatus(elements, elements.settingsStatusText, elements.settingsStatusPill, elements.settingsStatusProgress, status, tone);
+}
+
+export function setImageStatus(elements: AppElements, status: string, tone: StatusTone) {
+  applyToolStatus(elements, elements.imgStatusText, elements.imgStatusPill, elements.imgStatusProgress, status, tone);
+}
+
+export function setSketchStatus(elements: AppElements, status: string, tone: StatusTone) {
+  applyToolStatus(elements, elements.sketchStatusText, elements.sketchStatusPill, elements.sketchStatusProgress, status, tone);
+}
+
+export function setInpaintStatus(elements: AppElements, status: string, tone: StatusTone) {
+  applyToolStatus(elements, elements.inpaintStatusText, elements.inpaintStatusPill, elements.inpaintStatusProgress, status, tone);
+}
+
+export function setOutpaintStatus(elements: AppElements, status: string, tone: StatusTone) {
+  applyToolStatus(elements, elements.outpaintStatusText, elements.outpaintStatusPill, elements.outpaintStatusProgress, status, tone);
+}
+
+export function setUpscaleStatus(elements: AppElements, status: string, tone: StatusTone) {
+  applyToolStatus(elements, elements.upscaleStatusText, elements.upscaleStatusPill, elements.upscaleStatusProgress, status, tone);
+}
+
+export function setPromptLayerStatus(elements: AppElements, status: string, tone: StatusTone) {
+  applyToolStatus(elements, elements.promptLayerStatusText, elements.promptLayerStatusPill, elements.promptLayerStatusProgress, status, tone);
+}
+
+function applyToolError(errorMessage: HTMLElement, message: string) {
+  errorMessage.textContent = message;
+  errorMessage.hidden = !message;
+}
+
+export function setError(elements: AppElements, message: string) {
+  applyToolError(elements.errorMessage, message);
+  applyToolError(elements.settingsErrorMessage, message);
+}
+
+export function setImageError(elements: AppElements, message: string) {
+  applyToolError(elements.imgErrorMessage, message);
+}
+
+export function setSketchError(elements: AppElements, message: string) {
+  applyToolError(elements.sketchErrorMessage, message);
+}
+
+export function setInpaintError(elements: AppElements, message: string) {
+  applyToolError(elements.inpaintErrorMessage, message);
+}
+
+export function setOutpaintError(elements: AppElements, message: string) {
+  applyToolError(elements.outpaintErrorMessage, message);
+}
+
+export function setUpscaleError(elements: AppElements, message: string) {
+  applyToolError(elements.upscaleErrorMessage, message);
+}
+
+export function setPromptLayerError(elements: AppElements, message: string) {
+  applyToolError(elements.promptLayerErrorMessage, message);
+}
+
+export function setDiagnostics(elements: AppElements, message: string) {
+  elements.diagnosticsText.textContent = message;
+  elements.imgDiagnosticsText.textContent = message;
+  elements.sketchDiagnosticsText.textContent = message;
+  elements.inpaintDiagnosticsText.textContent = message;
+  elements.outpaintDiagnosticsText.textContent = message;
+  elements.upscaleDiagnosticsText.textContent = message;
+  elements.promptLayerDiagnosticsText.textContent = message;
+  elements.settingsDiagnosticsText.textContent = message;
+}
+
+export function setImageDiagnostics(elements: AppElements, message: string) {
+  elements.imgDiagnosticsText.textContent = message;
+  elements.settingsDiagnosticsText.textContent = message;
+}
+
+export function setSketchDiagnostics(elements: AppElements, message: string) {
+  elements.sketchDiagnosticsText.textContent = message;
+  elements.settingsDiagnosticsText.textContent = message;
+}
+
+export function setInpaintDiagnostics(elements: AppElements, message: string) {
+  elements.inpaintDiagnosticsText.textContent = message;
+  elements.settingsDiagnosticsText.textContent = message;
+}
+
+export function setOutpaintDiagnostics(elements: AppElements, message: string) {
+  elements.outpaintDiagnosticsText.textContent = message;
+  elements.settingsDiagnosticsText.textContent = message;
+}
+
+export function setUpscaleDiagnostics(elements: AppElements, message: string) {
+  elements.upscaleDiagnosticsText.textContent = message;
+  elements.settingsDiagnosticsText.textContent = message;
+}
+
+export function setPromptLayerDiagnostics(elements: AppElements, message: string) {
+  elements.promptLayerDiagnosticsText.textContent = message;
+  elements.settingsDiagnosticsText.textContent = message;
+}

--- a/tests/ui/statusProgress.test.ts
+++ b/tests/ui/statusProgress.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveStatusProgress } from "../../src/ui/App";
+import { resolveStatusProgress } from "../../src/ui/statusBars";
 
 describe("resolveStatusProgress", () => {
   it("is hidden when not busy", () => {


### PR DESCRIPTION
Task 7 of v0.8, in the two commits we agreed: the move first, then the bug the move exposes.

### 1. `Extract the status bars out of App.ts` (e065e8a)

347 lines move to `src/ui/statusBars.ts` — status text, the Ready/Working/Error pill, the progress bar, the error line, the diagnostics line, the home dot. Pure DOM writes over `AppElements`, no generation state and no closure variables, so the group moves as a unit.

Relocation only. The moved lines are byte-identical to the originals apart from the `export` keyword — verified by diffing the removed band against the new file, not by eye. The progress-resolver test moves with it.

App.ts: **5,842 → 5,513 lines.**

### 2. `Stop Text to Image progress appearing in every tool's status bar` (854047d)

`setStatus` was doing two jobs under one name: the panel-wide setter *and* Text to Image's own setter, because Text to Image owns the unprefixed status elements from when it was the only tool in the panel. Every Text to Image message was broadcast to all six other tool bars. That is live in v0.7 today.

Split by audience:

| | writes | sites |
|---|---|---|
| `setGlobalStatus` | all 7 tool bars + settings + home dot | 23 — connection, port scan, GPU detect, workflow health, diagnostics copy, settings save/reset, history |
| `setTextToImageStatus` | the Text to Image bar + home dot | 11 + the `generationToolUi` row |

History stays on the global setter deliberately: the History screen has no status bar of its own, and clearing history is not one tool's business.

### Smoke test

ComfyUI up, panel open in Photoshop.

1. **Settings → Check ComfyUI.** Then visit Text to Image, Inpaint and Upscale: each bar should read `ComfyUI is online. Models loaded.` — the global fan-out is meant to survive.
2. **Text to Image → prompt → Generate.** While it is running, switch to **Inpaint**. Its bar must read `Ready.` with a grey idle pill and **no moving progress bar**. On v0.7 it reads `Generating image...` with a Working pill — that is the bug.
3. Also check **Upscale** and **Prompt from Layer** mid-run: same, still `Ready.`
4. Back on **Text to Image**: its own bar shows the progress fill and ends on `Generation complete.` The home screen dot follows along.
5. **Import to Layers** on that result: `Importing image into Photoshop...` → `Imported layer: ...` with the green flash. Inpaint's bar still `Ready.`
6. **Run one Inpaint generation** end to end. Its bar behaves exactly as before — the per-tool setters were not touched, this confirms it.
7. **History → Clear History**, then go back to a tool: `History cleared.` is expected there.
8. Close and reopen the panel: no stuck progress bar anywhere.

Step 2 is the one that matters; the rest is regression cover.

### Noticed, not fixed

`setDiagnostics` has the identical defect one line down: it writes all eight diagnostics lines, and it is still what the `text-to-image` row uses, so `Seed used: 12345.` from a Text to Image run lands in Inpaint's diagnostics line too. `setError` similarly writes the Text to Image error line *and* the Settings one. Same shape, same fix, ~30 call sites. Left out to keep this PR to the agreed scope — say the word and it is a third commit here, or its own task.

CI is typecheck + lint + test + build; none of them can see this class of bug, since the setters are DOM writes and the suite is node-only. Step 2 above is the real gate.
