### PR TITLE
Measure styles.css: an audit script and the numbers it produces

### DIFF
--- a/docs/css-audit.md
+++ b/docs/css-audit.md
@@ -1,0 +1,96 @@
+# CSS audit — `src/styles.css`
+
+Task 9 of v0.8. **Measurement only: no CSS was changed.** Regenerate with `npm run audit-css`;
+the numbers come from parsing the stylesheet and cross-referencing every class name against
+`src/` and `scripts/`.
+
+## Size
+
+| | |
+|---|---:|
+| Lines | 7451 |
+| Rule blocks | 929 |
+| Distinct selectors | 678 |
+| Selectors declared more than once | 261 |
+| `!important` declarations | 1049 |
+| …of those, inside a `theme-compact` rule | 1046 |
+
+## The two themes
+
+`theme-compact` and `theme-classic` are both selectable in Settings ("Compact Adobe Dark" and
+"Classic v0.4"). Compact is the default and the shipped look. Classic is not a dead code path —
+it is what the 309 unscoped rules render.
+
+| | rules | lines |
+|---|---:|---:|
+| Scoped to `.theme-compact` | 611 | 5798 |
+| Scoped to `.theme-classic` | 9 | 76 |
+| Unscoped (base — what Classic renders) | 309 | 2443 |
+
+65.8% of all rules are compact overrides and they carry
+99.7% of the `!important` in the file. **137** base selectors have a
+`theme-compact` counterpart.
+
+That last number is the override tax, and it is the mechanism behind the trap recorded in
+`docs/ORCHESTRATION.md` §3: a base rule that looks correct is often beaten by a compact
+`!important` block hundreds of lines further down. Grep `theme-compact <selector>` before
+concluding a base rule is what renders.
+
+## Most-redeclared selectors
+
+| times | selector |
+|---:|---|
+| 19 | `.app-shell.theme-compact .source-action-row` |
+| 17 | `.app-shell.theme-compact .generation-status-panel` |
+| 15 | `.app-shell.theme-compact .generator-panel` |
+| 14 | `.app-shell.theme-compact .settings-panel` |
+| 13 | `.app-shell.theme-compact .panel-section` |
+| 13 | `.app-shell.theme-compact .result-panel` |
+| 13 | `.app-shell.theme-compact .history-panel` |
+| 12 | `.app-shell.theme-compact .input` |
+| 12 | `.app-shell.theme-compact .select` |
+| 11 | `.app-shell.theme-compact .settings-grid .field` |
+| 11 | `.app-shell.theme-compact .img2img-settings-grid .field` |
+| 11 | `.app-shell.theme-compact .app-footer` |
+| 10 | `.app-shell.theme-compact` |
+| 10 | `.app-shell.theme-compact .home-view` |
+| 10 | `.app-shell.theme-compact .generator-view` |
+| 10 | `.app-shell.theme-compact .image-to-image-view` |
+| 10 | `.app-shell.theme-compact .settings-view` |
+| 10 | `.app-shell.theme-compact .history-view` |
+| 10 | `.app-shell.theme-compact .screen-nav` |
+| 10 | `.app-shell.theme-compact .textarea` |
+
+## Unreferenced classes
+
+28 class names appear in the stylesheet and nowhere in `src/` or `scripts/`. Rules that match
+only those names span **630 lines across 83 rule blocks** — roughly 8.5% of the file.
+
+### `ol-*` (the pre-v0.5 naming)
+
+`.ol-button`, `.ol-button-orange`, `.ol-field`, `.ol-footer`, `.ol-form-grid`, `.ol-input`, `.ol-label`, `.ol-panel`, `.ol-pill-ready`, `.ol-row-status`, `.ol-select`, `.ol-textarea`
+
+### Everything else
+
+`.connection-panel`, `.field-row`, `.footer-link`, `.home-tool-section`, `.icon-glyph`, `.icon-svg`, `.screen-tool-icon`, `.settings-actions`, `.settings-shortcut`, `.shortcut-label`, `.shortcut-note`, `.text-image-shortcuts`, `.tool-card-header`, `.tool-grid`, `.tool-status`, `.version-badge`
+
+### Checked, and NOT dead
+
+10 `is-*` names never appear as literals because they are assembled at runtime from
+`is-${card.status}` (`ToolCardStatus`), `is-${item.state}` (`WorkflowHealthState`) and
+`is-${card.state}` (the diagnostics summary cards). A text search calls them unused. They are
+not. Do not delete these:
+
+`.is-available`, `.is-coming-soon`, `.is-experimental`, `.is-future`, `.is-missing-model`, `.is-missing-node`, `.is-missing-workflow`, `.is-ready`, `.is-setup`, `.is-setup-required`
+
+## What the numbers say
+
+1. **Deleting the dead classes is the cheap, safe win** — about 630 lines, no live selector
+   touched. It still needs a real Photoshop pass, because the check is "no literal mention in
+   the source", and only the host can prove nothing regressed.
+2. **Consolidation is a bigger job than it looks, and it is not deletion.** Both themes ship,
+   so the 137 shadowed selectors cannot simply collapse into one rule; that work is merging
+   two designs, and it belongs behind a decision about whether Classic still earns its place.
+3. **The `!important` count is a symptom, not the disease.** 99.7% of it sits in compact
+   overrides fighting base rules. It shrinks when the theme layering is fixed, not by editing
+   the declarations.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc --noEmit && vite build && node scripts/copy-uxp-assets.mjs",
     "package": "npm run build && node scripts/package.mjs",
     "setup-pack": "node scripts/build-setup-pack.mjs",
+    "audit-css": "node scripts/audit-css.mjs",
     "test": "vitest run --config vitest.config.ts"
   },
   "devDependencies": {

--- a/scripts/audit-css.mjs
+++ b/scripts/audit-css.mjs
@@ -1,0 +1,178 @@
+// Measures src/styles.css and regenerates docs/css-audit.md.
+//
+// Read-only with respect to the stylesheet: it parses, counts, and writes a
+// report. It changes no CSS. Run it with `npm run audit-css` after any styling
+// work so the numbers in the doc stay honest.
+//
+// The one judgement call encoded here is the dynamic-class rule. Several class
+// names are assembled at runtime (`is-${card.status}`, `is-${item.state}`,
+// `is-${card.state}`), so a plain text search reports them as unused when they
+// are not. Anything matching a dynamic prefix is reported separately and never
+// listed as dead.
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const css = readFileSync(join(root, "src/styles.css"), "utf8");
+const lines = css.split(/\r?\n/);
+
+const sourceFiles = [];
+function walk(dir) {
+  for (const name of readdirSync(dir)) {
+    if (name === "node_modules" || name === ".git" || name === "dist") continue;
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) walk(full);
+    else if (/\.(ts|tsx|js|mjs|html|json)$/.test(name)) sourceFiles.push(full);
+  }
+}
+walk(join(root, "src"));
+walk(join(root, "scripts"));
+const sourceText = sourceFiles.map((file) => readFileSync(file, "utf8")).join("\n");
+
+// Blank comments in place so line numbers stay true.
+const blanked = css.replace(/\/\*[\s\S]*?\*\//g, (comment) => comment.replace(/[^\n]/g, " "));
+
+const rules = [];
+const ruleRegex = /([^{}]+)\{([^{}]*)\}/g;
+let match;
+while ((match = ruleRegex.exec(blanked))) {
+  const prelude = match[1].trim();
+  if (!prelude || prelude.startsWith("@")) continue;
+  const startLine = blanked.slice(0, match.index).split("\n").length;
+  const endLine = blanked.slice(0, match.index + match[0].length).split("\n").length;
+  rules.push({ selectors: prelude, body: match[2], lineCount: endLine - startLine + 1 });
+}
+
+const normalize = (selector) => selector.trim().replace(/\s+/g, " ");
+
+const selectorCounts = new Map();
+for (const rule of rules) {
+  for (const selector of rule.selectors.split(",")) {
+    const key = normalize(selector);
+    if (key) selectorCounts.set(key, (selectorCounts.get(key) ?? 0) + 1);
+  }
+}
+const repeated = [...selectorCounts.entries()].filter(([, n]) => n > 1).sort((a, b) => b[1] - a[1]);
+
+const compactRules = rules.filter((rule) => rule.selectors.includes("theme-compact"));
+const classicRules = rules.filter((rule) => rule.selectors.includes("theme-classic"));
+const baseRules = rules.filter(
+  (rule) => !rule.selectors.includes("theme-compact") && !rule.selectors.includes("theme-classic")
+);
+const sumLines = (list) => list.reduce((total, rule) => total + rule.lineCount, 0);
+
+const compactSelectors = new Set();
+for (const rule of compactRules) {
+  for (const selector of rule.selectors.split(",")) {
+    compactSelectors.add(
+      normalize(selector).replace(/^\.app-shell\.theme-compact\s*/, "").replace(/^\.theme-compact\s*/, "")
+    );
+  }
+}
+const baseSelectors = new Set();
+for (const rule of baseRules) for (const selector of rule.selectors.split(",")) baseSelectors.add(normalize(selector));
+const shadowed = [...baseSelectors].filter((selector) => compactSelectors.has(selector));
+
+const importantTotal = (blanked.match(/!important/g) ?? []).length;
+const importantInCompact = compactRules.reduce((n, rule) => n + (rule.body.match(/!important/g) ?? []).length, 0);
+
+const classNames = new Set();
+for (const found of blanked.matchAll(/\.(-?[_a-zA-Z][\w-]*)/g)) classNames.add(found[1]);
+
+const DYNAMIC_PREFIXES = ["is-"];
+const isDynamic = (name) => DYNAMIC_PREFIXES.some((prefix) => name.startsWith(prefix));
+const dead = [...classNames].filter((name) => !isDynamic(name) && !sourceText.includes(name)).sort();
+const dynamicOnly = [...classNames].filter((name) => isDynamic(name) && !sourceText.includes(name)).sort();
+const deadSet = new Set(dead);
+
+const classesIn = (selector) => [...selector.matchAll(/\.(-?[_a-zA-Z][\w-]*)/g)].map((found) => found[1]);
+const deletableRules = rules.filter((rule) => {
+  const parts = rule.selectors.split(",").map(normalize).filter(Boolean);
+  return parts.length > 0 && parts.every((part) => classesIn(part).some((name) => deadSet.has(name)));
+});
+
+const list = (names) => (names.length ? names.map((name) => `\`.${name}\``).join(", ") : "_none_");
+const pct = (part, whole) => ((part / whole) * 100).toFixed(1);
+
+const report = `# CSS audit — \`src/styles.css\`
+
+Task 9 of v0.8. **Measurement only: no CSS was changed.** Regenerate with \`npm run audit-css\`;
+the numbers come from parsing the stylesheet and cross-referencing every class name against
+\`src/\` and \`scripts/\`.
+
+## Size
+
+| | |
+|---|---:|
+| Lines | ${lines.length} |
+| Rule blocks | ${rules.length} |
+| Distinct selectors | ${selectorCounts.size} |
+| Selectors declared more than once | ${repeated.length} |
+| \`!important\` declarations | ${importantTotal} |
+| …of those, inside a \`theme-compact\` rule | ${importantInCompact} |
+
+## The two themes
+
+\`theme-compact\` and \`theme-classic\` are both selectable in Settings ("Compact Adobe Dark" and
+"Classic v0.4"). Compact is the default and the shipped look. Classic is not a dead code path —
+it is what the ${baseRules.length} unscoped rules render.
+
+| | rules | lines |
+|---|---:|---:|
+| Scoped to \`.theme-compact\` | ${compactRules.length} | ${sumLines(compactRules)} |
+| Scoped to \`.theme-classic\` | ${classicRules.length} | ${sumLines(classicRules)} |
+| Unscoped (base — what Classic renders) | ${baseRules.length} | ${sumLines(baseRules)} |
+
+${pct(compactRules.length, rules.length)}% of all rules are compact overrides and they carry
+${pct(importantInCompact, importantTotal)}% of the \`!important\` in the file. **${shadowed.length}** base selectors have a
+\`theme-compact\` counterpart.
+
+That last number is the override tax, and it is the mechanism behind the trap recorded in
+\`docs/ORCHESTRATION.md\` §3: a base rule that looks correct is often beaten by a compact
+\`!important\` block hundreds of lines further down. Grep \`theme-compact <selector>\` before
+concluding a base rule is what renders.
+
+## Most-redeclared selectors
+
+| times | selector |
+|---:|---|
+${repeated.slice(0, 20).map(([selector, n]) => `| ${n} | \`${selector}\` |`).join("\n")}
+
+## Unreferenced classes
+
+${dead.length} class names appear in the stylesheet and nowhere in \`src/\` or \`scripts/\`. Rules that match
+only those names span **${sumLines(deletableRules)} lines across ${deletableRules.length} rule blocks** — roughly ${pct(sumLines(deletableRules), lines.length)}% of the file.
+
+### \`ol-*\` (the pre-v0.5 naming)
+
+${list(dead.filter((name) => name.startsWith("ol-")))}
+
+### Everything else
+
+${list(dead.filter((name) => !name.startsWith("ol-")))}
+
+### Checked, and NOT dead
+
+${dynamicOnly.length} \`is-*\` names never appear as literals because they are assembled at runtime from
+\`is-\${card.status}\` (\`ToolCardStatus\`), \`is-\${item.state}\` (\`WorkflowHealthState\`) and
+\`is-\${card.state}\` (the diagnostics summary cards). A text search calls them unused. They are
+not. Do not delete these:
+
+${list(dynamicOnly)}
+
+## What the numbers say
+
+1. **Deleting the dead classes is the cheap, safe win** — about ${sumLines(deletableRules)} lines, no live selector
+   touched. It still needs a real Photoshop pass, because the check is "no literal mention in
+   the source", and only the host can prove nothing regressed.
+2. **Consolidation is a bigger job than it looks, and it is not deletion.** Both themes ship,
+   so the ${shadowed.length} shadowed selectors cannot simply collapse into one rule; that work is merging
+   two designs, and it belongs behind a decision about whether Classic still earns its place.
+3. **The \`!important\` count is a symptom, not the disease.** ${pct(importantInCompact, importantTotal)}% of it sits in compact
+   overrides fighting base rules. It shrinks when the theme layering is fixed, not by editing
+   the declarations.
+`;
+
+writeFileSync(join(root, "docs/css-audit.md"), report);
+console.log(`docs/css-audit.md written — ${lines.length} lines measured, ${dead.length} unreferenced classes, ${sumLines(deletableRules)} deletable lines.`);


### PR DESCRIPTION
Task 9 of v0.8. **Measurement only — no CSS changed.** Independent of PR #39, touches no file that PR touches.

Adds `npm run audit-css`, which parses `src/styles.css`, cross-references every class name against `src/` and `scripts/`, and regenerates [`docs/css-audit.md`](docs/css-audit.md).

### What it found

| | |
|---|---:|
| Lines / rule blocks | 7,451 / 929 |
| `!important` declarations | 1,049 — **1,046 of them inside `theme-compact` overrides** |
| Base selectors shadowed by a `theme-compact` rule | **137** |
| Class names referenced nowhere in `src/` or `scripts/` | 28 (12 are `ol-*`) |
| Lines in rules matching only those names | **630 — 8.5% of the file** |

Three things worth knowing:

**Classic is not a dead code path.** It is selectable in Settings and is what the 309 unscoped rules render. So consolidation means merging two live designs, not deleting one — a bigger job than "collapse the duplicates", and it should sit behind a decision about whether Classic still earns its place.

**The `!important` count is a symptom.** 99.7% of it is compact overrides fighting base rules. It shrinks when the layering is fixed, not by editing declarations.

**The naive version of this audit was wrong, and that is the useful part.** The first pass called 22 `is-*` classes dead. They are not — `is-available`, `is-ready`, `is-missing-model` and friends are built at runtime from `is-${card.status}` and `is-${item.state}`, so no text search can see them. Deleting on that evidence would have broken the tool cards and the workflow-health list, silently, in a way CI cannot catch. The script now excludes dynamic prefixes and prints those names as an explicit do-not-delete list.

### Smoke test

None. No CSS, markup or TypeScript behaviour changes — the diff is one script, one generated report, one `package.json` line. CI is the gate.

If you want to see the numbers yourself:

```bash
npm run audit-css
```

### The follow-up this sets up

Deleting the 28 dead classes is ~630 lines and touches no live selector. It is safe on the evidence but still needs your Photoshop pass, since "no literal mention in the source" is the whole basis. Say the word and it becomes its own gated task — I would not fold it into v0.8 without your check.
