### PR TITLE
Leave the progress bar in the status panel

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -7077,10 +7077,12 @@ body,
   margin: 0;
   padding: 0 0 8px;
   background: transparent;
-}
-
-.app-shell.theme-compact .screen-head .status-progress {
-  margin: 0 0 7px !important;
+  /* No rule under the nav. The nav inherits a border-bottom from the base
+     .screen-nav rule, and in UXP it renders as a stray part-width line rather
+     than the full-width hairline a browser draws. The sticky header already
+     separates itself from the form by sitting on its own opaque background,
+     so the border earns nothing here. */
+  border-bottom: 0 !important;
 }
 
 /* v0.6 #6: one consistent form gutter. Drive spacing purely from the panel
@@ -7170,13 +7172,6 @@ body,
   color: #9fe0b5 !important;
 }
 
-/* #7: the header progress bar renders as one clean full-width bar. */
-.app-shell.theme-compact .screen-head .status-progress {
-  width: 100% !important;
-  margin: 0 0 6px !important;
-  border-radius: 999px !important;
-}
-
 /* v0.6 final UXP hardening.
    Keep these rules deliberately simple: Photoshop's UXP renderer is more
    reliable with explicit margins, pixel radii, and fixed textarea heights. */
@@ -7240,59 +7235,6 @@ body,
 
 .app-shell.theme-compact .screen-head .tool-info-button {
   margin: 0 0 0 9px !important;
-}
-
-/* A bordered four-pixel track is more stable in UXP than a border-radius
-   pill. Remove the legacy percentage pseudo-label from the tiny track. */
-.app-shell.theme-compact .screen-head .status-progress {
-  display: block !important;
-  clear: both !important;
-  box-sizing: border-box !important;
-  width: 100% !important;
-  min-width: 100% !important;
-  max-width: 100% !important;
-  height: 6px !important;
-  margin: 0 0 8px !important;
-  padding: 1px !important;
-  overflow: hidden !important;
-  border: 1px solid #696969 !important;
-  border-radius: 3px !important;
-  background: #343434 !important;
-}
-
-/* The sticky header must not change height when a run starts. Hiding the
-   progress bar with display:none made the header grow mid-generation, and
-   Photoshop's UXP renderer does not reflow the panels below a sticky element
-   that resizes - so the bar was painted over the first section. The idle bar
-   therefore keeps its box and is made invisible instead.
-
-   It is painted the header's own colour rather than hidden, because UXP
-   ignores visibility:hidden here: the first attempt at this fix left the track
-   and its legacy 42%-wide fill (line 6749) showing as a stray half-width rule
-   under the nav in Photoshop, while looking correct in a browser. Colour is
-   the one mechanism both renderers agree on. */
-.app-shell.theme-compact .screen-head .status-progress[hidden] {
-  display: block !important;
-  border-color: #535353 !important;
-  background: #535353 !important;
-}
-
-.app-shell.theme-compact .screen-head .status-progress[hidden] > span {
-  width: 0 !important;
-  margin-left: 0 !important;
-  background: #535353 !important;
-  animation: none !important;
-}
-
-.app-shell.theme-compact .screen-head .status-progress > span {
-  display: block !important;
-  height: 2px !important;
-  border-radius: 1px !important;
-}
-
-.app-shell.theme-compact .screen-head .status-progress.is-determinate::after {
-  content: none !important;
-  display: none !important;
 }
 
 /* Textareas have no HTML character limit. Removing the compact max-height and

--- a/src/ui/appBindings.ts
+++ b/src/ui/appBindings.ts
@@ -431,27 +431,24 @@ export function bindToolWarnings(rootElement: HTMLElement) {
 }
 
 export function bindStickyProgress(rootElement: HTMLElement) {
-  // Wrap each screen's back/title nav and its progress bar in one sticky
-  // header so live progress stays visible even after scrolling down the form.
+  // Wrap each screen's back/title nav in one sticky header, so the tool name
+  // and the way back stay visible while scrolling the form.
+  //
+  // The progress bar deliberately does NOT move up here. It used to, and in
+  // Photoshop that produced a header whose height changed the moment a run
+  // started - UXP does not reflow the panels below a sticky element that
+  // resizes, so the bar painted over the first section. Reserving its box and
+  // hiding it by colour both failed in the host for their own reasons. The bar
+  // now simply stays where the markup puts it, in the generation status panel
+  // next to the status text it belongs with, in ordinary flow where no renderer
+  // has to agree about anything.
   const navs = Array.from(rootElement.querySelectorAll<HTMLElement>(".screen-nav"));
 
   for (const nav of navs) {
-    const view = nav.closest("section");
-
-    if (!view) {
-      continue;
-    }
-
     const head = document.createElement("div");
     head.className = "screen-head";
     nav.before(head);
     head.appendChild(nav);
-
-    const progress = view.querySelector<HTMLElement>(".status-progress");
-
-    if (progress) {
-      head.appendChild(progress);
-    }
   }
 }
 


### PR DESCRIPTION
Your call, and the right one: stop trying to make the progress bar survive inside the sticky header and take it out of there. **Net −61 lines.**

## What was actually wrong

Since v0.6, `bindStickyProgress` moved each screen's `.status-progress` up into the generated `.screen-head` so progress stayed visible while scrolling the form. **Every version of this bug came from that move.** The header changed height when a run started, and UXP does not reflow the panels below a sticky element that resizes, so the bar painted over whatever followed it.

Three attempts, each correct in a browser and wrong in Photoshop:

1. Reserve the bar's box → fixed the resize, but hid the idle bar with `visibility: hidden`, which UXP ignores → stray part-width track.
2. Paint it the header's colour → the track genuinely stopped painting (confirmed by console probe in the host), but a line was still visible under the nav.
3. This one: don't put it there at all.

## What it does

The bar stays where the markup already puts it — in the **generation status panel**, directly under the status text it describes, in ordinary flow. The sticky header now holds the nav and nothing else, a constant **55px** on every screen. Nothing in it can change size, so there is no layout change for the two renderers to disagree about.

**What is lost:** progress no longer stays pinned while you scroll down the form. The status text scrolls with it — which is where it always was before v0.6 moved the bar up.

**Also removed: the nav's `border-bottom` inside the sticky header.** That hairline was the last thing drawing under the nav — the one you kept seeing. It was never the progress bar (proven by removing `.status-progress` from the live DOM and watching the line stay), it is the base `.screen-nav` border rendering as a stray part-width line in UXP, and the sticky header already separates itself from the form with its own opaque background. One declaration to restore if you miss the separation.

Also deletes the six `.screen-head .status-progress` rule blocks, which can no longer match anything — dead weight in a file whose dead rules were just measured in task 9.

## Verified

Browser-checked across Text to Image, Inpaint and Upscale:

| | |
|---|---|
| progress bar in any header | **none** |
| header height, idle vs generating | **55px / 55px** |
| panel movement when a run starts | **0** |
| bar's parent element | `generation-status-panel` |
| determinate fill at 60% | correct |

`npm run typecheck`, `npm run lint`, `npm test` (47 files, 383 tests), `npm run build` — all pass.

## Smoke test

1. **Text to Image → prompt → Generate.** The progress bar appears in the status panel, under the `Generating step N of …` text, and fills as the run proceeds.
2. **Nothing under the nav.** Through the whole run, the area between `< Back to Tools | Text to Image` and the Generate panel stays empty — no bar, no line, no partial line.
3. **No movement.** The Generate panel's top edge does not shift when the run starts or finishes.
4. **Clean end.** When the run completes the bar disappears from the status panel, leaving no stub.
5. **Scrolling.** Scroll the form mid-run: the nav still sticks to the top; the progress bar scrolls with the status panel, by design.
6. **Inpaint and Upscale** behave the same.
