### PR TITLE
Release v0.8.1-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,25 @@
 # Changelog
 
-## Unreleased
+## v0.8.1-alpha - 2026-07-27
+
+A small follow-up to v0.8.0 carrying two changes that missed that tag. The reason it exists as its own release rather than waiting for v0.9 is the first entry below: the separated Preview panel gained its Import buttons the day after v0.8.0 shipped, and handing testers a build without them would spend a round of feedback on the panel's least finished state.
+
+### Added
+
+- Added the Import buttons to the separated Preview panel, so a result can be placed into the document from the large preview where it is actually being judged, instead of only from the thumbnail on the dashboard. The panel does not import anything itself — it forwards the request to the same seven import handlers the dashboard uses, because those handlers own the document-identity binding, the mask-ordering assertion, the transactional cleanup, and Inpaint's readiness contract. A preview image on its own carries no record of which document it came from, so importing it directly would place pixels into whichever document happened to be active.
+- The panel's buttons follow the image on screen rather than the pinned tool, stay disabled during a run and on mid-generation live frames, and report the outcome on their own status line so the result is visible when the dashboard is docked out of sight. The auto-import toggle appears only for the three tools that have that setting — Text to Image, Image to Image, and Live Painting.
 
 ### Fixed
 
 - Re-exported `img2img-z-image-turbo`'s editable source workflow, which held the vendor's Z-Image *text-to-image* demo graph rather than the image-to-image graph OpenLayer submits — no `LoadImage` or `VAEEncode`, an `EmptySD3LatentImage` generating a blank latent, one prompt encoder instead of two, and a bypassed LoRA loader. Nothing failed at runtime, because OpenLayer submits the API workflow and never the source; the cost was that anyone opening the file to learn the workflow got a graph that cannot do image to image. This was the last entry in the equivalence checker's known-mismatch list, so the list is now empty and the setup pack advertises an editable source for all eleven presets that claim one.
+
+### Known limitations
+
+- The Preview panel offers each tool's primary import only. Live Painting's second action, "Import Refined as Layer", is not on the panel, because the refined result is a separate image and the panel shows one at a time.
+- The status fix from v0.8.0 still covers the status bars only. The diagnostics line and the error text continue to mirror across tools: `setDiagnostics` writes all eight diagnostics lines, and `setError` writes both the Text to Image and the Settings error line. Same shape of fix, still deferred.
+- The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the list and the downloader instead — an internet connection is required.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+- CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
 
 ## v0.8.0-alpha - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.8.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows and the release's correctness fixes in Photoshop UXP, not for production work yet.
+`v0.8.1-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows and the 0.8 correctness fixes in Photoshop UXP, not for production work yet.
 
-New in `v0.8.0-alpha`:
+New in `v0.8.1-alpha`:
+
+- The separated **OpenLayer Preview** panel now has its own **Import** buttons, so a result can be placed into the document from the large preview instead of only from the dashboard thumbnail. The buttons act on the image currently on screen, stay disabled during a run and on live sampler frames, and report the outcome on their own status line.
+- `img2img-z-image-turbo`'s editable source workflow is correct. It previously held the vendor's text-to-image demo graph, so opening it to learn the workflow showed a graph that cannot do image to image. Generation was never affected.
+
+Also new in the 0.8 series:
 
 - The separated **OpenLayer Preview** panel can now stay pinned to one tool instead of always following the latest generation. Its selection persists across sessions.
 - Status updates now stay with the correct tool instead of Text to Image progress appearing in Inpaint, Upscale, and the other tool screens.
@@ -86,8 +91,10 @@ The earlier card-based dashboard established OpenLayer's honest available/experi
 
 </details>
 
-v0.8.0-alpha tester focus:
+v0.8.1-alpha tester focus:
 
+- Open **Plugins > OpenLayer Preview**, generate, and import the result using the panel's own **Import** button. Confirm the layer lands in the same document the generation started from, and that the panel's status line reports what happened.
+- Confirm the panel's Import button is disabled while a run is in progress and on live sampler frames, and enabled again once a result is committed.
 - Open **Plugins > OpenLayer Preview**, pin it to one tool, generate with another, and confirm the panel stays pinned and restores that choice in a later session.
 - Start Text to Image and confirm progress appears only in its own status bar; return Home and confirm the shared status row does not appear on tool screens.
 - Watch a sticky tool header before and during a run. There should be no progress bar in the header at all, its height should not change, and the bar should appear under the status text in the generation status panel with nothing painted over it.
@@ -95,7 +102,7 @@ v0.8.0-alpha tester focus:
 - Run `npm run setup-pack` and confirm it reports no source/API mismatches at all.
 - Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
-Known v0.8.0-alpha boundaries:
+Known v0.8.1-alpha boundaries:
 
 - Image to Image is an early foundation path, not a full production workflow yet.
 - Sketch to Image is limited to the first SD 1.x LINECN starter workflow.
@@ -123,7 +130,8 @@ Known v0.8.0-alpha boundaries:
 - CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
 - The status fix covers the status bars only. The diagnostics line and the error text still mirror across tools, and that fix is deferred.
 - Progress is no longer pinned while a tool's form is scrolled, which is the accepted cost of taking the progress bar out of the sticky header.
-- The v0.8.0 release focuses on correctness and maintainability. Existing generation capabilities should remain compatible with v0.7.0.
+- The 0.8 releases focus on correctness and maintainability. Existing generation capabilities should remain compatible with v0.7.0.
+- The Preview panel offers each tool's primary import only. Live Painting's "Import Refined as Layer" stays on the dashboard.
 - Layer, canvas, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
 - Live sampler previews require ComfyUI to be started with `--preview-method auto`, and the preview panel may flicker between steps until a future UI polish pass.
 - Classic v0.4 theme preserves the older visual feel, but it does not duplicate every old layout detail.
@@ -253,7 +261,7 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.8.0-alpha.zip
+packages/openlayer-v0.8.1-alpha.zip
 ```
 
 ## Loading In UXP Developer Tool
@@ -380,7 +388,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.8.0-alpha test result:
+Use this quick pass before reporting a v0.8.1-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
       "operatingSystem": "Windows, macOS",
       "applicationCategory": "DesignApplication",
       "applicationSubCategory": "Adobe Photoshop plugin",
-      "softwareVersion": "0.8.0-alpha",
+      "softwareVersion": "0.8.1-alpha",
       "description": "Open-source Photoshop UXP plugin that connects to a local ComfyUI server for AI image generation: text to image, image to image, sketch to image, inpaint, outpaint, and upscale with Stable Diffusion, SDXL, and Flux models.",
       "url": "https://mehran-ahmadi.com/OpenLayer/",
       "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases",
@@ -64,7 +64,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.8.0 · free &amp; open source</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.8.1 · free &amp; open source</p>
           <h1 id="hero-title">Local AI layers,<br><span class="grad">inside Photoshop.</span></h1>
           <p class="hero-lede">
             OpenLayer connects Photoshop to <strong>your own ComfyUI server</strong>.
@@ -307,15 +307,15 @@ npm run build</code></pre>
           <div class="status-grid">
             <article class="status-card status-card-ready">
               <h3>Separated preview panel is ready to test</h3>
-              <p>A second dockable panel shows the current generation at any size, mirroring every tool including Live Painting. It has passed a real Photoshop UXP smoke test.</p>
+              <p>A second dockable panel shows the current generation at any size, mirroring every tool including Live Painting. It can be pinned to one tool, and as of v0.8.1 it imports the result into your document without going back to the dashboard. It has passed a real Photoshop UXP smoke test.</p>
             </article>
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.8.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.8.1-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
-              <p>v0.8.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
+              <p>v0.8.1 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
             </article>
             <article class="status-card">
               <h3>Flux Fill is experimental</h3>
@@ -338,7 +338,7 @@ npm run build</code></pre>
               <li>Inpaint and Outpaint should be tested on duplicate layers first.</li>
               <li>Prompt from Layer requires the local Florence-2 PromptGen model and the comfyui-florence2 nodes. The custom-scripts pack is no longer needed.</li>
               <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.8.0 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.8.1 keeps the shared metadata foundation and session-history wiring.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
               <li>Progress is shown in the generation status panel rather than pinned to the screen header, so it scrolls with the form.</li>
@@ -401,7 +401,7 @@ npm run build</code></pre>
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.8.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.8.1-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a>
       </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlayer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlayer",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.openlayer.photoshop",
   "name": "OpenLayer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "index.html",
   "host": [
     {

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -1,7 +1,7 @@
 import { OpenLayerTheme } from "../utils/preferences";
 
 export const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-export const APP_VERSION = "0.8.0";
+export const APP_VERSION = "0.8.1";
 export const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 export const HISTORY_LIMIT = 5;
 export const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];


### PR DESCRIPTION
Release paperwork only — no behavior changes. Everything being released is already on `main` and already smoke-tested: #46 (z-image source workflow) and #47 (Preview panel Import buttons).

## Why this release exists

The published `v0.8.0-alpha` build does not contain the Preview panel Import buttons, which are the most tester-visible change built so far. Handing testers that build spends a feedback round on the panel's least finished state.

## Commits

1. `fe4ba33` — version bump to 0.8.1 in `package.json`, `package-lock.json`, `src/manifest.json`, `appConstants.ts`
2. `10b7e80` — CHANGELOG: promoted `Unreleased`, wrote the missing #47 entry, restated known limitations
3. `f37d893` — README (9 refs) and `docs/index.html` (6 refs)

## Two judgement calls worth your eye

- **The v0.8.0 CHANGELOG section is left exactly as published**, including its bullet listing the z-image source mismatch as a known limitation. That was true of the build people have; rewriting it would make the file disagree with the shipped zip. The v0.8.1 `Fixed` entry records the closure.
- **The README's "New in" list is split in two** — `New in v0.8.1-alpha` (2 entries) and `Also new in the 0.8 series` (the v0.8.0 entries). Folding them together would have claimed v0.8.0's work as new in v0.8.1.

## Validation

`npm run typecheck`, `npm test` (48 files / 401 tests), `npm run build` all green. `dist/manifest.json` reports `0.8.1`.

## Smoke checklist

Nothing new was built, so this is a version-and-docs check on a real build:

1. Build and load `dist/manifest.json` in UXP Developer Tool.
2. Open OpenLayer, go to **Settings** → confirm the version reads **0.8.1** (not 0.8.0).
3. Click **Copy Diagnostics** → confirm the pasted report says `0.8.1`.
4. Open **Plugins > OpenLayer Preview**, run a Text to Image generation, and click the panel's **Import** button → confirm the layer lands in the correct document and the panel's status line reports it. (Re-confirming #47 survives on a packaged build, not just the dev build.)
5. Start a run and confirm the panel's Import button is disabled during it, and enabled again after the result commits.

If all five pass, say the word and I'll merge, tag `v0.8.1-alpha` on the merge commit, build both zips, and cut the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)