### PR TITLE
Release v0.8.0-alpha: the paperwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.8.0-alpha - 2026-07-27
+
+Correctness-and-maintainability release with no new generation capability: it fixes status bleed, the error-details crash, and header overlap, closes preview pinning and missing source-workflow limitations from v0.7, and continues breaking up `App.ts`.
+
+### Added
+
+- Added a tool selector to the separated Preview panel so it can stay pinned to one tool instead of always following the latest publisher. The selection has its own `localStorage` key and survives restarts.
+- Added a workflow-pair checker that compares every editable GUI source workflow with its API-format twin. The previous checks could catch a missing file or a mismatch with the preset registry, but could not detect source/API drift.
+- Exported the four editable GUI source workflows that registered presets named but the repository did not contain, so every advertised source workflow is now available.
+- Added ESLint to CI, including a rule that rejects `TextEncoder` and `TextDecoder` in `src/`. Node provides those globals, so TypeScript and Vitest could accept code that would fail in Photoshop UXP.
+- Added `npm run audit-css` and `docs/css-audit.md` to measure the current stylesheet before consolidation. This release records the duplication but deliberately changes no CSS.
+
+### Changed
+
+- Continued decomposing `App.ts` by extracting tool error messages, status-bar handling, and 614 lines of DOM event wiring into `toolErrorMessages.ts`, `statusBars.ts`, and `appBindings.ts`. `App.ts` has fallen from 8,149 lines originally to 4,917, making these behaviors easier to test and change in isolation.
+- Bumped plugin, package, visible UI, and landing page metadata to `0.8.0` / `v0.8.0-alpha`.
+
+### Fixed
+
+- Fixed `getTechnicalErrorDetails` crashing while trying to explain another failure. Extracting the error-message helpers exposed the bad path and allowed it to be covered directly.
+- Fixed Text to Image progress appearing in Inpaint, Upscale, and the other tool status bars. The old `setStatus` wrote all seven bars at once; global and Text to Image status now have separate update paths.
+- Fixed the home-screen status row rendering on every tool screen and colliding with the sticky header during generation. It now stays on Home because each tool already shows the same message in its own status bar.
+- Fixed the sticky tool header growing by 14 pixels when a run began and painting its progress bar over the first panel section. Its progress-bar box is now reserved while idle and hidden by colour, avoiding the resize that Photoshop UXP does not reflow below a sticky element.
+
+### Known limitations
+
+- The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the list and the downloader instead — an internet connection is required.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+- CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
+- A thin separator below the screen navigation renders at the wrong width in Photoshop UXP. This is cosmetic and deferred.
+
 ## v0.7.0-alpha - 2026-07-25
 
 Release focused on getting previews out of the cramped side panel and getting a new machine to a working ComfyUI without guesswork.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,34 +2,38 @@
 
 ## v0.8.0-alpha - 2026-07-27
 
-Correctness-and-maintainability release with no new generation capability: it fixes status bleed, the error-details crash, and header overlap, closes preview pinning and missing source-workflow limitations from v0.7, and continues breaking up `App.ts`.
+Correctness-and-maintainability release with no new generation capability: it stops one tool's status appearing in another's status bar, fixes the error-details crash and the progress bar painting over the form, closes the preview-pinning and missing-source-workflow limitations from v0.7, and continues breaking up `App.ts`.
 
 ### Added
 
 - Added a tool selector to the separated Preview panel so it can stay pinned to one tool instead of always following the latest publisher. The selection has its own `localStorage` key and survives restarts.
 - Added a workflow-pair checker that compares every editable GUI source workflow with its API-format twin. The previous checks could catch a missing file or a mismatch with the preset registry, but could not detect source/API drift.
-- Exported the four editable GUI source workflows that registered presets named but the repository did not contain, so every advertised source workflow is now available.
+- Exported the four editable GUI source workflows that registered presets named but the repository did not contain: `txt2img-basic`, `img2img-basic`, `sketch2img-linecn-basic`, and `inpaint-basic`. Ten of the eleven presets that claim an editable source now ship one.
 - Added ESLint to CI, including a rule that rejects `TextEncoder` and `TextDecoder` in `src/`. Node provides those globals, so TypeScript and Vitest could accept code that would fail in Photoshop UXP.
 - Added `npm run audit-css` and `docs/css-audit.md` to measure the current stylesheet before consolidation. This release records the duplication but deliberately changes no CSS.
 
 ### Changed
 
-- Continued decomposing `App.ts` by extracting tool error messages, status-bar handling, and 614 lines of DOM event wiring into `toolErrorMessages.ts`, `statusBars.ts`, and `appBindings.ts`. `App.ts` has fallen from 8,149 lines originally to 4,917, making these behaviors easier to test and change in isolation.
+- Continued decomposing `App.ts` by extracting tool error messages, status-bar handling, and the DOM event wiring into `toolErrorMessages.ts` (296 lines), `statusBars.ts` (383), and `appBindings.ts` (631). `App.ts` has fallen from 6,112 lines at v0.7.0 to 4,922, and from a peak of 8,149, making these behaviors easier to test and change in isolation.
+- Wrote down how the two assistants working on this project divide the work, in `docs/ORCHESTRATION.md`: one implements, the other reviews, and each contribution is a separate commit so a pull request shows who did what.
 - Bumped plugin, package, visible UI, and landing page metadata to `0.8.0` / `v0.8.0-alpha`.
 
 ### Fixed
 
 - Fixed `getTechnicalErrorDetails` crashing while trying to explain another failure. Extracting the error-message helpers exposed the bad path and allowed it to be covered directly.
-- Fixed Text to Image progress appearing in Inpaint, Upscale, and the other tool status bars. The old `setStatus` wrote all seven bars at once; global and Text to Image status now have separate update paths.
+- Fixed Text to Image progress appearing in Inpaint, Upscale, and the other tool status bars. The old `setStatus` wrote the global bar and all seven tool and Settings bars on every call; global and Text to Image status now have separate update paths.
 - Fixed the home-screen status row rendering on every tool screen and colliding with the sticky header during generation. It now stays on Home because each tool already shows the same message in its own status bar.
-- Fixed the sticky tool header growing by 14 pixels when a run began and painting its progress bar over the first panel section. Its progress-bar box is now reserved while idle and hidden by colour, avoiding the resize that Photoshop UXP does not reflow below a sticky element.
+- Fixed the progress bar painting over the first section of the form during a run. Since v0.6 the bar had been moved up into the sticky screen header, which made the header change height the moment a run started, and Photoshop UXP does not reflow the panels below a sticky element that resizes. The bar now stays where the markup puts it, in the generation status panel under the status text it describes, and the sticky header holds the navigation and nothing else, at a constant height on every screen. The trade-off is that progress no longer stays pinned while the form is scrolled.
+- Removed the hairline below the screen navigation, which Photoshop UXP drew as a stray part-width line rather than the full-width rule a browser draws. The header's own opaque background already separates it from the form.
 
 ### Known limitations
 
 - The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the list and the downloader instead — an internet connection is required.
 - Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
 - CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
-- A thin separator below the screen navigation renders at the wrong width in Photoshop UXP. This is cosmetic and deferred.
+- `img2img-z-image-turbo` is the one preset whose editable source workflow does not match its API twin — the new checker reports the differing nodes and omits that source from the setup pack's `REQUIREMENTS.md` until it is re-exported. The preset itself still runs, because the API workflow is what OpenLayer submits.
+- The status fix covers the status bars only. The diagnostics line and the error text still mirror across tools: `setDiagnostics` writes all eight diagnostics lines, and `setError` writes both the Text to Image and the Settings error line. Same shape of fix, deferred to a later release.
+- Progress is no longer visible while a tool's form is scrolled past the status panel, which is the accepted cost of taking the bar out of the sticky header.
 
 ## v0.7.0-alpha - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.7.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows, the separated preview panel, and the ComfyUI setup pack, not for production work yet.
+`v0.8.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows and the release's correctness fixes in Photoshop UXP, not for production work yet.
 
-New in `v0.7.0-alpha`:
+New in `v0.8.0-alpha`:
 
-- Added **OpenLayer Preview**, a second dockable Photoshop panel that shows the current generation at whatever size you drag it to. It mirrors every tool — including Live Painting — and keeps the small in-panel previews as they are.
-- Added a generated ComfyUI setup pack (`npm run setup-pack`) with the workflows, an exact per-model requirements list, and a downloader that puts each model in the folder ComfyUI actually reads it from.
-- Added verified download URLs and install folders for all 13 models the runnable presets need, plus licence gating on the two Flux weights.
-- Prompt from Layer no longer needs the `comfyui-custom-scripts` custom-node pack.
+- The separated **OpenLayer Preview** panel can now stay pinned to one tool instead of always following the latest generation. Its selection persists across sessions.
+- Status updates now stay with the correct tool instead of Text to Image progress appearing in Inpaint, Upscale, and the other tool screens.
+- Technical error details no longer crash while explaining a failure, and tool headers no longer overlap the first panel section when generation begins.
+- All four previously missing editable GUI source workflows are included, with a checker that compares every GUI source workflow with its API-format twin.
+- ESLint now runs in CI and rejects browser globals such as `TextEncoder` and `TextDecoder` that Node provides but Photoshop UXP does not.
+- `App.ts` has been reduced from 8,149 lines originally to 4,917 by extracting error messages, status handling, and DOM event wiring. A separate CSS audit measures consolidation work without changing styles in this release.
 
 Included in this alpha:
 
@@ -84,20 +86,16 @@ The earlier card-based dashboard established OpenLayer's honest available/experi
 
 </details>
 
-v0.7.0-alpha tester focus:
+v0.8.0-alpha tester focus:
 
-- Open **Plugins > OpenLayer Preview**, dock or float it, and confirm it follows every tool you generate with, including Live Painting.
-- Run `npm run setup-pack` and check the folder table in the generated `REQUIREMENTS.md` against your own ComfyUI install.
-- Confirm Prompt from Layer still returns a caption now that `comfyui-custom-scripts` is no longer required.
-- Confirm Text to Image, Image to Image, Z_image_Turbo, and experimental Flux1-dev fp8 Text to Image generation.
-- Confirm Prompt from Layer with the local Florence-2 PromptGen workflow.
-- Confirm Upscale with a local pixel/model upscale model such as `4x-UltraSharp.pth`.
-- Confirm Workflow Health, Cancel Generation, session History metadata, and Reuse Settings.
-- Test Flux Fill Inpaint and Flux Fill Outpaint as experimental workflows only.
-- Confirm inpaint-basic and Flux Fill Inpaint retain the v0.5.5 upload filename and alignment fixes, including Import to Layers.
-- Confirm Cancel Generation on both a running prompt and a queued prompt when ComfyUI is busy.
+- Open **Plugins > OpenLayer Preview**, pin it to one tool, generate with another, and confirm the panel stays pinned and restores that choice in a later session.
+- Start Text to Image and confirm progress appears only in its own status bar; return Home and confirm the shared status row does not appear on tool screens.
+- Watch a sticky tool header before and during a run. Its height should remain fixed, and the progress bar must not cover the first panel section.
+- Exercise an error path and open its technical details to confirm the original failure is reported without a second crash.
+- Run the workflow checks and setup-pack build to confirm every registered editable GUI workflow is present and still matches its API-format twin.
+- Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
-Known v0.7.0-alpha boundaries:
+Known v0.8.0-alpha boundaries:
 
 - Image to Image is an early foundation path, not a full production workflow yet.
 - Sketch to Image is limited to the first SD 1.x LINECN starter workflow.
@@ -120,9 +118,11 @@ Known v0.7.0-alpha boundaries:
 - Outpaint is experimental and currently uses `outpaint-flux-fill-basic` with `flux1-fill-dev.safetensors`, `clip_l.safetensors`, `t5xxl_fp16.safetensors` or the accepted T5 fp8 fallback, and `ae.safetensors`.
 - Upscale currently uses a simple pixel/model upscale path. It does not use prompts, latent upscale, tiled diffusion, or creative enhancement.
 - Upscale needs ComfyUI's `UpscaleModelLoader` and `ImageUpscaleWithModel` nodes plus an installed upscale model such as `4x-UltraSharp.pth` or `RealESRGAN_x4plus.pth`.
-- The separated preview panel always follows whichever tool generated most recently. Pinning it to a single tool is designed but not built.
 - The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the requirements list and a downloader instead. An internet connection is required.
-- The v0.7.0 release focuses on the preview panel and ComfyUI setup. Generation and Photoshop integration behavior should remain compatible with v0.6.0.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+- CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
+- A thin separator below the screen navigation renders at the wrong width in Photoshop UXP. This is cosmetic and deferred.
+- The v0.8.0 release focuses on correctness and maintainability. Existing generation capabilities should remain compatible with v0.7.0.
 - Layer, canvas, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
 - Live sampler previews require ComfyUI to be started with `--preview-method auto`, and the preview panel may flicker between steps until a future UI polish pass.
 - Classic v0.4 theme preserves the older visual feel, but it does not duplicate every old layout detail.
@@ -252,7 +252,7 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.7.0-alpha.zip
+packages/openlayer-v0.8.0-alpha.zip
 ```
 
 ## Loading In UXP Developer Tool
@@ -379,7 +379,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.7.0-alpha test result:
+Use this quick pass before reporting a v0.8.0-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ New in `v0.8.0-alpha`:
 
 - The separated **OpenLayer Preview** panel can now stay pinned to one tool instead of always following the latest generation. Its selection persists across sessions.
 - Status updates now stay with the correct tool instead of Text to Image progress appearing in Inpaint, Upscale, and the other tool screens.
-- Technical error details no longer crash while explaining a failure, and tool headers no longer overlap the first panel section when generation begins.
+- Technical error details no longer crash while explaining a failure, and the progress bar no longer paints over the first section of the form. The bar has moved out of the sticky header and back under the status text it describes, so nothing in the header changes size when a run starts.
 - All four previously missing editable GUI source workflows are included, with a checker that compares every GUI source workflow with its API-format twin.
 - ESLint now runs in CI and rejects browser globals such as `TextEncoder` and `TextDecoder` that Node provides but Photoshop UXP does not.
-- `App.ts` has been reduced from 8,149 lines originally to 4,917 by extracting error messages, status handling, and DOM event wiring. A separate CSS audit measures consolidation work without changing styles in this release.
+- `App.ts` has been reduced from 6,112 lines at v0.7.0 to 4,922 — down from a peak of 8,149 — by extracting error messages, status handling, and DOM event wiring. A separate CSS audit measures consolidation work without changing styles in this release.
 
 Included in this alpha:
 
@@ -90,9 +90,9 @@ v0.8.0-alpha tester focus:
 
 - Open **Plugins > OpenLayer Preview**, pin it to one tool, generate with another, and confirm the panel stays pinned and restores that choice in a later session.
 - Start Text to Image and confirm progress appears only in its own status bar; return Home and confirm the shared status row does not appear on tool screens.
-- Watch a sticky tool header before and during a run. Its height should remain fixed, and the progress bar must not cover the first panel section.
+- Watch a sticky tool header before and during a run. There should be no progress bar in the header at all, its height should not change, and the bar should appear under the status text in the generation status panel with nothing painted over it.
 - Exercise an error path and open its technical details to confirm the original failure is reported without a second crash.
-- Run the workflow checks and setup-pack build to confirm every registered editable GUI workflow is present and still matches its API-format twin.
+- Run `npm run setup-pack` and confirm the only source/API mismatch it reports is `img2img-z-image-turbo`.
 - Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
 Known v0.8.0-alpha boundaries:
@@ -121,7 +121,9 @@ Known v0.8.0-alpha boundaries:
 - The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the requirements list and a downloader instead. An internet connection is required.
 - Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
 - CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
-- A thin separator below the screen navigation renders at the wrong width in Photoshop UXP. This is cosmetic and deferred.
+- `img2img-z-image-turbo` is the one preset whose editable source workflow does not match its API twin. The checker reports the differing nodes and omits that source from the setup pack's `REQUIREMENTS.md` until it is re-exported; the preset still runs, because the API workflow is what OpenLayer submits.
+- The status fix covers the status bars only. The diagnostics line and the error text still mirror across tools, and that fix is deferred.
+- Progress is no longer pinned while a tool's form is scrolled, which is the accepted cost of taking the progress bar out of the sticky header.
 - The v0.8.0 release focuses on correctness and maintainability. Existing generation capabilities should remain compatible with v0.7.0.
 - Layer, canvas, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
 - Live sampler previews require ComfyUI to be started with `--preview-method auto`, and the preview panel may flicker between steps until a future UI polish pass.

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
       "operatingSystem": "Windows, macOS",
       "applicationCategory": "DesignApplication",
       "applicationSubCategory": "Adobe Photoshop plugin",
-      "softwareVersion": "0.7.0-alpha",
+      "softwareVersion": "0.8.0-alpha",
       "description": "Open-source Photoshop UXP plugin that connects to a local ComfyUI server for AI image generation: text to image, image to image, sketch to image, inpaint, outpaint, and upscale with Stable Diffusion, SDXL, and Flux models.",
       "url": "https://mehran-ahmadi.com/OpenLayer/",
       "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases",
@@ -64,7 +64,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.7.0 · free &amp; open source</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.8.0 · free &amp; open source</p>
           <h1 id="hero-title">Local AI layers,<br><span class="grad">inside Photoshop.</span></h1>
           <p class="hero-lede">
             OpenLayer connects Photoshop to <strong>your own ComfyUI server</strong>.
@@ -91,15 +91,15 @@
 
       <section class="intro" aria-labelledby="intro-title">
         <div class="section-inner">
-          <p class="eyebrow">v0.7 artist-first interface</p>
+          <p class="eyebrow">v0.8 correctness and control</p>
           <h2 id="intro-title">Local generation that now feels at home inside Photoshop.</h2>
           <p class="intro-lede">
             OpenLayer starts with dependable local workflows — text to image, image to image,
             sketch to image, experimental inpaint and outpaint, pixel upscale, lossless PNG
             source capture, live previews, diagnostics, and clean import into the active document.
-            v0.7 adds a second dockable panel that shows the current generation at any size, and a
-            generated ComfyUI setup pack that tells a new machine exactly which models it needs and which
-            folder each one belongs in — without hiding the experimental edges.
+            v0.8 lets the separated preview stay pinned to one tool, fixes status and sticky-header
+            failures seen during real generations, and fills the missing editable workflow sources —
+            without adding a new generation capability or hiding the experimental edges.
           </p>
         </div>
       </section>
@@ -311,11 +311,11 @@ npm run build</code></pre>
             </article>
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.7.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.8.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
-              <p>v0.7.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
+              <p>v0.8.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
             </article>
             <article class="status-card">
               <h3>Flux Fill is experimental</h3>
@@ -338,10 +338,10 @@ npm run build</code></pre>
               <li>Inpaint and Outpaint should be tested on duplicate layers first.</li>
               <li>Prompt from Layer requires the local Florence-2 PromptGen model and the comfyui-florence2 nodes. The custom-scripts pack is no longer needed.</li>
               <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.7.0 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.8.0 keeps the shared metadata foundation and session-history wiring.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
-              <li>The separated preview panel follows whichever tool generated most recently. Pinning it to one tool is future work.</li>
+              <li>A thin separator below the screen navigation renders at the wrong width in Photoshop UXP. This is cosmetic and deferred.</li>
               <li>The ComfyUI setup pack ships the requirements list and a downloader, not the model weights. An internet connection is required.</li>
             </ul>
           </details>
@@ -372,6 +372,10 @@ npm run build</code></pre>
               <p>A separated dockable preview panel mirroring every tool, a generated ComfyUI setup pack with verified model download locations, and one fewer custom-node dependency.</p>
             </article>
             <article>
+              <h3>v0.8 · Correctness and maintainability</h3>
+              <p>Persistent preview pinning, complete editable workflow sources with source/API drift checks, three user-visible fixes, and a smaller <code>App.ts</code>.</p>
+            </article>
+            <article>
               <h3>Next · Reliability and artist control</h3>
               <p>Finish Inpaint and Outpaint alignment, strengthen workflow validation, and turn the metadata foundation into repeatable layer-level iteration.</p>
             </article>
@@ -397,7 +401,7 @@ npm run build</code></pre>
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.7.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.8.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a>
       </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -341,7 +341,8 @@ npm run build</code></pre>
               <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.8.0 keeps the shared metadata foundation and session-history wiring.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
-              <li>A thin separator below the screen navigation renders at the wrong width in Photoshop UXP. This is cosmetic and deferred.</li>
+              <li>One preset, <code>img2img-z-image-turbo</code>, has an editable source workflow that does not match its API twin. The preset still runs; the source is held back until it is re-exported.</li>
+              <li>Progress is shown in the generation status panel rather than pinned to the screen header, so it scrolls with the form.</li>
               <li>The ComfyUI setup pack ships the requirements list and a downloader, not the model weights. An internet connection is required.</li>
             </ul>
           </details>
@@ -373,7 +374,7 @@ npm run build</code></pre>
             </article>
             <article>
               <h3>v0.8 · Correctness and maintainability</h3>
-              <p>Persistent preview pinning, complete editable workflow sources with source/API drift checks, three user-visible fixes, and a smaller <code>App.ts</code>.</p>
+              <p>Persistent preview pinning, the missing editable workflow sources plus a source/API drift check, four user-visible fixes to status and progress, and a smaller <code>App.ts</code>.</p>
             </article>
             <article>
               <h3>Next · Reliability and artist control</h3>


### PR DESCRIPTION
Task 10, the last item in v0.8. Documentation only — no `src/` changes, and the version was already `0.8.0` in `package.json`, `src/manifest.json` and `src/ui/appConstants.ts` from #31, so nothing is bumped here.

Two commits, per `docs/ORCHESTRATION.md` §5a:

1. **9f3e247** — Codex's draft: CHANGELOG section, README version references, landing page. Covers #31–#43.
2. **c1e90c8** — my review pass against the real merge list (#31–#44) and the code on `main`.

## What the review changed

| Draft claim | Reality |
|---|---|
| Header fix = progress box reserved while idle, hidden by colour | That was #43, **replaced** by #44, which moved the bar out of the sticky header. Rewritten; #44 now covered at all. |
| Known limitation: "thin separator below the nav renders at the wrong width" | **Resolved.** That hairline was the nav's `border-bottom`, deleted in #44. Removed from CHANGELOG, README and the landing page. |
| `App.ts` "8,149 → 4,917", "614 lines of DOM event wiring" | 8,149 is the *peak*, not this release's start. 6,112 at v0.7.0 → **4,922** now (#44 added 5 lines). #41 removed 615 lines and `appBindings.ts` is 631; 614 matches neither. Replaced with the three real file sizes. |
| "`setStatus` wrote all seven bars" | Global bar **plus** seven tool/Settings bars — eight targets. |
| "every advertised source workflow is now available" | True only because the new checker suppresses the bad one. Added the real limitation. |
| — | Added: the status bleed is fixed for the **status bars only**; `setDiagnostics` still writes all eight diagnostics lines and `setError` writes both the T2I and Settings error line. |
| "growing by 14 pixels" | Unverified measurement, dropped. |

Also adds the `docs/ORCHESTRATION.md` doc from #38 to Changed.

Verified locally: `typecheck`, `lint`, `test` (47 files / 383 tests), `build` all green. `npm run setup-pack` runs and reports exactly one source/API mismatch (`img2img-z-image-turbo`), which the notes now name.

## Smoke checklist

Docs-only, so nothing here can break the panel — but the notes make claims about the host, and these are the claims. Load `dist/manifest.json` in UXP Developer Tool after `npm run build`.

1. **Progress bar placement.** Open **Text to Image**, enter a prompt, click **Generate**. While it runs: the screen header (back arrow + title) must contain **no** progress bar, and its height must look identical to before you clicked. The bar must appear inside the generation status panel, directly under the `Status: …` text. Nothing should be painted over the first section of the form.
2. **Header height is constant.** Repeat step 1 on **Inpaint** and **Upscale**. Watch the top of the form as the run starts — no vertical jump.
3. **No hairline under the nav.** Look directly below the back arrow / title row on any tool screen. There should be no part-width line. Confirm the header still reads as separate from the form on its own background; if it does not, say so and I will restore one declaration.
4. **Status stays with its tool.** Start a Text to Image run. While it runs, go to **Inpaint** and **Upscale** — their status bars must still read `Ready`, not Text to Image's step count.
5. **Home status row.** Return **Home** during that run: the shared status row appears there. Go to any tool screen: it must not appear.
6. **Preview pin persists.** Open **Plugins > OpenLayer Preview**. Pin it to **Inpaint**. Generate in **Text to Image** — the panel must keep showing Inpaint's last result (or an empty state naming Inpaint), not the new image. Close Photoshop, reopen, reopen the panel: still pinned to Inpaint.
7. **Error details don't crash twice.** Stop ComfyUI, click **Generate**, expand the technical error details. You should get the original connection failure, not a second error about reporting the error.
8. **Version in the footer.** Panel footer reads `0.8.0`.

Report per step and I'll merge, then package, tag and cut the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
