### PR TITLE
Spike: UXP save-file picker for Layer Tools

### DIFF
--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -136,6 +136,8 @@ import {
   getUpscaleFailureHint
 } from "./toolErrorMessages";
 import { createLayerName, sweepStaleTemporaryFiles } from "../utils/fileUtils";
+// SPIKE (v0.9 Layer Tools task 0): remove with src/utils/saveFilePicker.ts.
+import { describeSaveFilePickerOutcome, runSaveFilePickerSpike } from "../utils/saveFilePicker";
 import {
   clearOpenLayerPreferences,
   loadOpenLayerPreferences,
@@ -687,6 +689,7 @@ export function renderApp(rootElement: HTMLElement) {
     detectHardware: createActionRunner(elements, "detectHardware", handleDetectHardware),
     checkWorkflowHealth: createActionRunner(elements, "checkWorkflowHealth", handleCheckWorkflowHealth),
     copyDiagnostics: createActionRunner(elements, "copyDiagnostics", handleCopyDiagnostics),
+    saveFilePickerSpike: createActionRunner(elements, "saveFilePickerSpike", handleSaveFilePickerSpike),
     saveSettings: createActionRunner(elements, "saveSettings", handleSaveSettings),
     resetSettings: createActionRunner(elements, "resetSettings", handleResetSettings),
     toggleNegativePrompt: createActionRunner(elements, "toggleNegativePrompt", handleToggleNegativePrompt),
@@ -754,6 +757,7 @@ export function renderApp(rootElement: HTMLElement) {
   bindActionControl(elements.detectHardwareButton, actionHandlers.detectHardware);
   bindActionControl(elements.checkWorkflowHealthButton, actionHandlers.checkWorkflowHealth);
   bindActionControl(elements.copyDiagnosticsButton, actionHandlers.copyDiagnostics);
+  bindActionControl(elements.saveFilePickerSpikeButton, actionHandlers.saveFilePickerSpike);
   bindActionControl(elements.saveSettingsButton, actionHandlers.saveSettings);
   bindActionControl(elements.resetSettingsButton, actionHandlers.resetSettings);
   bindActionControl(elements.negativePromptToggle, actionHandlers.toggleNegativePrompt);
@@ -1088,6 +1092,33 @@ export function renderApp(rootElement: HTMLElement) {
     } catch {
       setGlobalStatus(elements, "Diagnostics ready to copy.", "ready");
       setDiagnostics(elements, "Clipboard is unavailable here. The diagnostics report is shown below for manual copy.");
+    }
+  }
+
+  // SPIKE (v0.9 Layer Tools task 0): remove with src/utils/saveFilePicker.ts.
+  // Reports the outcome into the diagnostics line so the answer survives on
+  // screen instead of only in the UXP console, and so a failure message can be
+  // copied out verbatim rather than retyped from a screenshot.
+  async function handleSaveFilePickerSpike() {
+    setGlobalStatus(elements, "Opening the save dialog...", "idle");
+
+    try {
+      const outcome = await runSaveFilePickerSpike("OpenLayer_SavePickerSpike.png");
+      const summary = describeSaveFilePickerOutcome(outcome);
+
+      setGlobalStatus(
+        elements,
+        outcome.kind === "saved" ? "Save picker spike: saved." : `Save picker spike: ${outcome.kind}.`,
+        outcome.kind === "failed" ? "error" : "ready"
+      );
+      setDiagnostics(elements, summary);
+    } catch (caughtError) {
+      // Nothing should reach here — the spike returns its failures. If this
+      // fires, the interesting fact is that it threw where it was designed
+      // not to, so say that rather than hiding it behind a generic message.
+      const message = `Save picker spike threw instead of returning an outcome: ${getErrorMessage(caughtError)}`;
+      setGlobalStatus(elements, "Save picker spike: unexpected throw.", "error");
+      setDiagnostics(elements, message);
     }
   }
 

--- a/src/ui/appBindings.ts
+++ b/src/ui/appBindings.ts
@@ -24,6 +24,7 @@ export type ActionName =
   | "detectHardware"
   | "checkWorkflowHealth"
   | "copyDiagnostics"
+  | "saveFilePickerSpike"
   | "saveSettings"
   | "resetSettings"
   | "toggleNegativePrompt"

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -62,6 +62,7 @@ export type AppElements = {
   detectHardwareButton: HTMLElement;
   checkWorkflowHealthButton: HTMLElement;
   copyDiagnosticsButton: HTMLElement;
+  saveFilePickerSpikeButton: HTMLElement;
   saveSettingsButton: HTMLElement;
   resetSettingsButton: HTMLElement;
   generateButton: HTMLElement;
@@ -413,6 +414,8 @@ export function createAppMarkup() {
             <button class="button action-control" id="detect-gpu" data-openlayer-action="detectHardware" type="button">Detect GPU &amp; Recommend Models</button>
             <button class="button action-control" id="check-workflow-health" data-openlayer-action="checkWorkflowHealth" type="button">Check Workflow Health</button>
             <button class="button action-control" id="copy-diagnostics" data-openlayer-action="copyDiagnostics" type="button">Copy Diagnostics</button>
+            <!-- SPIKE (v0.9 Layer Tools task 0): temporary, remove with src/utils/saveFilePicker.ts. -->
+            <button class="button action-control" id="save-file-picker-spike" data-openlayer-action="saveFilePickerSpike" type="button">Spike: Save Picker</button>
             <button class="button action-control" id="save-settings" data-openlayer-action="saveSettings" type="button">Save Settings</button>
             <button class="button action-control" id="reset-settings" data-openlayer-action="resetSettings" type="button">Reset Defaults</button>
           </div>
@@ -1288,6 +1291,7 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     detectHardwareButton: getElement<HTMLElement>(rootElement, "detect-gpu"),
     checkWorkflowHealthButton: getElement<HTMLElement>(rootElement, "check-workflow-health"),
     copyDiagnosticsButton: getElement<HTMLElement>(rootElement, "copy-diagnostics"),
+    saveFilePickerSpikeButton: getElement<HTMLElement>(rootElement, "save-file-picker-spike"),
     saveSettingsButton: getElement<HTMLElement>(rootElement, "save-settings"),
     resetSettingsButton: getElement<HTMLElement>(rootElement, "reset-settings"),
     generateButton: getElement<HTMLElement>(rootElement, "generate"),

--- a/src/ui/toolDescriptors.ts
+++ b/src/ui/toolDescriptors.ts
@@ -96,6 +96,7 @@ export const BUSY_ALWAYS_DISABLED_ACTIONS: readonly ActionElementKey[] = [
   "detectHardwareButton",
   "checkWorkflowHealthButton",
   "copyDiagnosticsButton",
+  "saveFilePickerSpikeButton",
   "saveSettingsButton",
   "resetSettingsButton",
   "generateButton",

--- a/src/utils/saveFilePicker.ts
+++ b/src/utils/saveFilePicker.ts
@@ -39,23 +39,19 @@ export async function runSaveFilePickerSpike(suggestedName: string): Promise<Sav
     return { kind: "unsupported" };
   }
 
-  const getFileForSaving = uxp.storage?.localFileSystem?.getFileForSaving;
+  const localFileSystem = uxp.storage?.localFileSystem;
 
   // An older or differently-provisioned UXP build may simply not have it. That
   // is a real answer, not a crash, and it decides whether Layer Tools can offer
   // "save as" at all.
-  if (typeof getFileForSaving !== "function") {
+  if (typeof localFileSystem?.getFileForSaving !== "function") {
     return { kind: "unsupported" };
   }
 
   let file: UxpFile | null;
 
   try {
-    // Called outside executeAsModal on purpose. This opens OS-level UI, and
-    // Photoshop's modal scope is for document mutation; if this turns out to
-    // need a modal, the thrown error is exactly what the spike should surface
-    // rather than something to guess at in advance.
-    file = await getFileForSaving(suggestedName, { types: ["png"] });
+    file = await openSaveDialog(localFileSystem, suggestedName);
   } catch (caughtError) {
     return { kind: "failed", stage: "picker", message: describeError(caughtError) };
   }
@@ -76,6 +72,30 @@ export async function runSaveFilePickerSpike(suggestedName: string): Promise<Sav
   }
 
   return { kind: "saved", fileName: file.name, byteLength: bytes.byteLength };
+}
+
+export type SaveDialogHost = {
+  getFileForSaving?: (
+    suggestedName: string,
+    options?: { types?: readonly string[] }
+  ) => Promise<UxpFile | null>;
+};
+
+// Split out so the receiver can be regression-tested without Photoshop. The
+// first run of this spike pulled getFileForSaving off localFileSystem to
+// typeof-check it and then called it bare, so `this` was undefined inside UXP
+// and it threw "Cannot read properties of undefined" before any dialog
+// appeared. The method must be invoked on its object.
+//
+// Called outside executeAsModal on purpose. This opens OS-level UI, and
+// Photoshop's modal scope is for document mutation; if this turns out to need
+// a modal, the thrown error is what the spike should surface rather than
+// something to guess at in advance.
+export async function openSaveDialog(
+  host: SaveDialogHost,
+  suggestedName: string
+): Promise<UxpFile | null> {
+  return host.getFileForSaving!(suggestedName, { types: ["png"] });
 }
 
 // A flat magenta square with an opaque black border. Chosen so that a file that

--- a/src/utils/saveFilePicker.ts
+++ b/src/utils/saveFilePicker.ts
@@ -1,0 +1,131 @@
+// SPIKE (v0.9 Layer Tools, task 0) — delete or promote this file, do not leave it.
+//
+// Every file OpenLayer has ever written went to the temporary folder via
+// saveBlobToTemporaryFile. Layer Tools has to write where the artist chooses,
+// and nothing in this repository has opened a save dialog, so the behavior of
+// uxp.storage.localFileSystem.getFileForSaving in Photoshop UXP is unverified.
+//
+// This module answers that question and nothing else. It deliberately writes a
+// generated image rather than a captured layer: the capture paths are already
+// proven by generation, so mixing them in would mean a failure could not be
+// attributed. Isolate the unknown.
+//
+// The outcome is a discriminated result rather than a thrown error, because
+// "the artist pressed Cancel" and "this UXP build has no such API" are both
+// expected answers here and must be told apart from a genuine failure.
+
+import { encodeRgbaPng } from "./png";
+
+export type SaveFilePickerOutcome =
+  | { kind: "saved"; fileName: string; byteLength: number }
+  | { kind: "cancelled" }
+  | { kind: "unsupported" }
+  | { kind: "failed"; stage: SaveFilePickerStage; message: string };
+
+export type SaveFilePickerStage = "picker" | "write";
+
+const SPIKE_IMAGE_EDGE = 64;
+
+export async function runSaveFilePickerSpike(suggestedName: string): Promise<SaveFilePickerOutcome> {
+  let uxp: UxpModule;
+
+  // Browser preview builds have no require("uxp") at all, the same reason
+  // openExternalUrl guards its shell lookup. Treating that as "unsupported"
+  // keeps the browser from reporting a misleading crash, and it is also the
+  // honest answer for any host without the module.
+  try {
+    uxp = require("uxp") as UxpModule;
+  } catch {
+    return { kind: "unsupported" };
+  }
+
+  const getFileForSaving = uxp.storage?.localFileSystem?.getFileForSaving;
+
+  // An older or differently-provisioned UXP build may simply not have it. That
+  // is a real answer, not a crash, and it decides whether Layer Tools can offer
+  // "save as" at all.
+  if (typeof getFileForSaving !== "function") {
+    return { kind: "unsupported" };
+  }
+
+  let file: UxpFile | null;
+
+  try {
+    // Called outside executeAsModal on purpose. This opens OS-level UI, and
+    // Photoshop's modal scope is for document mutation; if this turns out to
+    // need a modal, the thrown error is exactly what the spike should surface
+    // rather than something to guess at in advance.
+    file = await getFileForSaving(suggestedName, { types: ["png"] });
+  } catch (caughtError) {
+    return { kind: "failed", stage: "picker", message: describeError(caughtError) };
+  }
+
+  // UXP resolves to null when the dialog is dismissed. Verifying that it does
+  // not throw instead matters: Layer Tools must not report a cancelled save as
+  // a failed one.
+  if (!file) {
+    return { kind: "cancelled" };
+  }
+
+  const bytes = createSpikeImageBytes();
+
+  try {
+    await file.write(toArrayBuffer(bytes), { format: uxp.storage.formats.binary });
+  } catch (caughtError) {
+    return { kind: "failed", stage: "write", message: describeError(caughtError) };
+  }
+
+  return { kind: "saved", fileName: file.name, byteLength: bytes.byteLength };
+}
+
+// A flat magenta square with an opaque black border. Chosen so that a file that
+// opens at all is obviously the file this spike wrote, and so that a truncated
+// write is visible as a partial image rather than passing for a valid one.
+export function createSpikeImageBytes(): Uint8Array {
+  const edge = SPIKE_IMAGE_EDGE;
+  const rgba = new Uint8Array(edge * edge * 4);
+
+  for (let y = 0; y < edge; y += 1) {
+    for (let x = 0; x < edge; x += 1) {
+      const offset = (y * edge + x) * 4;
+      const isBorder = x === 0 || y === 0 || x === edge - 1 || y === edge - 1;
+
+      rgba[offset] = isBorder ? 0 : 255;
+      rgba[offset + 1] = 0;
+      rgba[offset + 2] = isBorder ? 0 : 255;
+      rgba[offset + 3] = 255;
+    }
+  }
+
+  return encodeRgbaPng({ width: edge, height: edge, rgba });
+}
+
+export function describeSaveFilePickerOutcome(outcome: SaveFilePickerOutcome): string {
+  switch (outcome.kind) {
+    case "saved":
+      return `Save picker spike: wrote ${outcome.byteLength} bytes to "${outcome.fileName}". Open it — it should be a 64x64 magenta square with a black border.`;
+    case "cancelled":
+      return "Save picker spike: dialog opened and was cancelled, and UXP reported the cancellation instead of throwing. That is the expected result for Cancel.";
+    case "unsupported":
+      return "Save picker spike: this UXP build does not expose getFileForSaving at all. Layer Tools cannot offer a chosen save location on this host.";
+    case "failed":
+      return outcome.stage === "picker"
+        ? `Save picker spike: opening the dialog failed. ${outcome.message}`
+        : `Save picker spike: the dialog returned a file but writing to it failed. ${outcome.message}`;
+  }
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(copy).set(bytes);
+
+  return copy;
+}
+
+function describeError(caughtError: unknown): string {
+  if (caughtError instanceof Error && caughtError.message) {
+    return caughtError.message;
+  }
+
+  return String(caughtError);
+}

--- a/src/uxp.d.ts
+++ b/src/uxp.d.ts
@@ -27,6 +27,13 @@ type UxpModule = {
     localFileSystem: {
       getTemporaryFolder: () => Promise<UxpFolder>;
       createSessionToken: (file: unknown) => Promise<string>;
+      // Resolves to null when the artist cancels the dialog. Optional here
+      // because the spike must be able to detect a UXP build that does not
+      // expose it at all, rather than assume it and crash.
+      getFileForSaving?: (
+        suggestedName: string,
+        options?: { types?: readonly string[] }
+      ) => Promise<UxpFile | null>;
     };
   };
 };

--- a/tests/ui/toolDescriptors.test.ts
+++ b/tests/ui/toolDescriptors.test.ts
@@ -94,7 +94,9 @@ describe("busy-state tables", () => {
       ...BUSY_GATED_ACTIONS.map(({ button }) => button)
     ];
 
-    expect(plainActions).toHaveLength(29);
+    // 30 includes the temporary save-picker spike button. Removing the spike
+    // takes this back to 29 — see src/utils/saveFilePicker.ts.
+    expect(plainActions).toHaveLength(30);
     expect(BUSY_GATED_ACTIONS).toHaveLength(11);
     expect(new Set(allActions).size).toBe(allActions.length);
   });
@@ -148,6 +150,7 @@ describe("busy-state tables", () => {
       "detectHardwareButton",
       "checkWorkflowHealthButton",
       "copyDiagnosticsButton",
+      "saveFilePickerSpikeButton",
       "saveSettingsButton",
       "resetSettingsButton",
       "clearHistoryButton"

--- a/tests/utils/saveFilePicker.test.ts
+++ b/tests/utils/saveFilePicker.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeRgbaPng } from "../../src/utils/png";
+import {
+  createSpikeImageBytes,
+  describeSaveFilePickerOutcome,
+  type SaveFilePickerOutcome
+} from "../../src/utils/saveFilePicker";
+
+// The picker call itself needs Photoshop and is Mehran's smoke test. What can
+// be checked here is that the bytes the spike offers to write are a real PNG,
+// so that "the saved file will not open" can be attributed to the write path
+// rather than to the payload.
+describe("save file picker spike payload", () => {
+  it("encodes a decodable 64x64 PNG", () => {
+    const decoded = decodeRgbaPng(createSpikeImageBytes());
+
+    expect(decoded.width).toBe(64);
+    expect(decoded.height).toBe(64);
+    expect(decoded.rgba.byteLength).toBe(64 * 64 * 4);
+  });
+
+  it("draws an opaque black border around a magenta field", () => {
+    const decoded = decodeRgbaPng(createSpikeImageBytes());
+    const pixelAt = (x: number, y: number) => {
+      const offset = (y * decoded.width + x) * 4;
+
+      return Array.from(decoded.rgba.slice(offset, offset + 4));
+    };
+
+    expect(pixelAt(0, 0)).toEqual([0, 0, 0, 255]);
+    expect(pixelAt(63, 63)).toEqual([0, 0, 0, 255]);
+    expect(pixelAt(32, 32)).toEqual([255, 0, 255, 255]);
+  });
+});
+
+describe("save file picker spike reporting", () => {
+  // Cancel and unsupported are expected answers, not failures, and the spike is
+  // only useful if its report says which one happened.
+  it("describes every outcome distinctly", () => {
+    const outcomes: SaveFilePickerOutcome[] = [
+      { kind: "saved", fileName: "spike.png", byteLength: 128 },
+      { kind: "cancelled" },
+      { kind: "unsupported" },
+      { kind: "failed", stage: "picker", message: "boom" },
+      { kind: "failed", stage: "write", message: "boom" }
+    ];
+
+    const described = outcomes.map(describeSaveFilePickerOutcome);
+
+    expect(new Set(described).size).toBe(outcomes.length);
+    expect(described.every((text) => text.startsWith("Save picker spike:"))).toBe(true);
+  });
+
+  it("reports the saved file name and size", () => {
+    const text = describeSaveFilePickerOutcome({
+      kind: "saved",
+      fileName: "spike.png",
+      byteLength: 128
+    });
+
+    expect(text).toContain("spike.png");
+    expect(text).toContain("128");
+  });
+
+  it("distinguishes a failed dialog from a failed write", () => {
+    const picker = describeSaveFilePickerOutcome({ kind: "failed", stage: "picker", message: "no" });
+    const write = describeSaveFilePickerOutcome({ kind: "failed", stage: "write", message: "no" });
+
+    expect(picker).toContain("opening the dialog failed");
+    expect(write).toContain("writing to it failed");
+  });
+});

--- a/tests/utils/saveFilePicker.test.ts
+++ b/tests/utils/saveFilePicker.test.ts
@@ -4,8 +4,46 @@ import { decodeRgbaPng } from "../../src/utils/png";
 import {
   createSpikeImageBytes,
   describeSaveFilePickerOutcome,
+  openSaveDialog,
   type SaveFilePickerOutcome
 } from "../../src/utils/saveFilePicker";
+
+// Regression for the spike's own first failure in Photoshop. The method was
+// pulled off localFileSystem to typeof-check it and then called bare, so `this`
+// was undefined inside UXP and it threw before any dialog appeared. Nothing in
+// TypeScript catches a detached method; only calling it can.
+describe("save dialog invocation", () => {
+  it("calls getFileForSaving on its host so the receiver survives", async () => {
+    const observed = { called: false, receiverWasHost: false };
+    const host = {
+      async getFileForSaving(this: unknown) {
+        observed.called = true;
+        observed.receiverWasHost = this === host;
+
+        return null;
+      }
+    };
+
+    await openSaveDialog(host, "spike.png");
+
+    expect(observed).toEqual({ called: true, receiverWasHost: true });
+  });
+
+  it("passes the suggested name and a png type filter", async () => {
+    const calls: unknown[][] = [];
+    const host = {
+      async getFileForSaving(...args: unknown[]) {
+        calls.push(args);
+
+        return null;
+      }
+    };
+
+    await openSaveDialog(host, "OpenLayer_SavePickerSpike.png");
+
+    expect(calls).toEqual([["OpenLayer_SavePickerSpike.png", { types: ["png"] }]]);
+  });
+});
 
 // The picker call itself needs Photoshop and is Mehran's smoke test. What can
 // be checked here is that the bytes the spike offers to write are a real PNG,


### PR DESCRIPTION
**This is a spike, not a feature.** It exists to answer one question before Layer Tools is designed around the answer, and the button is meant to be deleted.

## The question

Layer Tools must write files where the artist chooses. Every file OpenLayer has ever written went to the temp folder via `saveBlobToTemporaryFile` — nothing here has ever opened a save dialog. So `uxp.storage.localFileSystem.getFileForSaving` is unverified in Photoshop UXP, and it is the one part of Layer Tools that no test in this repo can reach.

## What it does

A temporary **Spike: Save Picker** button in Settings (next to Copy Diagnostics) writes a generated 64×64 magenta PNG with a black border through the save dialog, and reports the outcome on the diagnostics line so you can copy the text rather than retype it from a screenshot.

It writes a *generated* image rather than a captured layer on purpose — the capture paths are already proven by generation, so mixing them in would mean a failure could not be attributed to one half or the other.

## What each result means

| Report | Meaning |
|---|---|
| `saved` | The dialog works. Layer Tools can offer "save as". |
| `cancelled` | Cancel returns null instead of throwing — Layer Tools can tell cancel from failure. |
| `unsupported` | This UXP build has no such API. Layer Tools cannot offer a chosen save location, and its whole shape changes. |
| `failed (picker)` | The dialog itself failed — most likely it needs `executeAsModal`, which the spike deliberately does not use. |
| `failed (write)` | The dialog returned a file but the write failed. |

## Validation

`typecheck`, `test` (49 files / 406), `lint`, `build` all green. Verified in the browser preview that the panel still boots with the new element and that clicking reports `unsupported` cleanly rather than crashing.

One deliberate change worth your eye: adding the button moved the frozen busy-table count from **29 to 30** in `toolDescriptors.test.ts`. That is the inventory freeze doing its job; deleting the spike takes it back to 29, and the test carries a comment saying so.

## Smoke checklist

1. Build, load `dist/manifest.json` in UXP Developer Tool, open OpenLayer.
2. Go to **Settings** and click **Spike: Save Picker**.
3. **Does a real OS save dialog appear?** Note the folder it defaults to and whether the filename is pre-filled as `OpenLayer_SavePickerSpike.png`.
4. Press **Cancel** → the diagnostics line should say the dialog was cancelled and that UXP reported it instead of throwing.
5. Click it again, pick your Desktop, and **Save** → the diagnostics line should report bytes written. Open the file: it must be a 64×64 magenta square with a black border.
6. Try saving into a folder you would not normally have rights to (e.g. `C:\Program Files\`) and paste whatever the diagnostics line says, success or failure.
7. Start a generation and confirm the spike button is disabled while it runs.

**Paste the diagnostics text for steps 4, 5 and 6 verbatim** — the exact wording decides how Layer Tools handles each case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)