### PR TITLE
Let the separated Preview panel import to layers

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -7410,3 +7410,79 @@ body,
   font-size: 11px;
   text-align: center;
 }
+
+/* Import row. Styled from scratch like the rest of this block — the panel
+   renders outside .app-shell and inherits none of the compact theme's button
+   styling — and deliberately NOT with the dashboard's .button classes, which
+   would drag in theme-compact overrides that only resolve inside the shell.
+
+   flex: 0 0 auto keeps the row a fixed height under the stage, so the row
+   appearing when a result lands cannot resize anything above it. That is the
+   same failure the progress bar caused in the sticky header: UXP does not
+   reflow siblings below an element that changes size. */
+.openlayer-preview-panel-actions {
+  display: flex;
+  min-height: 24px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+
+.openlayer-preview-panel-import,
+.openlayer-preview-panel-auto-import {
+  flex: 0 0 auto;
+  padding: 4px 10px;
+  border: 1px solid #4a4a4a;
+  border-radius: 3px;
+  background: #383838;
+  color: #d7dde6;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+}
+
+.openlayer-preview-panel-import {
+  border-color: #3b6ea5;
+  background: #2f5c8a;
+  color: #f2f6fb;
+}
+
+.openlayer-preview-panel-import:hover {
+  border-color: #4a82bd;
+  background: #37699b;
+}
+
+.openlayer-preview-panel-auto-import:hover {
+  border-color: #5f5f5f;
+  background: #424242;
+}
+
+.openlayer-preview-panel-auto-import.is-active {
+  border-color: #3b6ea5;
+  background: #2f5c8a;
+  color: #f2f6fb;
+}
+
+/* Explicit disabled styling, and explicitly not via opacity alone: a disabled
+   Import button has to read as unavailable at a glance, because the reason it is
+   disabled (a run is active) is exactly when someone will jab at it. */
+.openlayer-preview-panel-import:disabled,
+.openlayer-preview-panel-import:disabled:hover {
+  border-color: #3f3f3f;
+  background: #333333;
+  color: #6f6f6f;
+  cursor: default;
+}
+
+.openlayer-preview-panel-import-status {
+  overflow: hidden;
+  flex: 1 1 auto;
+  color: #9a9a9a;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.openlayer-preview-panel-import-status.is-error {
+  color: #e06c6c;
+}

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -18,7 +18,8 @@ import {
   isGenerationCancelledError
 } from "../comfy/generationCancel";
 import { createObjectUrlRegistry, ObjectUrlRegistry } from "./objectUrlRegistry";
-import { previewHub, PreviewPublicationKind } from "./previewHub";
+import { previewHub, PreviewPublicationKind, PreviewToolId } from "./previewHub";
+import { importBridge } from "./importBridge";
 import {
   createGenerationController,
   GenerationPipelineUi,
@@ -344,6 +345,165 @@ export function renderApp(rootElement: HTMLElement) {
       upscaleSource
     });
     updateInpaintReferenceControlLock(elements, isBusy && busyTool === "inpaint");
+    syncImportBridge();
+  }
+
+  /**
+   * Points the separated Preview panel's Import button at the handler the
+   * dashboard button already uses.
+   *
+   * Every entry reuses an existing handler untouched. That is the whole point:
+   * A1's frozen document identity, A2's mask ordering assertion, A3's
+   * transactional cleanup and B1's readiness contract all live inside those
+   * handlers, and none of them is reachable from the blob the panel is showing.
+   *
+   * The outcome reported back to the panel is *read out of the tool's own status
+   * bar* after the handler settles, rather than inferred from whether the call
+   * threw. The handlers deliberately swallow their failures — each catches, sets
+   * an error status and returns — so a wrapper watching for exceptions would
+   * report every failed import as a success. Reading the status the handler just
+   * wrote means the panel cannot say anything the dashboard is not also saying.
+   */
+  function registerImportBridgeHandlers() {
+    type ImportRegistration = {
+      toolId: PreviewToolId;
+      run: () => void | Promise<void>;
+      statusText: HTMLElement;
+      /** Absent for Live Painting, which has a status line but no pill. */
+      statusPill?: HTMLElement;
+      toggleAutoImport?: () => void;
+    };
+
+    const registrations: ImportRegistration[] = [
+      {
+        toolId: "text-to-image",
+        run: () => handleImport("manual"),
+        statusText: elements.statusText,
+        statusPill: elements.statusPill,
+        toggleAutoImport: handleToggleAutoImport
+      },
+      {
+        toolId: "image-to-image",
+        run: handleImportImg2Img,
+        statusText: elements.imgStatusText,
+        statusPill: elements.imgStatusPill,
+        toggleAutoImport: handleToggleImg2ImgAutoImport
+      },
+      {
+        toolId: "sketch-to-image",
+        run: handleImportSketch,
+        statusText: elements.sketchStatusText,
+        statusPill: elements.sketchStatusPill
+      },
+      {
+        toolId: "inpaint",
+        run: () => handleImportInpaint(),
+        statusText: elements.inpaintStatusText,
+        statusPill: elements.inpaintStatusPill
+      },
+      {
+        toolId: "outpaint",
+        run: () => handleImportOutpaint(),
+        statusText: elements.outpaintStatusText,
+        statusPill: elements.outpaintStatusPill
+      },
+      {
+        toolId: "upscale",
+        run: handleImportUpscale,
+        statusText: elements.upscaleStatusText,
+        statusPill: elements.upscaleStatusPill
+      },
+      {
+        toolId: "live-painting",
+        run: handleImportLiveResult,
+        statusText: elements.liveStatusText,
+        toggleAutoImport: handleToggleLiveAutoImport
+      }
+    ];
+
+    for (const registration of registrations) {
+      importBridge.register(registration.toolId, {
+        requestImport: () => {
+          importBridge.reportOutcome({
+            toolId: registration.toolId,
+            status: "importing",
+            message: "Importing into Photoshop..."
+          });
+
+          void Promise.resolve()
+            .then(() => registration.run())
+            .then(() => {
+              const message = registration.statusText.textContent?.trim() || "Import finished.";
+              const failed = registration.statusPill
+                ? registration.statusPill.classList.contains("error")
+                : /fail|error/i.test(message);
+
+              importBridge.reportOutcome({
+                toolId: registration.toolId,
+                status: failed ? "failed" : "imported",
+                message
+              });
+            })
+            .catch((caughtError) => {
+              // A handler is not expected to throw, but if one ever does the
+              // panel must not be left saying "Importing..." forever.
+              importBridge.reportOutcome({
+                toolId: registration.toolId,
+                status: "failed",
+                message: getErrorMessage(caughtError)
+              });
+            });
+        },
+        toggleAutoImport: registration.toggleAutoImport
+      });
+    }
+  }
+
+  /**
+   * Tells the separated Preview panel what its Import button may do right now.
+   *
+   * Called from `syncBusy` on purpose: that is the one place the dashboard's own
+   * import buttons are enabled and disabled, so the panel gets the same answer
+   * from the same inputs instead of a second derivation that could disagree.
+   * `isBusy` is the A4 single-run lockout, and the per-tool result is the same
+   * gate `BUSY_GATED_ACTIONS` uses. The bridge drops unchanged snapshots, so
+   * calling this on every state change does not churn the panel during a live
+   * sequence.
+   */
+  function syncImportBridge() {
+    const canImport = (hasResult: unknown) => !isBusy && Boolean(hasResult);
+
+    importBridge.publishCapability("text-to-image", {
+      canImport: canImport(result),
+      auto: { isEnabled: importAutomatically }
+    });
+    importBridge.publishCapability("image-to-image", {
+      canImport: canImport(imageResult),
+      auto: { isEnabled: imageImportAutomatically }
+    });
+    importBridge.publishCapability("sketch-to-image", {
+      canImport: canImport(sketchResult),
+      auto: null
+    });
+    importBridge.publishCapability("inpaint", {
+      canImport: canImport(inpaintResult),
+      auto: null
+    });
+    importBridge.publishCapability("outpaint", {
+      canImport: canImport(outpaintResult),
+      auto: null
+    });
+    importBridge.publishCapability("upscale", {
+      canImport: canImport(upscaleResult),
+      auto: null
+    });
+    // Live Painting's import button is gated on liveLastResult by hand rather
+    // than through the busy tables, so its capability is derived the same way
+    // here instead of being read off the button.
+    importBridge.publishCapability("live-painting", {
+      canImport: canImport(liveLastResult),
+      auto: { isEnabled: liveImportAutomatically }
+    });
   }
 
   rootElement.innerHTML = createAppMarkup();
@@ -638,6 +798,7 @@ export function renderApp(rootElement: HTMLElement) {
   bindActionControl(elements.importLiveRefinedButton, actionHandlers.importLiveRefined);
   bindActionControl(elements.liveAutoImportToggle, actionHandlers.toggleLiveAutoImport);
   bindActionControl(elements.liveAutoRefineToggle, actionHandlers.toggleLiveAutoRefine);
+  registerImportBridgeHandlers();
   bindDelegatedActions(rootElement, actionHandlers);
   bindDocumentActions(rootElement, actionHandlers);
   bindHomeSectionToggles(rootElement);
@@ -970,18 +1131,21 @@ export function renderApp(rootElement: HTMLElement) {
     importAutomatically = !importAutomatically;
     updateAutoImportToggle(elements, importAutomatically);
     setDiagnostics(elements, importAutomatically ? "Auto import is on." : "Auto import is off.");
+    syncImportBridge();
   }
 
   function handleToggleImg2ImgAutoImport() {
     imageImportAutomatically = !imageImportAutomatically;
     updateImg2ImgAutoImportToggle(elements, imageImportAutomatically);
     setImageDiagnostics(elements, imageImportAutomatically ? "Image to Image auto import is on." : "Image to Image auto import is off.");
+    syncImportBridge();
   }
 
   function handleToggleUpscaleAutoImport() {
     upscaleImportAutomatically = !upscaleImportAutomatically;
     updateUpscaleAutoImportToggle(elements, upscaleImportAutomatically);
     setUpscaleDiagnostics(elements, upscaleImportAutomatically ? "Upscale auto import is on." : "Upscale auto import is off.");
+    syncImportBridge();
   }
 
   function handleToggleExperimentalCheckpoints() {
@@ -3366,6 +3530,7 @@ export function renderApp(rootElement: HTMLElement) {
         ? "The latest live result will import automatically when the session stops."
         : "Live auto import is off."
     );
+    syncImportBridge();
   }
 
   function updateLiveAutoImportToggle(isEnabled: boolean) {
@@ -3454,6 +3619,9 @@ export function renderApp(rootElement: HTMLElement) {
 
     liveLastResult = bindDocumentContext({ blob }, originatingDocument);
     setActionDisabled(elements.importLiveButton, false);
+    // Live Painting gates its import button by hand rather than through the busy
+    // tables, so the preview panel is told here too.
+    syncImportBridge();
   }
 
   function setResult(nextResult: AppGeneratedImageResult | null) {

--- a/src/ui/importBridge.ts
+++ b/src/ui/importBridge.ts
@@ -1,0 +1,227 @@
+import { PreviewPublication, PreviewToolId } from "./previewHub";
+
+/**
+ * The seam that lets the separated Preview panel trigger an import without
+ * containing one.
+ *
+ * `previewHub` carries pixels one way: a tool publishes a blob, a surface shows
+ * it. This carries *intent* the other way, and deliberately carries nothing
+ * else. The panel says "import what I am looking at"; `renderApp` decides what
+ * that means and does it with the handler it already had.
+ *
+ * ## Why the panel must not import for itself
+ *
+ * The obvious shortcut — the panel has the blob, so let it place the blob — is
+ * wrong in a way that no test outside Photoshop would catch. A publication
+ * carries a `Blob` and a `toolId` and nothing more; it has no
+ * `bindDocumentContext` binding, so importing from it would place pixels into
+ * whatever document happens to be active, which is precisely the failure
+ * invariant A1 exists to prevent. The seven import handlers live inside
+ * `renderApp` for good reason: each one owns the document identity frozen at
+ * submission time, the mask ordering assertion (A2), the transactional cleanup
+ * (A3), and for Inpaint the readiness contract evaluated against the source
+ * snapshotted at submit time (B1). None of that is reachable from a blob, and
+ * re-deriving any of it here would be a second implementation of the hardest,
+ * least testable code in the project.
+ *
+ * So the bridge moves a tool id and a click. Everything that could be wrong
+ * stays where it is already right.
+ *
+ * ## Why capability is pushed, not computed
+ *
+ * The panel could try to work out whether import is currently possible. It must
+ * not. `setBusy` already computes exactly that for every dashboard button —
+ * `isBusy || !gates[gate]` over `BUSY_GATED_ACTIONS` — and a second derivation
+ * would be free to disagree. A panel that offers Import while a run is active
+ * would break the A4 single-run lockout from a surface that never had to
+ * respect it. So `renderApp` pushes a snapshot from the same place it disables
+ * its own buttons, and the panel renders what it is told.
+ */
+
+/**
+ * What each publishing tool offers, in `PREVIEW_TOOLS` order.
+ *
+ * `hasAutoImport` is not a preference — it records which tools actually have an
+ * auto-import flag in `renderApp` today. Text to Image, Image to Image, Upscale
+ * and Live Painting do; Sketch, Inpaint and Outpaint have none, in the dashboard
+ * either. The panel mirrors the dashboard rather than inventing a control the
+ * rest of the app cannot honour, and this table is what stops the two drifting:
+ * adding the flag to a tool means changing it here, in one place, on purpose.
+ */
+export const IMPORT_TARGETS: Record<PreviewToolId, { label: string; hasAutoImport: boolean }> = {
+  "text-to-image": { label: "Import Result as New Layer", hasAutoImport: true },
+  "image-to-image": { label: "Import to Layers", hasAutoImport: true },
+  "sketch-to-image": { label: "Import to Layers", hasAutoImport: false },
+  inpaint: { label: "Import to Layers", hasAutoImport: false },
+  outpaint: { label: "Import to Layers", hasAutoImport: false },
+  upscale: { label: "Import to Layers", hasAutoImport: false },
+  "live-painting": { label: "Import to Layers", hasAutoImport: true }
+};
+
+export type ImportCapability = {
+  /**
+   * Whether the import button should be clickable right now. Mirrors the
+   * dashboard button's own disabled state: a result exists, and no run is
+   * active.
+   */
+  canImport: boolean;
+  /**
+   * Auto-import state, or null when the tool has no such control. Null and
+   * `{ isEnabled: false }` mean different things — "no toggle exists" versus
+   * "the toggle is off" — and the panel renders them differently.
+   */
+  auto: { isEnabled: boolean } | null;
+};
+
+export type ImportOutcome = {
+  toolId: PreviewToolId;
+  status: "importing" | "imported" | "failed";
+  message: string;
+};
+
+export type ImportBridgeListener = () => void;
+
+export type ImportHandlers = {
+  /** Runs the tool's existing import handler. */
+  requestImport: () => void;
+  /** Flips the tool's auto-import flag. Absent when the tool has no flag. */
+  toggleAutoImport?: () => void;
+};
+
+export type ImportBridge = {
+  /**
+   * `renderApp` registers a tool's handlers and gets an unregister function. A
+   * remount re-registers over the top, so a stale closure from a previous mount
+   * cannot keep serving clicks.
+   */
+  register: (toolId: PreviewToolId, handlers: ImportHandlers) => () => void;
+  /** Pushes the current enabled/auto state for one tool. */
+  publishCapability: (toolId: PreviewToolId, capability: ImportCapability) => void;
+  capabilityFor: (toolId: PreviewToolId) => ImportCapability | null;
+  /**
+   * Asks the registered handler to import. A no-op when the tool never
+   * registered or when its capability says it cannot import — the button should
+   * already be disabled, and this is the second line of defence rather than the
+   * first.
+   */
+  requestImport: (toolId: PreviewToolId) => void;
+  toggleAutoImport: (toolId: PreviewToolId) => void;
+  /** `renderApp` reports what happened so the clicking surface can say so. */
+  reportOutcome: (outcome: ImportOutcome) => void;
+  outcomeFor: (toolId: PreviewToolId) => ImportOutcome | null;
+  subscribe: (listener: ImportBridgeListener) => () => void;
+};
+
+/**
+ * Whether the panel should show an enabled import button for what it is
+ * currently displaying.
+ *
+ * A `live` publication is a mid-generation sampler frame. There is no committed
+ * result behind it — the handler would have nothing to place — and a run is by
+ * definition still active, so this is also the A4 lockout expressed at the one
+ * surface that can see the frame. Pure, and tested, because "is this button
+ * live-safe" is exactly the kind of judgement that rots silently in a renderer.
+ */
+export function resolveImportAffordance(
+  capability: ImportCapability | null,
+  publication: PreviewPublication | null
+): { visible: boolean; enabled: boolean; reason: string } {
+  if (!publication || !capability) {
+    return { visible: false, enabled: false, reason: "" };
+  }
+
+  if (publication.kind === "live") {
+    return { visible: true, enabled: false, reason: "Import when the generation finishes." };
+  }
+
+  if (!capability.canImport) {
+    return { visible: true, enabled: false, reason: "Import is unavailable while a generation is running." };
+  }
+
+  return { visible: true, enabled: true, reason: "" };
+}
+
+export function createImportBridge(): ImportBridge {
+  const handlers = new Map<PreviewToolId, ImportHandlers>();
+  const capabilities = new Map<PreviewToolId, ImportCapability>();
+  const outcomes = new Map<PreviewToolId, ImportOutcome>();
+  const listeners = new Set<ImportBridgeListener>();
+
+  // A surface that throws while re-rendering must not propagate back into the
+  // import handler that reported success, or a cosmetic bug becomes a failed
+  // import. Same reasoning as previewHub's deliver().
+  const notify = () => {
+    for (const listener of [...listeners]) {
+      try {
+        listener();
+      } catch (error) {
+        console.error("[OpenLayer] An import bridge listener threw.", error);
+      }
+    }
+  };
+
+  return {
+    register(toolId, toolHandlers) {
+      handlers.set(toolId, toolHandlers);
+      notify();
+
+      return () => {
+        // Only unregister if this registration is still the current one, so a
+        // remount's cleanup cannot tear down the mount that replaced it.
+        if (handlers.get(toolId) === toolHandlers) {
+          handlers.delete(toolId);
+          notify();
+        }
+      };
+    },
+    publishCapability(toolId, capability) {
+      const previous = capabilities.get(toolId);
+
+      if (
+        previous &&
+        previous.canImport === capability.canImport &&
+        previous.auto?.isEnabled === capability.auto?.isEnabled &&
+        (previous.auto === null) === (capability.auto === null)
+      ) {
+        // syncBusy runs on every state change; re-rendering the panel for an
+        // unchanged capability would rebuild its buttons during live frames.
+        return;
+      }
+
+      capabilities.set(toolId, capability);
+      notify();
+    },
+    capabilityFor: (toolId) => capabilities.get(toolId) ?? null,
+    requestImport(toolId) {
+      const capability = capabilities.get(toolId);
+
+      if (!capability?.canImport) {
+        return;
+      }
+
+      handlers.get(toolId)?.requestImport();
+    },
+    toggleAutoImport(toolId) {
+      handlers.get(toolId)?.toggleAutoImport?.();
+    },
+    reportOutcome(outcome) {
+      outcomes.set(outcome.toolId, outcome);
+      notify();
+    },
+    outcomeFor: (toolId) => outcomes.get(toolId) ?? null,
+    subscribe(listener) {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    }
+  };
+}
+
+/**
+ * The instance the panels share, for the same reason `previewHub` is a module
+ * singleton: both entrypoints are mounted from one module graph in one
+ * JavaScript context, so there is no realm to bridge.
+ */
+export const importBridge = createImportBridge();

--- a/src/ui/previewPanel.ts
+++ b/src/ui/previewPanel.ts
@@ -10,6 +10,12 @@ import {
   PreviewToolId
 } from "./previewHub";
 import { loadPreviewPanelPin, savePreviewPanelPin } from "../utils/preferences";
+import {
+  importBridge as sharedImportBridge,
+  ImportBridge,
+  IMPORT_TARGETS,
+  resolveImportAffordance
+} from "./importBridge";
 
 /**
  * The separated `openlayerPreview` panel: a large, resizable surface showing the
@@ -17,8 +23,22 @@ import { loadPreviewPanelPin, savePreviewPanelPin } from "../utils/preferences";
  *
  * It mirrors the dashboard's in-panel preview rather than replacing it. Moving
  * the preview out of the dashboard would mean an artist who never opens this
- * panel — or who closes it — loses previews entirely, and the Import buttons sit
- * next to the small preview because that is where the decision gets made.
+ * panel — or who closes it — loses previews entirely, so both surfaces keep
+ * their previews and both can import.
+ *
+ * The Import buttons are here as well as beside the small preview. This reverses
+ * what this comment used to say — that they belonged only next to the small
+ * preview "because that is where the decision gets made". Mehran's reasoning is
+ * better: the big preview is where you actually judge a result, so making you go
+ * back to a thumbnail to act on it is backwards. The buttons do not reimplement
+ * anything; they call the dashboard's own handlers through `importBridge`, which
+ * is what keeps A1's document binding and the rest of the import contract
+ * intact. See that module for why the panel must not import for itself.
+ *
+ * The button acts on the tool whose image is **on screen**, not the pinned tool.
+ * With a pin set they are the same; under "Follow active tool" it is the latest
+ * publisher. Either way the button acts on what you are looking at, which is the
+ * only rule that never surprises anyone.
  *
  * The registry and URL slot are module-level on purpose. UXP can call a panel's
  * create() again after a destroy(), and a per-mount registry would strand one
@@ -30,6 +50,7 @@ const urls = createObjectUrlRegistry();
 const ownedUrl = createOwnedObjectUrl(urls);
 
 let unsubscribe: (() => void) | null = null;
+let unsubscribeImports: (() => void) | null = null;
 let teardownRegistered = false;
 
 const KIND_LABEL: Record<PreviewPublication["kind"], string> = {
@@ -39,9 +60,14 @@ const KIND_LABEL: Record<PreviewPublication["kind"], string> = {
 
 const DEFAULT_EMPTY_MESSAGE = "Previews appear here while you generate.";
 
-export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = sharedPreviewHub) {
+export function renderPreviewPanel(
+  rootElement: HTMLElement,
+  hub: PreviewHub = sharedPreviewHub,
+  bridge: ImportBridge = sharedImportBridge
+) {
   // A remount must not leave the previous subscription feeding a detached node.
   unsubscribe?.();
+  unsubscribeImports?.();
 
   rootElement.innerHTML = "";
   rootElement.classList.add("openlayer-preview-panel-root");
@@ -95,8 +121,31 @@ export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = s
   image.alt = "OpenLayer generation preview";
   image.hidden = true;
 
+  // Import row. Built once and shown or hidden per publication rather than
+  // rebuilt, so clicking through a live sequence cannot swap the button out from
+  // under the pointer.
+  const actions = document.createElement("div");
+  actions.className = "openlayer-preview-panel-actions";
+
+  const importButton = document.createElement("button");
+  importButton.type = "button";
+  importButton.className = "openlayer-preview-panel-import";
+
+  const autoImportButton = document.createElement("button");
+  autoImportButton.type = "button";
+  autoImportButton.className = "openlayer-preview-panel-auto-import";
+
+  // Import feedback belongs here, not only in the dashboard's status bar: the
+  // artist who clicked is looking at this panel, and the dashboard may be docked
+  // out of sight or parked on another screen. The text is whatever the tool's own
+  // status bar says, so the two surfaces cannot contradict each other.
+  const importStatus = document.createElement("span");
+  importStatus.className = "openlayer-preview-panel-import-status";
+
+  actions.append(importButton, autoImportButton, importStatus);
+
   stage.append(emptyMessage, image);
-  shell.append(header, stage);
+  shell.append(header, stage, actions);
   rootElement.append(shell);
 
   let actualSize = false;
@@ -124,8 +173,69 @@ export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = s
   const resolve = (): PreviewPublication | null =>
     pinnedToolId ? hub.latestForTool(pinnedToolId) : hub.latest();
 
+  /**
+   * The tool the buttons currently act on: whoever published what is on screen.
+   * Held so the click listeners do not have to re-resolve and risk acting on a
+   * different tool than the one the label named.
+   */
+  let actionToolId: PreviewToolId | null = null;
+
+  const renderImportControls = (publication: PreviewPublication | null) => {
+    actionToolId = publication?.toolId ?? null;
+
+    const capability = publication ? bridge.capabilityFor(publication.toolId) : null;
+    const affordance = resolveImportAffordance(capability, publication);
+
+    actions.hidden = !affordance.visible;
+
+    if (!publication || !affordance.visible) {
+      importStatus.textContent = "";
+      importStatus.classList.remove("is-error");
+      return;
+    }
+
+    const target = IMPORT_TARGETS[publication.toolId];
+
+    importButton.textContent = target.label;
+    importButton.disabled = !affordance.enabled;
+    importButton.title = affordance.reason;
+
+    // A tool with no auto-import flag gets no toggle at all, rather than a
+    // disabled one. The dashboard has no such control for Sketch, Inpaint or
+    // Outpaint, and offering a dead button here would imply the app can do
+    // something it cannot.
+    const auto = target.hasAutoImport ? capability?.auto ?? null : null;
+
+    autoImportButton.hidden = !auto;
+
+    if (auto) {
+      autoImportButton.textContent = auto.isEnabled ? "Auto Import On" : "Import Automatically";
+      autoImportButton.setAttribute("aria-pressed", String(auto.isEnabled));
+      autoImportButton.classList.toggle("is-active", auto.isEnabled);
+    }
+
+    const outcome = bridge.outcomeFor(publication.toolId);
+
+    importStatus.textContent = affordance.enabled || outcome ? outcome?.message ?? "" : affordance.reason;
+    importStatus.classList.toggle("is-error", outcome?.status === "failed");
+  };
+
+  importButton.addEventListener("click", () => {
+    if (actionToolId) {
+      bridge.requestImport(actionToolId);
+    }
+  });
+
+  autoImportButton.addEventListener("click", () => {
+    if (actionToolId) {
+      bridge.toggleAutoImport(actionToolId);
+    }
+  });
+
   const render = () => {
     const publication = resolve();
+
+    renderImportControls(publication);
 
     if (!publication) {
       ownedUrl.release();
@@ -164,6 +274,11 @@ export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = s
   // re-resolves and finds nothing new for its tool.
   unsubscribe = hub.subscribe(render);
 
+  // Capability and outcome changes do not go through the hub — no new image has
+  // arrived — so the buttons are refreshed on their own channel. Only the import
+  // row re-renders, which keeps a busy-state change from touching the <img>.
+  unsubscribeImports = bridge.subscribe(() => renderImportControls(resolve()));
+
   if (!teardownRegistered) {
     teardownRegistered = true;
     window.addEventListener(
@@ -171,6 +286,8 @@ export function renderPreviewPanel(rootElement: HTMLElement, hub: PreviewHub = s
       () => {
         unsubscribe?.();
         unsubscribe = null;
+        unsubscribeImports?.();
+        unsubscribeImports = null;
         urls.revokeAll();
       },
       { once: true }

--- a/tests/ui/importBridge.test.ts
+++ b/tests/ui/importBridge.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createImportBridge,
+  IMPORT_TARGETS,
+  resolveImportAffordance
+} from "../../src/ui/importBridge";
+import { PREVIEW_TOOLS, PreviewPublication, PreviewToolId } from "../../src/ui/previewHub";
+
+const publication = (toolId: PreviewToolId, kind: PreviewPublication["kind"] = "result"): PreviewPublication => ({
+  toolId,
+  kind,
+  blob: new Blob(["x"])
+});
+
+describe("IMPORT_TARGETS", () => {
+  it("covers every tool that can publish a preview", () => {
+    // The panel indexes this by the displayed publication's toolId, so a tool
+    // added to PREVIEW_TOOLS without an entry here would render an undefined
+    // label. Freezing the pairing is cheaper than a runtime fallback.
+    expect(Object.keys(IMPORT_TARGETS).sort()).toEqual(PREVIEW_TOOLS.map((tool) => tool.id).sort());
+  });
+
+  it("claims auto-import only for the tools that have the flag", () => {
+    // Text to Image, Image to Image, Upscale and Live Painting have an
+    // auto-import flag in renderApp; Sketch, Inpaint and Outpaint have none, in
+    // the dashboard either. If someone adds a flag, this test is the reminder to
+    // record it here rather than letting the two surfaces disagree.
+    const withAuto = Object.entries(IMPORT_TARGETS)
+      .filter(([, target]) => target.hasAutoImport)
+      .map(([toolId]) => toolId)
+      .sort();
+
+    expect(withAuto).toEqual(["image-to-image", "live-painting", "text-to-image"]);
+  });
+});
+
+describe("resolveImportAffordance", () => {
+  it("hides the row when nothing is displayed", () => {
+    expect(resolveImportAffordance({ canImport: true, auto: null }, null).visible).toBe(false);
+  });
+
+  it("hides the row when the tool never registered a capability", () => {
+    expect(resolveImportAffordance(null, publication("inpaint")).visible).toBe(false);
+  });
+
+  it("refuses to import a live frame even when the tool says it can import", () => {
+    // A live publication is a mid-generation sampler frame: there is no
+    // committed result to place, and a run is by definition still active. This
+    // is the A4 lockout expressed at the only surface that can see the frame.
+    const affordance = resolveImportAffordance({ canImport: true, auto: null }, publication("inpaint", "live"));
+
+    expect(affordance).toEqual({
+      visible: true,
+      enabled: false,
+      reason: "Import when the generation finishes."
+    });
+  });
+
+  it("disables the button while the tool reports it cannot import", () => {
+    const affordance = resolveImportAffordance({ canImport: false, auto: null }, publication("upscale"));
+
+    expect(affordance.visible).toBe(true);
+    expect(affordance.enabled).toBe(false);
+    expect(affordance.reason).toContain("running");
+  });
+
+  it("enables the button for a finished result the tool can import", () => {
+    expect(resolveImportAffordance({ canImport: true, auto: null }, publication("upscale"))).toEqual({
+      visible: true,
+      enabled: true,
+      reason: ""
+    });
+  });
+});
+
+describe("createImportBridge", () => {
+  it("routes a request to the registered tool's handler and nobody else's", () => {
+    const bridge = createImportBridge();
+    const inpaint = vi.fn();
+    const upscale = vi.fn();
+
+    bridge.register("inpaint", { requestImport: inpaint });
+    bridge.register("upscale", { requestImport: upscale });
+    bridge.publishCapability("inpaint", { canImport: true, auto: null });
+    bridge.publishCapability("upscale", { canImport: true, auto: null });
+
+    bridge.requestImport("inpaint");
+
+    expect(inpaint).toHaveBeenCalledTimes(1);
+    expect(upscale).not.toHaveBeenCalled();
+  });
+
+  it("refuses a request the capability says is impossible", () => {
+    // The button should already be disabled. This is the second line of defence:
+    // a stale render must not be able to fire an import during a run.
+    const bridge = createImportBridge();
+    const handler = vi.fn();
+
+    bridge.register("inpaint", { requestImport: handler });
+    bridge.publishCapability("inpaint", { canImport: false, auto: null });
+
+    bridge.requestImport("inpaint");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("refuses a request for a tool that never published a capability", () => {
+    const bridge = createImportBridge();
+    const handler = vi.fn();
+
+    bridge.register("inpaint", { requestImport: handler });
+    bridge.requestImport("inpaint");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("ignores a request for a tool that never registered", () => {
+    const bridge = createImportBridge();
+
+    bridge.publishCapability("sketch-to-image", { canImport: true, auto: null });
+
+    expect(() => bridge.requestImport("sketch-to-image")).not.toThrow();
+  });
+
+  it("does nothing when asked to toggle auto-import on a tool without the control", () => {
+    const bridge = createImportBridge();
+
+    bridge.register("inpaint", { requestImport: vi.fn() });
+
+    expect(() => bridge.toggleAutoImport("inpaint")).not.toThrow();
+  });
+
+  it("notifies subscribers when a capability actually changes", () => {
+    const bridge = createImportBridge();
+    const listener = vi.fn();
+
+    bridge.subscribe(listener);
+    bridge.publishCapability("upscale", { canImport: false, auto: null });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    bridge.publishCapability("upscale", { canImport: true, auto: null });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops an unchanged capability rather than re-rendering the panel", () => {
+    // syncBusy runs on every state change, including every live frame. Without
+    // this the panel would rebuild its import row throughout a generation.
+    const bridge = createImportBridge();
+    const listener = vi.fn();
+
+    bridge.publishCapability("upscale", { canImport: true, auto: { isEnabled: false } });
+    bridge.subscribe(listener);
+    bridge.publishCapability("upscale", { canImport: true, auto: { isEnabled: false } });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing auto control as different from a disabled one", () => {
+    // null means "this tool has no toggle" and { isEnabled: false } means "the
+    // toggle is off". The panel renders them differently, so a change between
+    // them has to reach it.
+    const bridge = createImportBridge();
+    const listener = vi.fn();
+
+    bridge.publishCapability("upscale", { canImport: true, auto: null });
+    bridge.subscribe(listener);
+    bridge.publishCapability("upscale", { canImport: true, auto: { isEnabled: false } });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the newest registration when a panel remounts", () => {
+    const bridge = createImportBridge();
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const unregisterFirst = bridge.register("inpaint", { requestImport: first });
+    bridge.register("inpaint", { requestImport: second });
+    // The first mount's cleanup runs after the second has registered, which is
+    // the ordering UXP produces on a remount. It must not unregister the live one.
+    unregisterFirst();
+    bridge.publishCapability("inpaint", { canImport: true, auto: null });
+
+    bridge.requestImport("inpaint");
+
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it("retains the last outcome per tool", () => {
+    const bridge = createImportBridge();
+
+    bridge.reportOutcome({ toolId: "inpaint", status: "imported", message: "Imported layer: A" });
+    bridge.reportOutcome({ toolId: "upscale", status: "failed", message: "Import failed." });
+
+    expect(bridge.outcomeFor("inpaint")?.status).toBe("imported");
+    expect(bridge.outcomeFor("upscale")?.message).toBe("Import failed.");
+    expect(bridge.outcomeFor("sketch-to-image")).toBeNull();
+  });
+
+  it("keeps delivering to other listeners when one throws", () => {
+    // A surface that throws while re-rendering must not propagate back into the
+    // handler that reported success, or a cosmetic bug becomes a failed import.
+    const bridge = createImportBridge();
+    const healthy = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    bridge.subscribe(() => {
+      throw new Error("render failed");
+    });
+    bridge.subscribe(healthy);
+
+    expect(() => bridge.reportOutcome({ toolId: "inpaint", status: "imported", message: "ok" })).not.toThrow();
+    expect(healthy).toHaveBeenCalledTimes(1);
+
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
The v0.8.1 feature you asked for. **The panel does not import — it asks.**

New `src/ui/importBridge.ts` carries a tool id and a click from the panel into `renderApp`. Your seven import handlers are reused untouched.

## Why not just import in the panel

It looks reasonable until it doesn't. The panel already holds the blob, so it could place the blob — and that would be wrong in a way **no test outside Photoshop would catch**. A `PreviewPublication` carries a `Blob` and a `toolId` and *no document binding at all*, so importing from it would place pixels into whatever document happens to be active. That's precisely what **A1** exists to prevent. A2's mask ordering, A3's transactional cleanup and B1's submit-time source snapshot are all equally unreachable from a blob.

Capability is **pushed, not computed**, for the same class of reason: `setBusy` already computes each button's enabled state, and a second derivation in the panel would be free to disagree — a panel offering Import mid-run would break the **A4** lockout from a surface that never had to respect it. So `syncImportBridge()` is called from `syncBusy`, off the same `isBusy` flag and the same per-tool result gates.

## Two things the code decided, not taste

- **The button acts on the tool whose image is on screen**, not the pinned tool. With a pin set they coincide; under "Follow active tool" it's the latest publisher.
- **Auto-import appears only for Text to Image, Image to Image and Live Painting** — the three tools that actually have the flag. Sketch, Inpaint and Outpaint have none, in the dashboard either, so the panel shows *no* toggle rather than a dead one. A test freezes that list.

## One correction to a decision, stated out loud

`previewPanel.ts`'s header comment claimed the Import buttons belonged next to the small preview "because that is where the decision gets made." Your reasoning is better and the comment now says so, rather than being quietly contradicted.

## Feedback

The panel gets its own status line, per your choice. The text is **read out of the tool's own status bar** after the handler settles — not inferred from whether the call threw. Your handlers deliberately swallow failures (each catches, sets an error status, returns), so a wrapper watching for exceptions would report **every failed import as a success**. Reading back what the handler wrote means the panel can't contradict the dashboard.

## Not included

Live Painting's second import, **"Import Refined as Layer"**. The panel shows one image at a time and the refined result is a separate artefact. Say if you want it.

## Verification

`typecheck`, `lint`, **401 tests** (18 new on the bridge), `build` all green. Confirmed in the browser that `renderApp` still boots with the registration in place and all eight dashboard import buttons wire up correctly disabled. The panel itself only mounts under its UXP entrypoint — **its appearance and behaviour is entirely your smoke test.** Per the header-overlap lesson, the browser can't validate anything about how this row lays out in UXP.

## Smoke checklist

Build and load `dist/manifest.json` in UXP Developer Tool, then open **Plugins > OpenLayer Preview** and dock it beside the dashboard.

1. **Nothing shows with nothing to show.** Fresh panel, no generation yet: no Import button, no status line — just the empty message.
2. **Import from the big preview.** Run **Text to Image**. When it finishes, the panel shows **Import Result as New Layer** plus **Import Automatically**. Click Import. A new layer appears in the document, and the panel's own status line reads the same thing the dashboard's Text to Image status bar reads.
3. **Disabled during a run.** Start another Text to Image run. While it's generating, the panel's Import button must be **visibly disabled** (dimmed, not just unclickable) with the tooltip "Import when the generation finishes." Jab at it — nothing should happen.
4. **Per-tool labels and the missing toggle.** Generate in **Inpaint**. The panel should show **Import to Layers** and **no auto-import button at all**. Same for **Sketch to Image** and **Outpaint**. **Upscale** should also show no toggle.
5. **The button follows the image, not the pin.** Pin the panel to **Inpaint**, then generate in **Text to Image**. The panel keeps showing Inpaint's result — and its Import button must still import **Inpaint**, giving you an Inpaint layer, not a Text to Image one. This is the case I most want checked.
6. **Auto-import stays in sync both ways.** Toggle **Import Automatically** in the panel on the Text to Image screen; the dashboard's own toggle must flip to "Auto Import On" too. Then toggle it from the dashboard and confirm the panel's follows.
7. **A failed import reports as failed.** With no document open (or on a document that isn't the originating one), click Import from the panel. The status line must go **red** with the real reason — not a silent success.
8. **Inpaint still imports correctly.** Make a selection, run Inpaint, import **from the panel**, and confirm the mask alignment is exactly as good as importing from the dashboard. This is the A1/A2 check — if the bridge were wrong, this is where it would show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
