### PR TITLE
Fix the header overlap: home status row, and the sticky header resize under it

### DIFF
--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -3608,6 +3608,11 @@ export function renderApp(rootElement: HTMLElement) {
 
   function setView(view: AppView) {
     currentView = view;
+    // The status row belongs to the home screen only. On a tool screen it sits
+    // directly above that screen's sticky header, where it collided with the
+    // progress bar mid-generation, and it is redundant there: since the v0.8
+    // status split every tool carries its own status bar with the same message.
+    elements.homeStatusRow.hidden = view !== "home";
     elements.homeView.hidden = currentView !== "home";
     elements.generatorView.hidden = currentView !== "text-to-image";
     elements.imageToImageView.hidden = currentView !== "image-to-image";

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -44,6 +44,7 @@ export type AppElements = {
   upscaleView: HTMLElement;
   settingsView: HTMLElement;
   historyView: HTMLElement;
+  homeStatusRow: HTMLElement;
   homeStatusText: HTMLElement;
   homeStatusDot: HTMLElement;
   serverUrl: HTMLInputElement;
@@ -251,7 +252,7 @@ export function createAppMarkup() {
   return `
     <main class="app-shell theme-compact" id="app-shell">
       ${createBrandHeaderMarkup()}
-      <div class="home-status-row">
+      <div class="home-status-row" id="home-status-row">
         <span>Status:</span>
         <strong id="home-status-text">Ready</strong>
         <span class="home-status-dot idle" id="home-status-dot" aria-hidden="true"></span>
@@ -1269,6 +1270,7 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     upscaleView: getElement<HTMLElement>(rootElement, "upscale-view"),
     settingsView: getElement<HTMLElement>(rootElement, "settings-view"),
     historyView: getElement<HTMLElement>(rootElement, "history-view"),
+    homeStatusRow: getElement<HTMLElement>(rootElement, "home-status-row"),
     homeStatusText: getElement<HTMLElement>(rootElement, "home-status-text"),
     homeStatusDot: getElement<HTMLElement>(rootElement, "home-status-dot"),
     serverUrl: getElement<HTMLInputElement>(rootElement, "server-url"),


### PR DESCRIPTION
Fixes the header overlap you hit mid-generation. Two commits, one per defect, because the first one uncovered the second.

## Commit 1 — keep the home status row on the home screen

The reported symptom: the `Status: Generating step 18 of 20 (9…` line and the sticky header's progress bar drawn on top of each other.

**The recorded hypothesis was wrong.** The note on file said the sticky `.screen-head` scrolls up over the non-sticky `.home-status-row`. It can't. Measured in the built bundle at panel width (340x780):

- `.app-shell.theme-compact` is `height: 100vh; overflow: hidden` — the shell never scrolls.
- `.home-status-row` is `flex: 0 0 auto; position: static` — a fixed band at the top.
- The **view sections** are the scroll containers (`flex: 1 1 auto; overflow-y: auto`), so `.screen-head`'s `position: sticky; top: 0` sticks to the top of its *own section*, which begins below the row.
- Scrolled fully to the bottom, the two boxes are **8px apart**. The row stays the topmost painted element at its own coordinates.

So instead of guessing at the quirk, this removes the element that had no business being on a tool screen. The row is declared once at the top of `createAppMarkup` for the whole shell, so it renders above *every* screen — but it is named `home`-status-row, and **since the v0.8 task 7 status split every tool carries its own status bar with the same message** (`applyToolStatus` mirrors into the home row on every write, which is why it showed live generation text at all). On a tool screen it duplicated information while colliding with it. `setView` now hides it off home.

**No CSS needed**, which is worth stating given the ORCHESTRATION §3 trap: `.app-shell.theme-compact [hidden]` (styles.css:6512) is (0,3,0) with `!important`, the only `display` on the row is the base `.home-status-row { display: flex }` at (0,1,0), and nothing later re-declares it. Checked, then confirmed in the running bundle.

## Commit 2 — stop the sticky header resizing when a run starts

Your host retest confirmed the collision was gone and revealed the defect underneath: the progress bar drawing on top of the first panel section.

**Cause: a sticky header that changes height.** In `.screen-head` the progress bar was hidden with `display: none` while idle, so the moment a run starts the header grows by exactly **14px**. Measured in the browser, the panel below moves down by the same 14px — a browser reflows for it, which is precisely why none of this reproduced outside Photoshop. UXP does not reflow content below a sticky element that resizes, so the header grows over the panel and the bar lands on it.

**Fix:** reserve the bar's box permanently and hide only its paint, so the header is one fixed height whether idle or generating.

Measured after the change: header growth **0**, panel movement **0**, **24px** of clearance between bar and panel. The 14px it costs while idle reads as breathing room under the nav — screenshotted and checked.

This does not depend on knowing how UXP resolves `position: sticky`, which is still unidentified. It removes the layout change the two renderers disagree about, so the disagreement stops mattering.

Rule edited is the last of three `.screen-head .status-progress` declarations, at (0,5,0) — beating generic `[hidden]` at (0,3,0) and unscoped `.status-progress[hidden]` at (0,4,0). Checked, not assumed.

## Commit 3 — hide the idle bar with colour, not visibility

Commit 2 reserved the box correctly but hid the idle bar with `visibility: hidden`. Correct in a browser, **wrong in Photoshop: UXP ignores `visibility: hidden` here.** The reserved track stayed painted, and with it the legacy `width: 42% !important` indeterminate fill (styles.css:6749) — so the host showed a stray half-width rule under the nav on every tool screen. One artefact swapped for another.

Colour is the mechanism both renderers agree on. The idle bar keeps its exact box and is painted the header's own `#535353` on track, border and fill, with the fill forced to zero width. Nothing is hidden, so there is nothing for UXP to disagree about — the bar is simply the same colour as what sits behind it.

Geometry is unchanged from commit 2 and re-measured: header **69px** idle and generating, **0** growth, **0** panel movement. The determinate fill still tracks real progress — 60% renders at 178px of the 300px track once its 200ms width transition settles (an earlier reading of "0" was me measuring 50ms into that transition, not a regression).

Also checked so it does not get misread as a leftover: the faint full-width line under the nav is `.screen-nav`'s **pre-existing** `border-bottom: 0.8px rgba(255,255,255,0.1)`, not the bar.

**Two UXP/browser divergences in this one header**, both invisible to anything short of a real Photoshop: UXP does not reflow content below a sticky element that resizes, and it does not honour `visibility` on this element.

## Validation

`npm run typecheck`, `npm run lint`, `npm test` (47 files, 383 tests), `npm run build` — all pass, on all three commits.

Browser-verified: home → Text to Image → back → Settings → back with the row hiding and restoring each time; and the header measured idle vs generating, before and after the fix.

## Smoke test

1. **The original bug** — Open **Text to Image**, enter a prompt, **Generate**. While it runs, watch the band under `< Back to Tools | Text to Image`. The progress bar should be alone there, no `Status: …` text across it. Scroll the form while it runs; still clean.
2. **The second defect** — During that same run, watch the gap between the progress bar and the **Generate** panel below it. The bar should sit clear of the panel for the whole run.
3. **No jump on start/stop** — Watch the **Generate** panel's top edge as you press Generate, and again when the run finishes. It should not move at all. Previously it shifted 14px each way.
4. **Idle header** — On a tool screen with nothing running, the space under `< Back to Tools` should look like normal padding. **No half-width line, no sunken track.** One faint full-width hairline directly under the nav is expected and pre-existing (it is the nav's own border).
   Then let a generation finish and look again — the bar must disappear completely at the end of the run, not leave a stub behind.
5. **The tool still reports status** — Mid-run, the tool's own status bar further down the form should show `Generating step N of …` with its pill on Working. Nothing is lost by hiding the home row.
6. **Home still has its row** — **Back to Tools**: `Status: Ready` and its coloured dot should be back under the OpenLayer header.
7. **Round trip** — Into **Settings**, back, into **Inpaint**, back. The row should disappear and reappear each time with no layout jump on home.
8. **Status still reaches home** — From home, **Settings → Check ComfyUI**, then **Back to Tools**. The home row should reflect the result rather than being stuck on a stale value.
9. **Every tool** — Repeat steps 2–4 on **Inpaint** and **Upscale**; all screens share this header.
