### PR TITLE
Stop the sticky header resizing, and hide the idle bar with colour

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -7263,12 +7263,25 @@ body,
 /* The sticky header must not change height when a run starts. Hiding the
    progress bar with display:none made the header grow mid-generation, and
    Photoshop's UXP renderer does not reflow the panels below a sticky element
-   that resizes - so the bar was painted over the first section. Reserving the
-   bar's box permanently and only hiding its paint keeps the header one fixed
-   height whether idle or generating. */
+   that resizes - so the bar was painted over the first section. The idle bar
+   therefore keeps its box and is made invisible instead.
+
+   It is painted the header's own colour rather than hidden, because UXP
+   ignores visibility:hidden here: the first attempt at this fix left the track
+   and its legacy 42%-wide fill (line 6749) showing as a stray half-width rule
+   under the nav in Photoshop, while looking correct in a browser. Colour is
+   the one mechanism both renderers agree on. */
 .app-shell.theme-compact .screen-head .status-progress[hidden] {
   display: block !important;
-  visibility: hidden !important;
+  border-color: #535353 !important;
+  background: #535353 !important;
+}
+
+.app-shell.theme-compact .screen-head .status-progress[hidden] > span {
+  width: 0 !important;
+  margin-left: 0 !important;
+  background: #535353 !important;
+  animation: none !important;
 }
 
 .app-shell.theme-compact .screen-head .status-progress > span {

--- a/src/styles.css
+++ b/src/styles.css
@@ -7260,8 +7260,15 @@ body,
   background: #343434 !important;
 }
 
+/* The sticky header must not change height when a run starts. Hiding the
+   progress bar with display:none made the header grow mid-generation, and
+   Photoshop's UXP renderer does not reflow the panels below a sticky element
+   that resizes - so the bar was painted over the first section. Reserving the
+   bar's box permanently and only hiding its paint keeps the header one fixed
+   height whether idle or generating. */
 .app-shell.theme-compact .screen-head .status-progress[hidden] {
-  display: none !important;
+  display: block !important;
+  visibility: hidden !important;
 }
 
 .app-shell.theme-compact .screen-head .status-progress > span {


### PR DESCRIPTION
**Recovers two commits that were left behind.** PR #42 was merged at 18:27 UTC with head `b200b3c` — commit 1 only — before the two CSS commits were pushed to that branch. So main currently has the home-status-row fix but **neither CSS fix**. This carries them over unchanged; the diff is `src/styles.css` only.

Mehran's host testing was done against a local build (`index-By64OPqI.js`) that contained all three commits, so the verification below stands — it just never reached main.

## Commit 1 of 2 — stop the sticky header resizing when a run starts

After the status row was hidden, the defect underneath it showed: the progress bar drawing on top of the first panel section.

**Cause: a sticky header that changes height.** In `.screen-head` the progress bar was hidden with `display: none` while idle, so the moment a run starts the header grows by exactly **14px**. Measured in the browser, the panel below moves down by the same 14px — Chromium reflows for it, which is exactly why none of this reproduced outside Photoshop. **UXP does not reflow content below a sticky element that resizes**, so the header grows over the panel and the bar lands on it.

Fix: reserve the bar's box permanently so the header has one fixed height whether idle or generating. Measured after: header growth **0**, panel movement **0**, **24px** clearance.

## Commit 2 of 2 — hide the idle bar with colour, not visibility

The first attempt hid the reserved bar with `visibility: hidden`. Correct in a browser, wrong in Photoshop: **UXP ignores `visibility: hidden` here.** The track stayed painted along with the legacy `width: 42% !important` fill (styles.css:6749), showing as a stray half-width rule under the nav.

Colour is the mechanism both renderers agree on. The idle bar keeps its exact box and is painted the header's own `#535353` on track, border and fill, with the fill forced to zero width. Nothing is hidden, so there is nothing for UXP to disagree about.

## Verified in the host, not just the browser

Console probe run in Mehran's Photoshop on the Inpaint screen, idle:

```
"progHidden": true,  "progDisplay": "block",     <- box reserved, header cannot resize
"trackBg": "#535353", "trackBorder": "#535353",
"fillBg": "#535353",  "fillW": 0,                <- bar cannot paint
"headBg": "#535353"
```

Browser-side: determinate fill still tracks real progress (60% renders at 178px of the 300px track once its 200ms transition settles).

`npm run typecheck`, `npm run lint`, `npm test` (47 files, 383 tests), `npm run build` — all pass.

## Known, explicitly out of scope

A thin separator line under the screen nav is still visible in UXP. It was proven **not** to be the progress bar — removing `.status-progress` from the DOM entirely leaves the line in place — and this branch's complete CSS diff touches nothing but the two `.status-progress[hidden]` rules, so it cannot be caused by this work. It is the pre-existing `.screen-nav { border-bottom: 1px solid #424242 }` (styles.css:430, recoloured to white-10% by theme-compact), present in every build including v0.7. Tracked separately for a later fix.

## Smoke test

The idle state is already confirmed by the probe above. What remains is one generation:

1. **Text to Image → prompt → Generate.** The progress bar fills normally and stays clear of the **Generate** panel for the whole run.
2. **No jump.** The Generate panel's top edge does not move when the run starts, nor when it finishes. It previously shifted 14px each way.
3. **Clean end.** When the run completes the bar disappears entirely — no stub, no half-width remnant.
4. Repeat 1–3 on **Inpaint**.
