### PR TITLE
Re-export the img2img-z-image-turbo source workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Re-exported `img2img-z-image-turbo`'s editable source workflow, which held the vendor's Z-Image *text-to-image* demo graph rather than the image-to-image graph OpenLayer submits — no `LoadImage` or `VAEEncode`, an `EmptySD3LatentImage` generating a blank latent, one prompt encoder instead of two, and a bypassed LoRA loader. Nothing failed at runtime, because OpenLayer submits the API workflow and never the source; the cost was that anyone opening the file to learn the workflow got a graph that cannot do image to image. This was the last entry in the equivalence checker's known-mismatch list, so the list is now empty and the setup pack advertises an editable source for all eleven presets that claim one.
+
 ## v0.8.0-alpha - 2026-07-27
 
 Correctness-and-maintainability release with no new generation capability: it stops one tool's status appearing in another's status bar, fixes the error-details crash and the progress bar painting over the form, closes the preview-pinning and missing-source-workflow limitations from v0.7, and continues breaking up `App.ts`.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ v0.8.0-alpha tester focus:
 - Start Text to Image and confirm progress appears only in its own status bar; return Home and confirm the shared status row does not appear on tool screens.
 - Watch a sticky tool header before and during a run. There should be no progress bar in the header at all, its height should not change, and the bar should appear under the status text in the generation status panel with nothing painted over it.
 - Exercise an error path and open its technical details to confirm the original failure is reported without a second crash.
-- Run `npm run setup-pack` and confirm the only source/API mismatch it reports is `img2img-z-image-turbo`.
+- Run `npm run setup-pack` and confirm it reports no source/API mismatches at all.
 - Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
 Known v0.8.0-alpha boundaries:
@@ -121,7 +121,6 @@ Known v0.8.0-alpha boundaries:
 - The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the requirements list and a downloader instead. An internet connection is required.
 - Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
 - CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
-- `img2img-z-image-turbo` is the one preset whose editable source workflow does not match its API twin. The checker reports the differing nodes and omits that source from the setup pack's `REQUIREMENTS.md` until it is re-exported; the preset still runs, because the API workflow is what OpenLayer submits.
 - The status fix covers the status bars only. The diagnostics line and the error text still mirror across tools, and that fix is deferred.
 - Progress is no longer pinned while a tool's form is scrolled, which is the accepted cost of taking the progress bar out of the sticky header.
 - The v0.8.0 release focuses on correctness and maintainability. Existing generation capabilities should remain compatible with v0.7.0.

--- a/docs/index.html
+++ b/docs/index.html
@@ -341,7 +341,6 @@ npm run build</code></pre>
               <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.8.0 keeps the shared metadata foundation and session-history wiring.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
-              <li>One preset, <code>img2img-z-image-turbo</code>, has an editable source workflow that does not match its API twin. The preset still runs; the source is held back until it is re-exported.</li>
               <li>Progress is shown in the generation status panel rather than pinned to the screen header, so it scrolls with the form.</li>
               <li>The ComfyUI setup pack ships the requirements list and a downloader, not the model weights. An internet connection is required.</li>
             </ul>

--- a/src/workflows/source/img2img-z-image-turbo.workflow.json
+++ b/src/workflows/source/img2img-z-image-turbo.workflow.json
@@ -1,51 +1,586 @@
 {
-  "id": "9ae6082b-c7f4-433c-9971-7a8f65a3ea65",
+  "id": "00000000-0000-0000-0000-000000000000",
   "revision": 0,
-  "last_node_id": 55,
-  "last_link_id": 61,
+  "last_node_id": 23,
+  "last_link_id": 24,
   "nodes": [
     {
-      "id": 39,
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        982.798828125,
+        130
+      ],
+      "size": [
+        270,
+        262
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 13
+        },
+        {
+          "localized_name": "positive",
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 14
+        },
+        {
+          "localized_name": "negative",
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 15
+        },
+        {
+          "localized_name": "latent_image",
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 16
+        },
+        {
+          "localized_name": "seed",
+          "name": "seed",
+          "type": "INT",
+          "widget": {
+            "name": "seed"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "steps",
+          "name": "steps",
+          "type": "INT",
+          "widget": {
+            "name": "steps"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "cfg",
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "sampler_name",
+          "name": "sampler_name",
+          "type": "COMBO",
+          "widget": {
+            "name": "sampler_name"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "scheduler",
+          "name": "scheduler",
+          "type": "COMBO",
+          "widget": {
+            "name": "scheduler"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "denoise",
+          "name": "denoise",
+          "type": "FLOAT",
+          "widget": {
+            "name": "denoise"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "LATENT",
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            19
+          ]
+        }
+      ],
+      "title": "Sampler",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        1,
+        "randomize",
+        4,
+        1,
+        "res_multistep",
+        "simple",
+        0.7
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        482.798828125,
+        318
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "clip",
+          "name": "clip",
+          "type": "CLIP",
+          "link": 17
+        },
+        {
+          "localized_name": "text",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "CONDITIONING",
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            14
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        482.798828125,
+        648
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "clip",
+          "name": "clip",
+          "type": "CLIP",
+          "link": 18
+        },
+        {
+          "localized_name": "text",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "CONDITIONING",
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            15
+          ]
+        }
+      ],
+      "title": "Negative Prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1352.798828125,
+        130
+      ],
+      "size": [
+        140,
+        46
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "samples",
+          "name": "samples",
+          "type": "LATENT",
+          "link": 19
+        },
+        {
+          "localized_name": "vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 20
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            21
+          ]
+        }
+      ],
+      "title": "Decode",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "VAEDecode"
+      }
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        1592.798828125,
+        130
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "images",
+          "name": "images",
+          "type": "IMAGE",
+          "link": 21
+        },
+        {
+          "localized_name": "filename_prefix",
+          "name": "filename_prefix",
+          "type": "STRING",
+          "widget": {
+            "name": "filename_prefix"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "images",
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "OpenLayer_ZImage"
+      ]
+    },
+    {
+      "id": 10,
+      "type": "LoadImage",
+      "pos": [
+        100,
+        130
+      ],
+      "size": [
+        282.798828125,
+        102
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "image",
+          "name": "image",
+          "type": "COMBO",
+          "widget": {
+            "name": "image"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "choose file to upload",
+          "name": "upload",
+          "type": "IMAGEUPLOAD",
+          "widget": {
+            "name": "upload"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "IMAGE",
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            22
+          ]
+        },
+        {
+          "localized_name": "MASK",
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "title": "Source Image",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "LoadImage",
+        "#sdppp_variant": "default",
+        "#sdppp_simple_content": "canvas",
+        "#sdppp_simple_mask": "canvas",
+        "#sdppp_simple_boundary": "canvas",
+        "#sdppp_label": ""
+      },
+      "widgets_values": [
+        "",
+        "image"
+      ]
+    },
+    {
+      "id": 11,
+      "type": "VAEEncode",
+      "pos": [
+        482.798828125,
+        978
+      ],
+      "size": [
+        140,
+        46
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "pixels",
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 22
+        },
+        {
+          "localized_name": "vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 23
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "LATENT",
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            16
+          ]
+        }
+      ],
+      "title": "Encode Source",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "VAEEncode"
+      }
+    },
+    {
+      "id": 20,
+      "type": "UNETLoader",
+      "pos": [
+        100,
+        362
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "localized_name": "unet_name",
+          "name": "unet_name",
+          "type": "COMBO",
+          "widget": {
+            "name": "unet_name"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "weight_dtype",
+          "name": "weight_dtype",
+          "type": "COMBO",
+          "widget": {
+            "name": "weight_dtype"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "localized_name": "MODEL",
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            24
+          ]
+        }
+      ],
+      "title": "Load Z_image_Turbo Diffusion Model",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "z_image_turbo_bf16.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 21,
       "type": "CLIPLoader",
       "pos": [
-        130.2638101844517,
-        435.2545050421948
+        100,
+        574
       ],
       "size": [
         270,
         106
       ],
       "flags": {},
-      "order": 0,
+      "order": 2,
       "mode": 0,
-      "inputs": [],
+      "inputs": [
+        {
+          "localized_name": "clip_name",
+          "name": "clip_name",
+          "type": "COMBO",
+          "widget": {
+            "name": "clip_name"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "type",
+          "name": "type",
+          "type": "COMBO",
+          "widget": {
+            "name": "type"
+          },
+          "link": null
+        },
+        {
+          "localized_name": "device",
+          "name": "device",
+          "shape": 7,
+          "type": "COMBO",
+          "widget": {
+            "name": "device"
+          },
+          "link": null
+        }
+      ],
       "outputs": [
         {
+          "localized_name": "CLIP",
           "name": "CLIP",
           "type": "CLIP",
           "links": [
-            44
+            17,
+            18
           ]
         }
       ],
+      "title": "Load Qwen CLIP",
       "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
         "cnr_id": "comfy-core",
-        "ver": "0.3.73",
-        "Node name for S&R": "CLIPLoader",
-        "models": [
-          {
-            "name": "qwen_3_4b.safetensors",
-            "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors",
-            "directory": "text_encoders"
-          }
-        ]
+        "ver": "0.27.1",
+        "Node name for S&R": "CLIPLoader"
       },
       "widgets_values": [
         "qwen_3_4b.safetensors",
@@ -54,679 +589,220 @@
       ]
     },
     {
-      "id": 40,
+      "id": 22,
       "type": "VAELoader",
       "pos": [
-        130.2638101844517,
-        585.2545050421948
+        100,
+        810
       ],
       "size": [
         270,
         58
       ],
       "flags": {},
-      "order": 1,
+      "order": 3,
       "mode": 0,
-      "inputs": [],
+      "inputs": [
+        {
+          "localized_name": "vae_name",
+          "name": "vae_name",
+          "type": "COMBO",
+          "widget": {
+            "name": "vae_name"
+          },
+          "link": null
+        }
+      ],
       "outputs": [
         {
+          "localized_name": "VAE",
           "name": "VAE",
           "type": "VAE",
           "links": [
-            39
+            20,
+            23
           ]
         }
       ],
+      "title": "Load AE VAE",
       "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
         "cnr_id": "comfy-core",
-        "ver": "0.3.73",
-        "Node name for S&R": "VAELoader",
-        "models": [
-          {
-            "name": "ae.safetensors",
-            "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors",
-            "directory": "vae"
-          }
-        ]
+        "ver": "0.27.1",
+        "Node name for S&R": "VAELoader"
       },
       "widgets_values": [
         "ae.safetensors"
       ]
     },
     {
-      "id": 42,
-      "type": "ConditioningZeroOut",
+      "id": 23,
+      "type": "ModelSamplingAuraFlow",
       "pos": [
-        660.2638101844517,
-        725.2545050421948
-      ],
-      "size": [
-        197.712890625,
-        26
-      ],
-      "flags": {},
-      "order": 7,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "conditioning",
-          "type": "CONDITIONING",
-          "link": 36
-        }
-      ],
-      "outputs": [
-        {
-          "name": "CONDITIONING",
-          "type": "CONDITIONING",
-          "links": [
-            42
-          ]
-        }
-      ],
-      "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
-        "cnr_id": "comfy-core",
-        "ver": "0.3.73",
-        "Node name for S&R": "ConditioningZeroOut"
-      },
-      "widgets_values": []
-    },
-    {
-      "id": 46,
-      "type": "UNETLoader",
-      "pos": [
-        130.2638101844517,
-        305.2545050421948
+        482.798828125,
+        130
       ],
       "size": [
         270,
-        82
+        58
       ],
       "flags": {},
-      "order": 2,
+      "order": 4,
       "mode": 0,
-      "inputs": [],
+      "inputs": [
+        {
+          "localized_name": "model",
+          "name": "model",
+          "type": "MODEL",
+          "link": 24
+        },
+        {
+          "localized_name": "shift",
+          "name": "shift",
+          "type": "FLOAT",
+          "widget": {
+            "name": "shift"
+          },
+          "link": null
+        }
+      ],
       "outputs": [
         {
+          "localized_name": "MODEL",
           "name": "MODEL",
           "type": "MODEL",
           "links": [
-            54
+            13
           ]
         }
       ],
+      "title": "Z_image_Turbo Sampling",
       "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
-        "cnr_id": "comfy-core",
-        "ver": "0.3.73",
-        "Node name for S&R": "UNETLoader",
-        "models": [
-          {
-            "name": "z_image_turbo_bf16.safetensors",
-            "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors",
-            "directory": "diffusion_models"
-          }
-        ]
-      },
-      "widgets_values": [
-        "z_image_turbo_bf16.safetensors",
-        "default"
-      ]
-    },
-    {
-      "id": 41,
-      "type": "EmptySD3LatentImage",
-      "pos": [
-        130.2638101844517,
-        735.2545050421948
-      ],
-      "size": [
-        260,
-        110
-      ],
-      "flags": {},
-      "order": 3,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [
-        {
-          "name": "LATENT",
-          "type": "LATENT",
-          "slot_index": 0,
-          "links": [
-            43
-          ]
-        }
-      ],
-      "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
-        "cnr_id": "comfy-core",
-        "ver": "0.3.64",
-        "Node name for S&R": "EmptySD3LatentImage"
-      },
-      "widgets_values": [
-        1024,
-        1024,
-        1
-      ]
-    },
-    {
-      "id": 9,
-      "type": "SaveImage",
-      "pos": [
-        1240,
-        260
-      ],
-      "size": [
-        780,
-        660
-      ],
-      "flags": {},
-      "order": 11,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "images",
-          "type": "IMAGE",
-          "link": 45
-        }
-      ],
-      "outputs": [],
-      "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
-        "cnr_id": "comfy-core",
-        "ver": "0.3.64",
-        "Node name for S&R": "SaveImage"
-      },
-      "widgets_values": [
-        "z-image"
-      ]
-    },
-    {
-      "id": 44,
-      "type": "KSampler",
-      "pos": [
-        900.2638101844517,
-        375.2545050421948
-      ],
-      "size": [
-        315,
-        474
-      ],
-      "flags": {},
-      "order": 9,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "model",
-          "type": "MODEL",
-          "link": 40
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
         },
-        {
-          "name": "positive",
-          "type": "CONDITIONING",
-          "link": 41
-        },
-        {
-          "name": "negative",
-          "type": "CONDITIONING",
-          "link": 42
-        },
-        {
-          "name": "latent_image",
-          "type": "LATENT",
-          "link": 43
-        }
-      ],
-      "outputs": [
-        {
-          "name": "LATENT",
-          "type": "LATENT",
-          "slot_index": 0,
-          "links": [
-            38
-          ]
-        }
-      ],
-      "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
         "cnr_id": "comfy-core",
-        "ver": "0.3.64",
-        "Node name for S&R": "KSampler"
-      },
-      "widgets_values": [
-        481119356637814,
-        "randomize",
-        9,
-        1,
-        "res_multistep",
-        "simple",
-        1
-      ]
-    },
-    {
-      "id": 47,
-      "type": "ModelSamplingAuraFlow",
-      "pos": [
-        900.2638101844517,
-        265.2545050421948
-      ],
-      "size": [
-        310,
-        60
-      ],
-      "flags": {},
-      "order": 8,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "model",
-          "type": "MODEL",
-          "link": 60
-        }
-      ],
-      "outputs": [
-        {
-          "name": "MODEL",
-          "type": "MODEL",
-          "slot_index": 0,
-          "links": [
-            40
-          ]
-        }
-      ],
-      "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
-        "cnr_id": "comfy-core",
-        "ver": "0.3.64",
+        "ver": "0.27.1",
         "Node name for S&R": "ModelSamplingAuraFlow"
       },
       "widgets_values": [
         3
       ]
-    },
-    {
-      "id": 43,
-      "type": "VAEDecode",
-      "pos": [
-        1240,
-        170
-      ],
-      "size": [
-        210,
-        46
-      ],
-      "flags": {},
-      "order": 10,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "samples",
-          "type": "LATENT",
-          "link": 38
-        },
-        {
-          "name": "vae",
-          "type": "VAE",
-          "link": 39
-        }
-      ],
-      "outputs": [
-        {
-          "name": "IMAGE",
-          "type": "IMAGE",
-          "slot_index": 0,
-          "links": [
-            45
-          ]
-        }
-      ],
-      "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
-        "cnr_id": "comfy-core",
-        "ver": "0.3.64",
-        "Node name for S&R": "VAEDecode"
-      },
-      "widgets_values": []
-    },
-    {
-      "id": 45,
-      "type": "CLIPTextEncode",
-      "pos": [
-        450.2638101844517,
-        305.2545050421948
-      ],
-      "size": [
-        410,
-        370
-      ],
-      "flags": {},
-      "order": 5,
-      "mode": 0,
-      "inputs": [
-        {
-          "name": "clip",
-          "type": "CLIP",
-          "link": 44
-        }
-      ],
-      "outputs": [
-        {
-          "name": "CONDITIONING",
-          "type": "CONDITIONING",
-          "links": [
-            36,
-            41
-          ]
-        }
-      ],
-      "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
-        "cnr_id": "comfy-core",
-        "ver": "0.3.73",
-        "Node name for S&R": "CLIPTextEncode"
-      },
-      "widgets_values": [
-        "Latina female with thick wavy hair, harbor boats and pastel houses behind. Breezy seaside light, warm tones, cinematic close-up."
-      ],
-      "color": "#232",
-      "bgcolor": "#353"
-    },
-    {
-      "id": 48,
-      "type": "LoraLoaderModelOnly",
-      "pos": [
-        460,
-        140
-      ],
-      "size": [
-        370,
-        82
-      ],
-      "flags": {},
-      "order": 6,
-      "mode": 4,
-      "inputs": [
-        {
-          "name": "model",
-          "type": "MODEL",
-          "link": 54
-        }
-      ],
-      "outputs": [
-        {
-          "name": "MODEL",
-          "type": "MODEL",
-          "links": [
-            60
-          ]
-        }
-      ],
-      "properties": {
-        "enableTabs": false,
-        "tabWidth": 65,
-        "tabXOffset": 10,
-        "hasSecondTab": false,
-        "secondTabText": "Send Back",
-        "secondTabOffset": 80,
-        "secondTabWidth": 65,
-        "cnr_id": "comfy-core",
-        "ver": "0.3.75",
-        "Node name for S&R": "LoraLoaderModelOnly",
-        "models": [
-          {
-            "name": "qinglong_detailedeye_z-imageV2(comfy).safetensors",
-            "url": "https://huggingface.co/bdsqlsz/qinglong_DetailedEyes_Z-Image/resolve/main/qinglong_detailedeye_z-imageV2(comfy).safetensors",
-            "directory": "loras"
-          }
-        ]
-      },
-      "widgets_values": [
-        "qinglong_detailedeye_z-imageV2(comfy).safetensors",
-        1
-      ]
-    },
-    {
-      "id": 35,
-      "type": "MarkdownNote",
-      "pos": [
-        -390,
-        270
-      ],
-      "size": [
-        490,
-        400
-      ],
-      "flags": {
-        "collapsed": false
-      },
-      "order": 4,
-      "mode": 0,
-      "inputs": [],
-      "outputs": [],
-      "title": "Model link",
-      "properties": {},
-      "widgets_values": [
-        "## Report workflow issue\n\nIf you found any issues when running this workflow, [report template issue here](https://github.com/Comfy-Org/workflow_templates/issues)\n\n\n## Model links\n\n**text_encoders**\n\n- [qwen_3_4b.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors)\n\n**loras**\n\n- [qinglong_detailedeye_z-imageV2(comfy).safetensors](https://huggingface.co/bdsqlsz/qinglong_DetailedEyes_Z-Image/resolve/main/qinglong_detailedeye_z-imageV2(comfy).safetensors)\n\n**diffusion_models**\n\n- [z_image_turbo_bf16.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors)\n\n**vae**\n\n- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors)\n\n\nModel Storage Location\n\n```\n📂 ComfyUI/\n├── 📂 models/\n│   ├── 📂 text_encoders/\n│   │      └── qwen_3_4b.safetensors\n│   ├── 📂 loras/\n│   │      └── qinglong_detailedeye_z-imageV2(comfy).safetensors\n│   ├── 📂 diffusion_models/\n│   │      └── z_image_turbo_bf16.safetensors\n│   └── 📂 vae/\n│          └── ae.safetensors\n```\n"
-      ],
-      "color": "#432",
-      "bgcolor": "#653"
     }
   ],
   "links": [
     [
-      36,
-      45,
+      13,
+      23,
       0,
-      42,
-      0,
-      "CONDITIONING"
-    ],
-    [
-      38,
-      44,
-      0,
-      43,
-      0,
-      "LATENT"
-    ],
-    [
-      39,
-      40,
-      0,
-      43,
-      1,
-      "VAE"
-    ],
-    [
-      40,
-      47,
-      0,
-      44,
+      3,
       0,
       "MODEL"
     ],
     [
-      41,
-      45,
+      14,
+      6,
       0,
-      44,
+      3,
       1,
       "CONDITIONING"
     ],
     [
-      42,
-      42,
+      15,
+      7,
       0,
-      44,
+      3,
       2,
       "CONDITIONING"
     ],
     [
-      43,
-      41,
+      16,
+      11,
       0,
-      44,
+      3,
       3,
       "LATENT"
     ],
     [
-      44,
-      39,
+      17,
+      21,
       0,
-      45,
+      6,
       0,
       "CLIP"
     ],
     [
-      45,
-      43,
+      18,
+      21,
+      0,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      19,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      20,
+      22,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      21,
+      8,
       0,
       9,
       0,
       "IMAGE"
     ],
     [
-      54,
-      46,
+      22,
+      10,
       0,
-      48,
+      11,
       0,
-      "MODEL"
+      "IMAGE"
     ],
     [
-      60,
-      48,
+      23,
+      22,
       0,
-      47,
+      11,
+      1,
+      "VAE"
+    ],
+    [
+      24,
+      20,
+      0,
+      23,
       0,
       "MODEL"
     ]
   ],
-  "groups": [
-    {
-      "id": 2,
-      "title": "Step2 - Image size",
-      "bounding": [
-        120,
-        670,
-        290,
-        200
-      ],
-      "color": "#3f789e",
-      "font_size": 24,
-      "flags": {}
-    },
-    {
-      "id": 3,
-      "title": "Step3 - Prompt",
-      "bounding": [
-        430,
-        240,
-        450,
-        540
-      ],
-      "color": "#3f789e",
-      "font_size": 24,
-      "flags": {}
-    },
-    {
-      "id": 4,
-      "title": "Step1 - Load models",
-      "bounding": [
-        120,
-        240,
-        290,
-        413.6
-      ],
-      "color": "#3f789e",
-      "font_size": 24,
-      "flags": {}
-    },
-    {
-      "id": 5,
-      "title": "Ctrl-B to enable LoRA input",
-      "bounding": [
-        430,
-        70,
-        440,
-        160
-      ],
-      "color": "#3f789e",
-      "font_size": 24,
-      "flags": {}
-    }
-  ],
+  "groups": [],
   "config": {},
   "extra": {
+    "ue_links": [],
     "ds": {
-      "scale": 0.4599010788543567,
+      "scale": 0.9,
       "offset": [
-        1666.2764967812222,
-        589.9486780052241
+        416,
+        110
       ]
-    },
-    "frontendVersion": "1.32.9",
-    "VHS_latentpreview": false,
-    "VHS_latentpreviewrate": 0,
-    "VHS_MetadataImage": true,
-    "VHS_KeepIntermediate": true,
-    "workflowRendererVersion": "LG"
+    }
   },
   "version": 0.4
 }

--- a/tests/comfy/workflowSourceEquivalence.test.ts
+++ b/tests/comfy/workflowSourceEquivalence.test.ts
@@ -17,12 +17,7 @@ const SRC_ROOT = resolve(__dirname, "../../src");
  * still mismatch, so fixing one fails here and forces the entry to be deleted
  * rather than left behind as a stale excuse.
  */
-const KNOWN_MISMATCHES: Record<string, string> = {
-  "img2img-z-image-turbo":
-    "The shipped source is the vendor's Z-Image *text-to-image* demo (EmptySD3LatentImage, " +
-    "ConditioningZeroOut, a bypassed LoRA loader) rather than the image-to-image graph OpenLayer " +
-    "submits (LoadImage + VAEEncode, two CLIPTextEncode). Needs a real export; tracked as v0.8 Task 5."
-};
+const KNOWN_MISMATCHES: Record<string, string> = {};
 
 function loadPair(presetId: string, workflowFile: string, sourceWorkflowFile: string) {
   return {


### PR DESCRIPTION
Clears the one known limitation v0.8.0 shipped with. **No `src/` code changes** — a workflow JSON, an emptied test registry, and docs.

## The file existed; its contents were wrong

That's why this looked like a non-problem. The checker never said "missing file":

| | shipped source | API twin it claims to match |
|---|---|---|
| `LoadImage` | **absent** | 1 |
| `VAEEncode` | **absent** | 1 |
| `EmptySD3LatentImage` | 1 | absent |
| `ConditioningZeroOut` | 1 | absent |
| `CLIPTextEncode` | 1 | 2 |
| `LoraLoaderModelOnly` | 1 (bypassed) | absent |

`LoadImage` + `VAEEncode` are what make a workflow img2img; `EmptySD3LatentImage` generates a blank latent, which is txt2img. It was the vendor's Z-Image **text-to-image** demo saved under the img2img name.

Nothing failed at runtime and nothing would have — OpenLayer submits the API workflow and never reads the source. The cost fell on anyone opening the file to learn the workflow, which is the exact failure #36 was written to avoid.

## How it was re-exported

Rebuilt from the API workflow inside the running ComfyUI (`app.loadApiJson` → `graph.serialize`) and written straight to disk — no manual editor work. Node ids and widget placeholders differ from the API file as they always will; the checker compares classes, counts and wiring.

## The test guard did its job

`KNOWN_MISMATCHES` asserts its entries *still* mismatch, so fixing this failed the suite with "remove it from KNOWN_MISMATCHES." Its recorded reason independently named the same five node differences I'd found. Entry deleted; the registry is now empty.

## Docs

The **v0.8.0-alpha CHANGELOG section is deliberately untouched** — that release did ship with the defect and its notes said so honestly. The limitation is dropped from the README boundaries and the landing page, which describe current state, and the fix is recorded under `Unreleased`.

I did **not** re-upload the setup-pack asset on the v0.8.0 release. That zip genuinely has the defect and its notes name it; rewriting a published asset would make the notes wrong.

## Verification

`typecheck`, `lint`, **383 tests**, `build` all green. `npm run setup-pack` now reports **no source/API mismatches at all** (previously one), and `REQUIREMENTS.md` advertises an editable source for all eleven presets that claim one — 12 source workflows in the pack, up from 11.

## Smoke check

Light — nothing here reaches the panel or the adapter. If you want to confirm the payoff rather than the plumbing:

1. Unzip the new `packages/openlayer-comfyui-setup-0.8.0.zip`, open `workflows/source/img2img-z-image-turbo.workflow.json` in ComfyUI, and confirm it loads a graph with a **Source Image** (`LoadImage`) node feeding **Encode Source** (`VAEEncode`) into the sampler, with both a positive and negative prompt.
2. Optionally run Image to Image on the `img2img-z-image-turbo` preset in the panel to confirm generation still works — it submits the API workflow, which this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
