### PR TITLE
Implement the layer and selection PNG export primitives

### DIFF
--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -136,6 +136,14 @@ const INPAINT_CONTEXT_MULTIPLE = 8;
 // captures can exhaust UXP panel memory before the upload even starts.
 export const MAX_CAPTURE_PIXELS = 4096 * 4096;
 
+// Inpaint was the only caller that could hit this, so its phrasing is the
+// default and must stay byte-identical -- a test pins the exact sentence.
+export const DEFAULT_SELECTION_REQUESTER = "using Inpaint";
+
+export function createNoSelectionMessage(requestedBy: string = DEFAULT_SELECTION_REQUESTER) {
+  return `No active Photoshop selection was found. Make a selection before ${requestedBy}.`;
+}
+
 export function assertCaptureSizeWithinLimit(width: number, height: number) {
   if (width * height > MAX_CAPTURE_PIXELS) {
     throw createOpenLayerError(
@@ -812,7 +820,7 @@ export async function exportSelectionAsPNG(): Promise<ExportedSourceImage> {
     const capturedSource = await photoshop.core.executeAsModal(
       async () => {
         const document = getActiveDocument();
-        const selection = await readActiveSelectionInfo(photoshop, document);
+        const selection = await readActiveSelectionInfo(photoshop, document, "exporting a selection");
 
         if (typeof document.id !== "number") {
           throw createOpenLayerError(
@@ -864,7 +872,7 @@ export async function exportSelectionMask(): Promise<SelectionMaskExport> {
     const capturedMask = await photoshop.core.executeAsModal(
       async () => {
         const document = getActiveDocument();
-        const selection = await readActiveSelectionInfo(photoshop, document);
+        const selection = await readActiveSelectionInfo(photoshop, document, "exporting a selection mask");
 
         return {
           selection,
@@ -1103,9 +1111,15 @@ export async function preserveSelection<T>(_operation: PreserveSelectionOperatio
   );
 }
 
+// The caller names itself so the no-selection message can say what the artist
+// was actually doing. This helper predates any use outside Inpaint, so its
+// message hard-coded "before using Inpaint" -- which reads as a non sequitur
+// when the artist pressed Export Selection. Inpaint's wording is the default
+// so its behavior is unchanged.
 async function readActiveSelectionInfo(
   photoshop: PhotoshopModule,
-  document: PhotoshopDocument
+  document: PhotoshopDocument,
+  requestedBy = DEFAULT_SELECTION_REQUESTER
 ): Promise<ActiveSelectionInfo> {
   const selectionDescriptor = await getSelectionDescriptor(photoshop);
   const bounds = readSelectionBounds(selectionDescriptor);
@@ -1113,7 +1127,7 @@ async function readActiveSelectionInfo(
   if (!bounds) {
     throw createOpenLayerError(
       "PHOTOSHOP_NO_SELECTION",
-      "No active Photoshop selection was found. Make a selection before using Inpaint."
+      createNoSelectionMessage(requestedBy)
     );
   }
 

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -750,20 +750,110 @@ export async function importImageAlignedToSelectionWithLayerMask(
   }
 }
 
-export async function exportActiveLayerAsPNG(): Promise<Blob> {
-  // TODO(v0.4): Use this for mask-aware inpainting when selected-layer PNG export is fully verified.
-  throw createOpenLayerError(
-    "PHOTOSHOP_EXPORT_FAILED",
-    "Dedicated selected-layer PNG file export is planned for a future OpenLayer inpainting release. Current Image to Image and Sketch capture already encode source pixels as PNG through the Imaging API path."
-  );
+// Captures the active layer's pixels and returns the full source image so its
+// originating Photoshop document remains bound to the PNG instead of being lost with a bare Blob.
+export async function exportActiveLayerAsPNG(): Promise<ExportedSourceImage> {
+  const photoshop = getPhotoshop();
+  const imaging = getImagingApi(photoshop);
+
+  try {
+    const capturedSource = await photoshop.core.executeAsModal(
+      async () => {
+        const document = getActiveDocument();
+        const activeLayer = document.activeLayers?.[0];
+
+        if (!activeLayer) {
+          throw createOpenLayerError(
+            "PHOTOSHOP_EXPORT_FAILED",
+            "No active Photoshop layer was found. Select a pixel or smart object layer before exporting."
+          );
+        }
+
+        if (typeof document.id !== "number" || typeof activeLayer.id !== "number") {
+          throw createOpenLayerError(
+            "PHOTOSHOP_EXPORT_FAILED",
+            "Photoshop did not expose a stable document or layer ID for the active layer.",
+            "Active layer export needs document.id and activeLayer.id."
+          );
+        }
+
+        return captureSourceImage(imaging, {
+          pixelOptions: {
+            documentID: document.id,
+            layerID: activeLayer.id,
+            componentSize: 8,
+            colorSpace: "RGB",
+            applyAlpha: false
+          },
+          filenamePrefix: "OpenLayer_Layer",
+          sourceName: activeLayer.name || "Active layer",
+          originatingDocument: readDocumentIdentity(document)
+        });
+      },
+      { commandName: "Export OpenLayer Active Layer" }
+    );
+
+    return createExportedSourceImage(capturedSource);
+  } catch (caughtError) {
+    throw createOpenLayerError(
+      "PHOTOSHOP_EXPORT_FAILED",
+      `Could not export the active Photoshop layer. ${getErrorMessage(caughtError)}`
+    );
+  }
 }
 
-export async function exportSelectionAsPNG(): Promise<Blob> {
-  // TODO(v0.5): Export selected pixels as a standalone PNG when this path is verified separately.
-  throw createOpenLayerError(
-    "PHOTOSHOP_EXPORT_FAILED",
-    "Dedicated selected-pixels PNG export is planned for a future OpenLayer inpainting release. The current Inpaint foundation captures selection bounds as a PNG source image."
-  );
+// Captures the current selection's pixels and returns the full source image so its
+// originating Photoshop document remains bound to the PNG instead of being lost with a bare Blob.
+export async function exportSelectionAsPNG(): Promise<ExportedSourceImage> {
+  const photoshop = getPhotoshop();
+  const imaging = getImagingApi(photoshop);
+
+  try {
+    const capturedSource = await photoshop.core.executeAsModal(
+      async () => {
+        const document = getActiveDocument();
+        const selection = await readActiveSelectionInfo(photoshop, document);
+
+        if (typeof document.id !== "number") {
+          throw createOpenLayerError(
+            "PHOTOSHOP_EXPORT_FAILED",
+            "Photoshop did not expose a stable document ID for the active document.",
+            "Selection export needs document.id."
+          );
+        }
+
+        return captureSourceImage(imaging, {
+          pixelOptions: {
+            documentID: document.id,
+            sourceBounds: {
+              left: selection.bounds.left,
+              top: selection.bounds.top,
+              right: selection.bounds.right,
+              bottom: selection.bounds.bottom
+            },
+            componentSize: 8,
+            colorSpace: "RGB",
+            applyAlpha: false
+          },
+          filenamePrefix: "OpenLayer_Selection",
+          sourceName: `Selection from ${selection.documentName}`,
+          originatingDocument: selection.originatingDocument
+        });
+      },
+      { commandName: "Export OpenLayer Selection" }
+    );
+
+    return createExportedSourceImage(capturedSource);
+  } catch (caughtError) {
+    if (isOpenLayerNoSelectionError(caughtError)) {
+      throw caughtError;
+    }
+
+    throw createOpenLayerError(
+      "PHOTOSHOP_EXPORT_FAILED",
+      `Could not export the active Photoshop selection. ${getErrorMessage(caughtError)}`
+    );
+  }
 }
 
 export async function exportSelectionMask(): Promise<SelectionMaskExport> {

--- a/tests/photoshop/noSelectionMessage.test.ts
+++ b/tests/photoshop/noSelectionMessage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createNoSelectionMessage,
+  DEFAULT_SELECTION_REQUESTER
+} from "../../src/photoshop/photoshopAdapter";
+
+// readActiveSelectionInfo needs Photoshop and cannot be tested here. Its
+// no-selection message can, and it is worth pinning: the sentence was
+// hard-coded for Inpaint, and parameterising it for the new export paths is
+// exactly the kind of change that silently rewords an error a user already
+// knows.
+describe("no-selection message", () => {
+  it("keeps Inpaint's original sentence when no caller is named", () => {
+    expect(createNoSelectionMessage()).toBe(
+      "No active Photoshop selection was found. Make a selection before using Inpaint."
+    );
+    expect(DEFAULT_SELECTION_REQUESTER).toBe("using Inpaint");
+  });
+
+  it("names the caller so the message matches what the artist did", () => {
+    expect(createNoSelectionMessage("exporting a selection")).toBe(
+      "No active Photoshop selection was found. Make a selection before exporting a selection."
+    );
+    expect(createNoSelectionMessage("exporting a selection mask")).toBe(
+      "No active Photoshop selection was found. Make a selection before exporting a selection mask."
+    );
+  });
+
+  it("never leaves the sentence without its trailing period", () => {
+    expect(createNoSelectionMessage("doing something")).toMatch(/\.$/);
+  });
+});


### PR DESCRIPTION
First task of the Layer Tools foundation. **Two commits, two authors** — Codex implemented, I reviewed and fixed what the review found.

## What this does

`exportActiveLayerAsPNG` and `exportSelectionAsPNG` in `src/photoshop/photoshopAdapter.ts` have thrown since they were written, behind TODOs naming **v0.4** and **v0.5**. We are at v0.8.1. Both are now implemented on capture machinery that has existed for several releases — nothing was ever missing except the functions themselves.

`exportSelectionMask` was already fully implemented and completely dead; it gains its first correctness fix here and gets its caller in the next task.

## Commits

- `e8ecc76` — **Codex**: both implementations.
- `c90a7dd` — **my review pass**: the no-selection message defect below, plus its test.

## Three decisions worth your eye

**Both return `ExportedSourceImage`, not a bare `Blob`.** A `Blob` carries no record of which document it came from, and every image here is bound to its originating document — the invariant that stops a result landing in the wrong file. Zero existing callers, so widening the type costs nothing now and would have hurt later.

**The selection export captures `selection.bounds`, not the `contextBounds` the Inpaint path uses.** Codex diverged from its sibling deliberately and correctly: `contextBounds` pads the selection and snaps it to a multiple because the inpaint *model* needs surrounding context. An artist exporting a selection expects the pixels they selected and nothing else. I verified this rather than taking it on trust.

**The 16-megapixel capture limit applies to both without being restated**, because `encodeSourceImageDataAsPng` asserts it on the way through.

## What the review caught

`exportSelectionAsPNG` reuses `readActiveSelectionInfo`, whose no-selection error has always ended **"Make a selection before using Inpaint."** Correct while Inpaint was the only caller; a non sequitur when the artist pressed Export Selection and gets told about a tool they were not using. The caller now names itself, Inpaint's wording stays the default, and a test pins the exact legacy sentence. `exportSelectionMask` is retargeted too — leaving it would plant the same defect for the next task.

## Scope

Capture paths only. **No import path, no `photoshopTransaction.ts`, no `src/ui/**` was touched** — the brief forbade it and I verified the diff against that. Capture is read-only; the import side carries the mask-ordering and transactional-cleanup invariants and stays untouched.

## Validation

`typecheck`, `test` (49 files / 404), `lint`, `build` — all green, run by me, not taken from the report.

## Smoke checklist

**There is no UI for these yet** — that is the next task. So this PR is a regression check: nothing should behave differently, because nothing calls the new code.

1. Build and load `dist/manifest.json` in UXP Developer Tool.
2. **Inpaint, no selection**: open a document, make sure nothing is selected, go to Inpaint and press **Capture Selection**. The message must still read exactly *"No active Photoshop selection was found. Make a selection before using Inpaint."* — unchanged wording is the point.
3. **Inpaint, with a selection**: make a rectangular selection, Capture Selection, and confirm the source and mask preview exactly as before.
4. Run one **Image to Image** generation end to end and confirm capture and import are unaffected.
5. Run one **Inpaint** generation end to end on a duplicate layer and confirm the masked result still lands aligned.

Steps 4 and 5 exist because this commit edited a helper shared with those paths, even though the intent was additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)