### PR TITLE
Keep each tool's diagnostics and errors on its own screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased / v0.9.0-alpha draft
+
+Section in progress. The Layer Tools screen and the rest of the v0.9 notes are written at release time; this entry is here because it closes a limitation the last two releases published.
+
+### Fixed
+
+- Fixed one tool's diagnostics and error text appearing on the other tools' screens, the last part of the v0.7 status bleed. `setDiagnostics` wrote all eight diagnostics lines and `setError` wrote both the Text to Image and the Settings error line, because Text to Image owns the unprefixed elements from when it was the only tool in the panel — so "Generate pressed at 09:14:22.", "Seed used: 12345." and "Enter a prompt before generating." were broadcast to Inpaint, Upscale, Outpaint, Sketch to Image, Image to Image and Prompt from Layer. Each tool now writes its own diagnostics line plus the Settings line, which stays the panel-wide log, and keeps its errors to its own screen. Panel-wide diagnostics — the port scan, the GPU report, workflow health — report on Settings, where they are actionable. One visible consequence: each tool screen now keeps its opening hint ("Capture a Photoshop selection to prepare inpainting.") until that tool is actually used, instead of losing it to the first unrelated message.
+
 ## v0.8.1-alpha - 2026-07-27
 
 A small follow-up to v0.8.0 carrying two changes that missed that tag. The reason it exists as its own release rather than waiting for v0.9 is the first entry below: the separated Preview panel gained its Import buttons the day after v0.8.0 shipped, and handing testers a build without them would spend a round of feedback on the panel's least finished state.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Known v0.8.1-alpha boundaries:
 - The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the requirements list and a downloader instead. An internet connection is required.
 - Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
 - CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
-- The status fix covers the status bars only. The diagnostics line and the error text still mirror across tools, and that fix is deferred.
+- Panel-wide diagnostics such as the port scan, the GPU report, and workflow health are reported on the Settings screen rather than on every tool screen. Each tool's own diagnostics line also mirrors to Settings, which is the panel-wide log.
 - Progress is no longer pinned while a tool's form is scrolled, which is the accepted cost of taking the progress bar out of the sticky header.
 - The 0.8 releases focus on correctness and maintainability. Existing generation capabilities should remain compatible with v0.7.0.
 - The Preview panel offers each tool's primary import only. Live Painting's "Import Refined as Layer" stays on the dashboard.

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -251,6 +251,8 @@ import {
   setSketchError,
   setSketchStatus,
   setStatusProgress,
+  setTextToImageDiagnostics,
+  setTextToImageError,
   setTextToImageStatus,
   setUpscaleDiagnostics,
   setUpscaleError,
@@ -1182,7 +1184,7 @@ export function renderApp(rootElement: HTMLElement) {
   function handleToggleAutoImport() {
     importAutomatically = !importAutomatically;
     updateAutoImportToggle(elements, importAutomatically);
-    setGlobalDiagnostics(elements, importAutomatically ? "Auto import is on." : "Auto import is off.");
+    setTextToImageDiagnostics(elements, importAutomatically ? "Auto import is on." : "Auto import is off.");
     syncImportBridge();
   }
 
@@ -1233,7 +1235,7 @@ export function renderApp(rootElement: HTMLElement) {
     error: (elements: AppElements, message: string) => void;
     progress?: (elements: AppElements, message: string, blob?: Blob) => void;
   }> = {
-    "text-to-image": { status: setTextToImageStatus, diagnostics: setGlobalDiagnostics, error: setGlobalError, progress: setProgressPreview },
+    "text-to-image": { status: setTextToImageStatus, diagnostics: setTextToImageDiagnostics, error: setTextToImageError, progress: setProgressPreview },
     "image-to-image": { status: setImageStatus, diagnostics: setImageDiagnostics, error: setImageError, progress: setImageProgressPreview },
     "sketch-to-image": { status: setSketchStatus, diagnostics: setSketchDiagnostics, error: setSketchError, progress: setSketchProgressPreview },
     inpaint: { status: setInpaintStatus, diagnostics: setInpaintDiagnostics, error: setInpaintError, progress: setInpaintProgressPreview },
@@ -1309,15 +1311,15 @@ export function renderApp(rootElement: HTMLElement) {
       return;
     }
 
-    setGlobalDiagnostics(elements, `Generate pressed at ${new Date().toLocaleTimeString()}.`);
+    setTextToImageDiagnostics(elements, `Generate pressed at ${new Date().toLocaleTimeString()}.`);
 
     if (!elements.prompt.value.trim()) {
-      setGlobalError(elements, getErrorMessage(createOpenLayerError("PROMPT_REQUIRED", "Enter a prompt before generating.")));
+      setTextToImageError(elements, getErrorMessage(createOpenLayerError("PROMPT_REQUIRED", "Enter a prompt before generating.")));
       setTextToImageStatus(elements, "Prompt required.", "error");
       return;
     }
 
-    setGlobalError(elements, "");
+    setTextToImageError(elements, "");
     setResult(null);
     busyTool = "text-to-image";
     isBusy = true;
@@ -1341,7 +1343,7 @@ export function renderApp(rootElement: HTMLElement) {
       const client = new ComfyClient(elements.serverUrl.value);
 
       applyValidatedSettings(elements, settings);
-      setGlobalDiagnostics(elements, warnings.length > 0 ? warnings.join(" ") : createWorkflowDiagnostics(preset, checkpointName));
+      setTextToImageDiagnostics(elements, warnings.length > 0 ? warnings.join(" ") : createWorkflowDiagnostics(preset, checkpointName));
       await client.checkOnline();
 
       if (!checkpointName) {
@@ -1351,7 +1353,7 @@ export function renderApp(rootElement: HTMLElement) {
       const compatibility = getCheckpointCompatibility(checkpointName, preset);
 
       if (compatibility.isExperimental) {
-        setGlobalDiagnostics(elements, `${compatibility.label} ${compatibility.warning}`);
+        setTextToImageDiagnostics(elements, `${compatibility.label} ${compatibility.warning}`);
       }
 
       setTextToImageStatus(elements, "Checking selected checkpoint...", "idle");
@@ -1416,11 +1418,11 @@ export function renderApp(rootElement: HTMLElement) {
 
       if (importAutomatically) {
         setTextToImageStatus(elements, "Generation complete. Auto-importing...", "idle");
-        setGlobalDiagnostics(elements, `Seed used: ${buildResult.seed}. Auto import is on.`);
+        setTextToImageDiagnostics(elements, `Seed used: ${buildResult.seed}. Auto import is on.`);
         await handleImport("auto");
       } else {
         setTextToImageStatus(elements, "Generation complete.", "ready");
-        setGlobalDiagnostics(elements, `Seed used: ${buildResult.seed}. Workflow: ${buildResult.preset.id}.`);
+        setTextToImageDiagnostics(elements, `Seed used: ${buildResult.seed}. Workflow: ${buildResult.preset.id}.`);
       }
 
       savePreferencesFromElements(elements, { seed: requestedSeed });
@@ -1432,8 +1434,8 @@ export function renderApp(rootElement: HTMLElement) {
       }
 
       setTextToImageStatus(elements, "Generation failed.", "error");
-      setGlobalError(elements, getErrorMessage(caughtError));
-      setGlobalDiagnostics(elements, getTechnicalErrorDetails(caughtError));
+      setTextToImageError(elements, getErrorMessage(caughtError));
+      setTextToImageDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
       busyTool = null;
@@ -1479,7 +1481,7 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   function loadHistoryResultIntoTool(entry: HistoryEntry) {
-    setGlobalError(elements, "");
+    setTextToImageError(elements, "");
     setImageError(elements, "");
     setSketchError(elements, "");
     setInpaintError(elements, "");
@@ -1591,14 +1593,14 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleImport(source: "manual" | "auto" = "manual") {
-    setGlobalDiagnostics(elements, source === "auto" ? "Auto import started." : "Import pressed.");
+    setTextToImageDiagnostics(elements, source === "auto" ? "Auto import started." : "Import pressed.");
 
     if (!result) {
-      setGlobalError(elements, "Generate an image before importing.");
+      setTextToImageError(elements, "Generate an image before importing.");
       return;
     }
 
-    setGlobalError(elements, "");
+    setTextToImageError(elements, "");
     busyTool = "text-to-image";
     isBusy = true;
     syncBusy();
@@ -1607,26 +1609,26 @@ export function renderApp(rootElement: HTMLElement) {
     try {
       const layerName = createLayerName("OpenLayer_Generated");
 
-      setGlobalDiagnostics(elements, `Importing into ${result.originatingDocument?.name || "the originating document"}...`);
+      setTextToImageDiagnostics(elements, `Importing into ${result.originatingDocument?.name || "the originating document"}...`);
       const importedLayerName = await importGeneratedImageAsLayer({
         blob: result.blob,
         originatingDocument: result.originatingDocument,
         layerName,
         onProgress: (message) => {
           setTextToImageStatus(elements, message, "idle");
-          setGlobalDiagnostics(elements, message);
+          setTextToImageDiagnostics(elements, message);
         }
       });
       setTextToImageStatus(elements, `Imported layer: ${importedLayerName}`, "ready");
       flashImported(elements.statusText);
       markHistoryImported(elements, historyEntries, result, importedLayerName);
       const metadataMessage = await writeMetadataForImportedResult(historyEntries, result, importedLayerName, (message) => {
-        setGlobalDiagnostics(elements, message);
+        setTextToImageDiagnostics(elements, message);
       });
-      setGlobalDiagnostics(elements, `Layer created: ${importedLayerName}. ${metadataMessage}`);
+      setTextToImageDiagnostics(elements, `Layer created: ${importedLayerName}. ${metadataMessage}`);
     } catch (caughtError) {
       setTextToImageStatus(elements, "Import failed.", "error");
-      setGlobalError(elements, getErrorMessage(caughtError));
+      setTextToImageError(elements, getErrorMessage(caughtError));
     } finally {
       isBusy = false;
       busyTool = null;
@@ -3949,7 +3951,7 @@ function updateTextCheckpointCompatibility(elements: AppElements) {
     const checkpointName = readSelectValue(elements.checkpoint);
     const message = createWorkflowDiagnosticMessage(preset, { selectedModelName: checkpointName });
 
-    setGlobalDiagnostics(elements, formatWorkflowDiagnosticMessage(message));
+    setTextToImageDiagnostics(elements, formatWorkflowDiagnosticMessage(message));
     updateSettingsReport(elements);
   } catch {
     // Selection-change diagnostics should never break the panel.

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -231,8 +231,8 @@ import { AppElements, createAppMarkup, getAppElements } from "./appMarkup";
 import {
   applyDeterminateProgress,
   flashImported,
-  setDiagnostics,
-  setError,
+  setGlobalDiagnostics,
+  setGlobalError,
   setGlobalStatus,
   setImageDiagnostics,
   setImageError,
@@ -836,12 +836,12 @@ export function renderApp(rootElement: HTMLElement) {
     applyTheme(elements, readThemeSelection(elements));
     savePreferencesFromElements(elements);
     updateSettingsReport(elements);
-    setDiagnostics(elements, `Panel theme set to ${getThemeLabel(readThemeSelection(elements))}.`);
+    setGlobalDiagnostics(elements, `Panel theme set to ${getThemeLabel(readThemeSelection(elements))}.`);
   });
 
   setGlobalStatus(elements, "Ready.", "idle");
   setView(currentView);
-  setError(elements, "");
+  setGlobalError(elements, "");
   syncBusy();
   updateNegativePromptDisclosure(elements, isNegativePromptOpen);
   updateAutoImportToggle(elements, importAutomatically);
@@ -958,14 +958,14 @@ export function renderApp(rootElement: HTMLElement) {
       updateSettingsReport(elements);
     } catch (caughtError) {
       setGlobalStatus(elements, "Ready.", "idle");
-      setError(elements, `Using fallback model list. ${getErrorMessage(caughtError)}`);
+      setGlobalError(elements, `Using fallback model list. ${getErrorMessage(caughtError)}`);
       updateSettingsReport(elements);
     }
   }
 
   async function handleCheckComfy() {
-    setDiagnostics(elements, "Check ComfyUI pressed.");
-    setError(elements, "");
+    setGlobalDiagnostics(elements, "Check ComfyUI pressed.");
+    setGlobalError(elements, "");
     setGlobalStatus(elements, "Checking ComfyUI...", "idle");
 
     try {
@@ -987,23 +987,23 @@ export function renderApp(rootElement: HTMLElement) {
       updateSettingsReport(elements);
     } catch (caughtError) {
       setGlobalStatus(elements, "ComfyUI check failed.", "error");
-      setError(elements, getErrorMessage(caughtError));
+      setGlobalError(elements, getErrorMessage(caughtError));
       updateSettingsReport(elements);
     }
   }
 
   async function handleFindComfyPort() {
-    setDiagnostics(elements, "Scanning common local ComfyUI ports...");
-    setError(elements, "");
+    setGlobalDiagnostics(elements, "Scanning common local ComfyUI ports...");
+    setGlobalError(elements, "");
     setGlobalStatus(elements, "Looking for ComfyUI...", "idle");
 
     const foundUrl = await findActiveComfyUrl(elements.serverUrl.value, (message) => {
-      setDiagnostics(elements, message);
+      setGlobalDiagnostics(elements, message);
     });
 
     if (!foundUrl) {
       setGlobalStatus(elements, "No active ComfyUI port found.", "error");
-      setError(elements, "OpenLayer could not find ComfyUI on the common local ports. Start ComfyUI and try again.");
+      setGlobalError(elements, "OpenLayer could not find ComfyUI on the common local ports. Start ComfyUI and try again.");
       updateSettingsReport(elements);
       return;
     }
@@ -1025,18 +1025,18 @@ export function renderApp(rootElement: HTMLElement) {
       updateUpscaleCompatibility(elements, upscaleSource);
       savePreferencesFromElements(elements);
       setGlobalStatus(elements, `Found ComfyUI at ${foundUrl}.`, "ready");
-      setDiagnostics(elements, `Active ComfyUI server selected: ${foundUrl}.`);
+      setGlobalDiagnostics(elements, `Active ComfyUI server selected: ${foundUrl}.`);
     } catch (caughtError) {
       setGlobalStatus(elements, `Found ${foundUrl}, but model loading failed.`, "error");
-      setError(elements, getErrorMessage(caughtError));
+      setGlobalError(elements, getErrorMessage(caughtError));
     } finally {
       updateSettingsReport(elements);
     }
   }
 
   async function handleDetectHardware() {
-    setDiagnostics(elements, "Detecting GPU and installed model families through ComfyUI...");
-    setError(elements, "");
+    setGlobalDiagnostics(elements, "Detecting GPU and installed model families through ComfyUI...");
+    setGlobalError(elements, "");
     setGlobalStatus(elements, "Detecting GPU...", "idle");
 
     try {
@@ -1047,21 +1047,21 @@ export function renderApp(rootElement: HTMLElement) {
 
       renderHardwareReport(elements, hardwareReport);
       setGlobalStatus(elements, "GPU recommendations ready.", "ready");
-      setDiagnostics(elements, formatHardwareReport(hardwareReport));
+      setGlobalDiagnostics(elements, formatHardwareReport(hardwareReport));
     } catch (caughtError) {
       hardwareReport = null;
       renderHardwareReport(elements, hardwareReport);
       setGlobalStatus(elements, "GPU detection failed.", "error");
-      setError(elements, getErrorMessage(caughtError));
-      setDiagnostics(elements, "Start ComfyUI, confirm the server URL, then run Detect GPU & Recommend Models again.");
+      setGlobalError(elements, getErrorMessage(caughtError));
+      setGlobalDiagnostics(elements, "Start ComfyUI, confirm the server URL, then run Detect GPU & Recommend Models again.");
     } finally {
       updateSettingsReport(elements);
     }
   }
 
   async function handleCheckWorkflowHealth() {
-    setDiagnostics(elements, "Checking workflow health against local ComfyUI...");
-    setError(elements, "");
+    setGlobalDiagnostics(elements, "Checking workflow health against local ComfyUI...");
+    setGlobalError(elements, "");
     setGlobalStatus(elements, "Checking workflow health...", "idle");
 
     try {
@@ -1078,13 +1078,13 @@ export function renderApp(rootElement: HTMLElement) {
       workflowHealthReport = report;
       renderWorkflowHealthReport(elements, workflowHealthReport);
       setGlobalStatus(elements, "Workflow health checked.", report.issueCount > 0 ? "idle" : "ready");
-      setDiagnostics(elements, report.summary);
+      setGlobalDiagnostics(elements, report.summary);
     } catch (caughtError) {
       workflowHealthReport = null;
       renderWorkflowHealthReport(elements, workflowHealthReport);
       setGlobalStatus(elements, "Workflow health check failed.", "error");
-      setError(elements, getErrorMessage(caughtError));
-      setDiagnostics(elements, "Start ComfyUI, confirm the server URL, then run Check Workflow Health again.");
+      setGlobalError(elements, getErrorMessage(caughtError));
+      setGlobalDiagnostics(elements, "Start ComfyUI, confirm the server URL, then run Check Workflow Health again.");
     } finally {
       updateSettingsReport(elements);
     }
@@ -1106,10 +1106,10 @@ export function renderApp(rootElement: HTMLElement) {
 
       await clipboard.writeText(reportText);
       setGlobalStatus(elements, "Diagnostics copied.", "ready");
-      setDiagnostics(elements, "Copied a compact OpenLayer diagnostics report to the clipboard.");
+      setGlobalDiagnostics(elements, "Copied a compact OpenLayer diagnostics report to the clipboard.");
     } catch {
       setGlobalStatus(elements, "Diagnostics ready to copy.", "ready");
-      setDiagnostics(elements, "Clipboard is unavailable here. The diagnostics report is shown below for manual copy.");
+      setGlobalDiagnostics(elements, "Clipboard is unavailable here. The diagnostics report is shown below for manual copy.");
     }
   }
 
@@ -1147,7 +1147,7 @@ export function renderApp(rootElement: HTMLElement) {
     const wasSaved = savePreferencesFromElements(elements);
     updateSettingsReport(elements);
     setGlobalStatus(elements, wasSaved ? "Settings saved." : "Settings are active for this session.", "ready");
-    setDiagnostics(
+    setGlobalDiagnostics(
       elements,
       wasSaved
         ? "Saved ComfyUI URL, checkpoint, generation defaults, and panel theme."
@@ -1168,9 +1168,9 @@ export function renderApp(rootElement: HTMLElement) {
     elements.upscaleWorkflow.value = DEFAULT_UPSCALE_WORKFLOW;
     fillSingleCheckpointSelect(elements.upscaleModel, FALLBACK_UPSCALE_MODELS, FALLBACK_UPSCALE_MODELS[0]);
     updateUpscaleCompatibility(elements, upscaleSource);
-    setError(elements, "");
+    setGlobalError(elements, "");
     setGlobalStatus(elements, "Settings reset to OpenLayer defaults.", "ready");
-    setDiagnostics(elements, "Defaults restored. Click Check ComfyUI to reload available models.");
+    setGlobalDiagnostics(elements, "Defaults restored. Click Check ComfyUI to reload available models.");
     updateSettingsReport(elements);
   }
 
@@ -1182,7 +1182,7 @@ export function renderApp(rootElement: HTMLElement) {
   function handleToggleAutoImport() {
     importAutomatically = !importAutomatically;
     updateAutoImportToggle(elements, importAutomatically);
-    setDiagnostics(elements, importAutomatically ? "Auto import is on." : "Auto import is off.");
+    setGlobalDiagnostics(elements, importAutomatically ? "Auto import is on." : "Auto import is off.");
     syncImportBridge();
   }
 
@@ -1233,7 +1233,7 @@ export function renderApp(rootElement: HTMLElement) {
     error: (elements: AppElements, message: string) => void;
     progress?: (elements: AppElements, message: string, blob?: Blob) => void;
   }> = {
-    "text-to-image": { status: setTextToImageStatus, diagnostics: setDiagnostics, error: setError, progress: setProgressPreview },
+    "text-to-image": { status: setTextToImageStatus, diagnostics: setGlobalDiagnostics, error: setGlobalError, progress: setProgressPreview },
     "image-to-image": { status: setImageStatus, diagnostics: setImageDiagnostics, error: setImageError, progress: setImageProgressPreview },
     "sketch-to-image": { status: setSketchStatus, diagnostics: setSketchDiagnostics, error: setSketchError, progress: setSketchProgressPreview },
     inpaint: { status: setInpaintStatus, diagnostics: setInpaintDiagnostics, error: setInpaintError, progress: setInpaintProgressPreview },
@@ -1269,7 +1269,7 @@ export function renderApp(rootElement: HTMLElement) {
     const active = generation.cancelActive();
 
     if (!active) {
-      setDiagnostics(elements, "No active generation to cancel.");
+      setGlobalDiagnostics(elements, "No active generation to cancel.");
       return;
     }
 
@@ -1309,15 +1309,15 @@ export function renderApp(rootElement: HTMLElement) {
       return;
     }
 
-    setDiagnostics(elements, `Generate pressed at ${new Date().toLocaleTimeString()}.`);
+    setGlobalDiagnostics(elements, `Generate pressed at ${new Date().toLocaleTimeString()}.`);
 
     if (!elements.prompt.value.trim()) {
-      setError(elements, getErrorMessage(createOpenLayerError("PROMPT_REQUIRED", "Enter a prompt before generating.")));
+      setGlobalError(elements, getErrorMessage(createOpenLayerError("PROMPT_REQUIRED", "Enter a prompt before generating.")));
       setTextToImageStatus(elements, "Prompt required.", "error");
       return;
     }
 
-    setError(elements, "");
+    setGlobalError(elements, "");
     setResult(null);
     busyTool = "text-to-image";
     isBusy = true;
@@ -1341,7 +1341,7 @@ export function renderApp(rootElement: HTMLElement) {
       const client = new ComfyClient(elements.serverUrl.value);
 
       applyValidatedSettings(elements, settings);
-      setDiagnostics(elements, warnings.length > 0 ? warnings.join(" ") : createWorkflowDiagnostics(preset, checkpointName));
+      setGlobalDiagnostics(elements, warnings.length > 0 ? warnings.join(" ") : createWorkflowDiagnostics(preset, checkpointName));
       await client.checkOnline();
 
       if (!checkpointName) {
@@ -1351,7 +1351,7 @@ export function renderApp(rootElement: HTMLElement) {
       const compatibility = getCheckpointCompatibility(checkpointName, preset);
 
       if (compatibility.isExperimental) {
-        setDiagnostics(elements, `${compatibility.label} ${compatibility.warning}`);
+        setGlobalDiagnostics(elements, `${compatibility.label} ${compatibility.warning}`);
       }
 
       setTextToImageStatus(elements, "Checking selected checkpoint...", "idle");
@@ -1416,11 +1416,11 @@ export function renderApp(rootElement: HTMLElement) {
 
       if (importAutomatically) {
         setTextToImageStatus(elements, "Generation complete. Auto-importing...", "idle");
-        setDiagnostics(elements, `Seed used: ${buildResult.seed}. Auto import is on.`);
+        setGlobalDiagnostics(elements, `Seed used: ${buildResult.seed}. Auto import is on.`);
         await handleImport("auto");
       } else {
         setTextToImageStatus(elements, "Generation complete.", "ready");
-        setDiagnostics(elements, `Seed used: ${buildResult.seed}. Workflow: ${buildResult.preset.id}.`);
+        setGlobalDiagnostics(elements, `Seed used: ${buildResult.seed}. Workflow: ${buildResult.preset.id}.`);
       }
 
       savePreferencesFromElements(elements, { seed: requestedSeed });
@@ -1432,8 +1432,8 @@ export function renderApp(rootElement: HTMLElement) {
       }
 
       setTextToImageStatus(elements, "Generation failed.", "error");
-      setError(elements, getErrorMessage(caughtError));
-      setDiagnostics(elements, getTechnicalErrorDetails(caughtError));
+      setGlobalError(elements, getErrorMessage(caughtError));
+      setGlobalDiagnostics(elements, getTechnicalErrorDetails(caughtError));
     } finally {
       isBusy = false;
       busyTool = null;
@@ -1445,12 +1445,12 @@ export function renderApp(rootElement: HTMLElement) {
     clearHistoryEntries(historyEntries, objectUrls);
     renderHistory(elements, historyEntries);
     setGlobalStatus(elements, "History cleared.", "ready");
-    setDiagnostics(elements, "Recent session history cleared.");
+    setGlobalDiagnostics(elements, "Recent session history cleared.");
   }
 
   function handleHistoryAction(action: HistoryActionName, historyId: string) {
     if (isBusy && action !== "preview") {
-      setDiagnostics(elements, "Finish the current operation before using history.");
+      setGlobalDiagnostics(elements, "Finish the current operation before using history.");
       return;
     }
 
@@ -1458,7 +1458,7 @@ export function renderApp(rootElement: HTMLElement) {
 
     if (!entry) {
       setGlobalStatus(elements, "History item not found.", "error");
-      setError(elements, "That history item is no longer available in this session.");
+      setGlobalError(elements, "That history item is no longer available in this session.");
       return;
     }
 
@@ -1479,7 +1479,7 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   function loadHistoryResultIntoTool(entry: HistoryEntry) {
-    setError(elements, "");
+    setGlobalError(elements, "");
     setImageError(elements, "");
     setSketchError(elements, "");
     setInpaintError(elements, "");
@@ -1591,14 +1591,14 @@ export function renderApp(rootElement: HTMLElement) {
   }
 
   async function handleImport(source: "manual" | "auto" = "manual") {
-    setDiagnostics(elements, source === "auto" ? "Auto import started." : "Import pressed.");
+    setGlobalDiagnostics(elements, source === "auto" ? "Auto import started." : "Import pressed.");
 
     if (!result) {
-      setError(elements, "Generate an image before importing.");
+      setGlobalError(elements, "Generate an image before importing.");
       return;
     }
 
-    setError(elements, "");
+    setGlobalError(elements, "");
     busyTool = "text-to-image";
     isBusy = true;
     syncBusy();
@@ -1607,26 +1607,26 @@ export function renderApp(rootElement: HTMLElement) {
     try {
       const layerName = createLayerName("OpenLayer_Generated");
 
-      setDiagnostics(elements, `Importing into ${result.originatingDocument?.name || "the originating document"}...`);
+      setGlobalDiagnostics(elements, `Importing into ${result.originatingDocument?.name || "the originating document"}...`);
       const importedLayerName = await importGeneratedImageAsLayer({
         blob: result.blob,
         originatingDocument: result.originatingDocument,
         layerName,
         onProgress: (message) => {
           setTextToImageStatus(elements, message, "idle");
-          setDiagnostics(elements, message);
+          setGlobalDiagnostics(elements, message);
         }
       });
       setTextToImageStatus(elements, `Imported layer: ${importedLayerName}`, "ready");
       flashImported(elements.statusText);
       markHistoryImported(elements, historyEntries, result, importedLayerName);
       const metadataMessage = await writeMetadataForImportedResult(historyEntries, result, importedLayerName, (message) => {
-        setDiagnostics(elements, message);
+        setGlobalDiagnostics(elements, message);
       });
-      setDiagnostics(elements, `Layer created: ${importedLayerName}. ${metadataMessage}`);
+      setGlobalDiagnostics(elements, `Layer created: ${importedLayerName}. ${metadataMessage}`);
     } catch (caughtError) {
       setTextToImageStatus(elements, "Import failed.", "error");
-      setError(elements, getErrorMessage(caughtError));
+      setGlobalError(elements, getErrorMessage(caughtError));
     } finally {
       isBusy = false;
       busyTool = null;
@@ -3949,7 +3949,7 @@ function updateTextCheckpointCompatibility(elements: AppElements) {
     const checkpointName = readSelectValue(elements.checkpoint);
     const message = createWorkflowDiagnosticMessage(preset, { selectedModelName: checkpointName });
 
-    setDiagnostics(elements, formatWorkflowDiagnosticMessage(message));
+    setGlobalDiagnostics(elements, formatWorkflowDiagnosticMessage(message));
     updateSettingsReport(elements);
   } catch {
     // Selection-change diagnostics should never break the panel.

--- a/src/ui/appBindings.ts
+++ b/src/ui/appBindings.ts
@@ -1,6 +1,6 @@
 import { AppView } from "./appConstants";
 import { AppElements } from "./appMarkup";
-import { setDiagnostics } from "./statusBars";
+import { setGlobalDiagnostics } from "./statusBars";
 
 /**
  * Every DOM event binding in the panel: direct control bindings, delegated
@@ -94,7 +94,7 @@ export function createActionRunner(
 
     lastRunAt = now;
     console.log(`[OpenLayer] action ${actionName} from ${eventName}`);
-    setDiagnostics(elements, `Event received: ${actionName} (${eventName}).`);
+    setGlobalDiagnostics(elements, `Event received: ${actionName} (${eventName}).`);
     void handler();
   };
 }

--- a/src/ui/statusBars.ts
+++ b/src/ui/statusBars.ts
@@ -379,15 +379,16 @@ export function setPromptLayerError(elements: AppElements, message: string) {
  * at...", "Seed used: ..." and workflow warning was written into the Inpaint,
  * Upscale, Outpaint, Sketch, Image to Image and Prompt from Layer diagnostics
  * lines as well.
+ *
+ * It writes the Settings line only, unlike setGlobalStatus, which does still
+ * paint every bar. A status bar reports state -- "ComfyUI is offline" is true of
+ * every tool, so every tool should say it. A diagnostics line reports the last
+ * thing that happened, it has no idle state to fall back to, and a GPU report
+ * produced on the Settings screen did not happen on the Upscale screen: it would
+ * sit there until the next upscale. Settings is where these are actionable and
+ * where every tool already logs, so that is where they belong.
  */
 export function setGlobalDiagnostics(elements: AppElements, message: string) {
-  elements.diagnosticsText.textContent = message;
-  elements.imgDiagnosticsText.textContent = message;
-  elements.sketchDiagnosticsText.textContent = message;
-  elements.inpaintDiagnosticsText.textContent = message;
-  elements.outpaintDiagnosticsText.textContent = message;
-  elements.upscaleDiagnosticsText.textContent = message;
-  elements.promptLayerDiagnosticsText.textContent = message;
   elements.settingsDiagnosticsText.textContent = message;
 }
 

--- a/src/ui/statusBars.ts
+++ b/src/ui/statusBars.ts
@@ -321,9 +321,28 @@ function applyToolError(errorMessage: HTMLElement, message: string) {
   errorMessage.hidden = !message;
 }
 
-export function setError(elements: AppElements, message: string) {
+/**
+ * An error that belongs to the panel rather than to a tool: the ComfyUI
+ * connection, the port scan, GPU detection, workflow health, settings reset.
+ * It writes the Settings error line, where the server URL that usually fixes it
+ * lives, and the Text to Image line, which is the screen most likely to be open
+ * when startup falls back to the built-in model list.
+ *
+ * Nothing a single tool is doing may come through here. The six other tools each
+ * surface their own failures through their own setter, and Text to Image now has
+ * one too.
+ */
+export function setGlobalError(elements: AppElements, message: string) {
   applyToolError(elements.errorMessage, message);
   applyToolError(elements.settingsErrorMessage, message);
+}
+
+// Text to Image owns the unprefixed error element, the same leftover that gave
+// it the unprefixed status elements. Like every other per-tool error setter it
+// writes its own line only -- its "Enter a prompt before generating." has no
+// business appearing on the Settings screen.
+export function setTextToImageError(elements: AppElements, message: string) {
+  applyToolError(elements.errorMessage, message);
 }
 
 export function setImageError(elements: AppElements, message: string) {
@@ -350,7 +369,18 @@ export function setPromptLayerError(elements: AppElements, message: string) {
   applyToolError(elements.promptLayerErrorMessage, message);
 }
 
-export function setDiagnostics(elements: AppElements, message: string) {
+/**
+ * A diagnostic that belongs to the panel rather than to a tool: the ComfyUI
+ * connection, the port scan, the hardware report, workflow health, the settings
+ * screen, the session history.
+ *
+ * Nothing a single tool is doing may come through here. This used to be the only
+ * fan-out setter *and* Text to Image's own setter, so every "Generate pressed
+ * at...", "Seed used: ..." and workflow warning was written into the Inpaint,
+ * Upscale, Outpaint, Sketch, Image to Image and Prompt from Layer diagnostics
+ * lines as well.
+ */
+export function setGlobalDiagnostics(elements: AppElements, message: string) {
   elements.diagnosticsText.textContent = message;
   elements.imgDiagnosticsText.textContent = message;
   elements.sketchDiagnosticsText.textContent = message;
@@ -358,6 +388,15 @@ export function setDiagnostics(elements: AppElements, message: string) {
   elements.outpaintDiagnosticsText.textContent = message;
   elements.upscaleDiagnosticsText.textContent = message;
   elements.promptLayerDiagnosticsText.textContent = message;
+  elements.settingsDiagnosticsText.textContent = message;
+}
+
+// Text to Image owns the unprefixed diagnostics element. Like every other
+// per-tool diagnostics setter it writes its own line plus the Settings line,
+// which is the panel's catch-all log: Settings shows what every tool reported,
+// each tool shows only its own.
+export function setTextToImageDiagnostics(elements: AppElements, message: string) {
+  elements.diagnosticsText.textContent = message;
   elements.settingsDiagnosticsText.textContent = message;
 }
 

--- a/tests/ui/statusBarFanOut.test.ts
+++ b/tests/ui/statusBarFanOut.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { AppElements } from "../../src/ui/appMarkup";
+import {
+  setGlobalDiagnostics,
+  setGlobalError,
+  setImageDiagnostics,
+  setImageError,
+  setInpaintDiagnostics,
+  setInpaintError,
+  setOutpaintDiagnostics,
+  setOutpaintError,
+  setPromptLayerDiagnostics,
+  setPromptLayerError,
+  setSketchDiagnostics,
+  setSketchError,
+  setTextToImageDiagnostics,
+  setTextToImageError,
+  setUpscaleDiagnostics,
+  setUpscaleError
+} from "../../src/ui/statusBars";
+
+/**
+ * Which screens a diagnostics or error message reaches. The setters are DOM
+ * writes and the suite is node-only, but these two only ever touch `textContent`
+ * and `hidden`, so a bag of plain objects is enough to record the fan-out.
+ *
+ * Worth testing because a wrong owner is invisible until a user sees one tool's
+ * message on another tool's screen: nothing throws, nothing fails to compile,
+ * and the panel looks fine to whoever made the change.
+ */
+
+const DIAGNOSTICS_KEYS = [
+  "diagnosticsText",
+  "imgDiagnosticsText",
+  "sketchDiagnosticsText",
+  "inpaintDiagnosticsText",
+  "outpaintDiagnosticsText",
+  "upscaleDiagnosticsText",
+  "promptLayerDiagnosticsText",
+  "settingsDiagnosticsText"
+] as const;
+
+const ERROR_KEYS = [
+  "errorMessage",
+  "imgErrorMessage",
+  "sketchErrorMessage",
+  "inpaintErrorMessage",
+  "outpaintErrorMessage",
+  "upscaleErrorMessage",
+  "promptLayerErrorMessage",
+  "settingsErrorMessage"
+] as const;
+
+type LineKey = (typeof DIAGNOSTICS_KEYS)[number] | (typeof ERROR_KEYS)[number];
+
+function createLines() {
+  const lines = {} as Record<LineKey, { textContent: string; hidden: boolean }>;
+
+  for (const key of [...DIAGNOSTICS_KEYS, ...ERROR_KEYS]) {
+    lines[key] = { textContent: "", hidden: true };
+  }
+
+  return lines;
+}
+
+function linesWritten(
+  keys: readonly LineKey[],
+  write: (elements: AppElements) => void
+) {
+  const lines = createLines();
+
+  write(lines as unknown as AppElements);
+
+  return keys.filter((key) => lines[key].textContent === "written");
+}
+
+function diagnosticsReach(setter: (elements: AppElements, message: string) => void) {
+  return linesWritten(DIAGNOSTICS_KEYS, (elements) => setter(elements, "written"));
+}
+
+function errorReach(setter: (elements: AppElements, message: string) => void) {
+  return linesWritten(ERROR_KEYS, (elements) => setter(elements, "written"));
+}
+
+describe("diagnostics fan-out", () => {
+  it("keeps a panel-wide diagnostic on the Settings screen", () => {
+    // The GPU report and the port scan happen on Settings. Before v0.9 they were
+    // written into all seven tool lines too, where they had nothing to do and no
+    // idle state to clear them.
+    expect(diagnosticsReach(setGlobalDiagnostics)).toEqual(["settingsDiagnosticsText"]);
+  });
+
+  it.each([
+    ["text to image", setTextToImageDiagnostics, "diagnosticsText"],
+    ["image to image", setImageDiagnostics, "imgDiagnosticsText"],
+    ["sketch to image", setSketchDiagnostics, "sketchDiagnosticsText"],
+    ["inpaint", setInpaintDiagnostics, "inpaintDiagnosticsText"],
+    ["outpaint", setOutpaintDiagnostics, "outpaintDiagnosticsText"],
+    ["upscale", setUpscaleDiagnostics, "upscaleDiagnosticsText"],
+    ["prompt from layer", setPromptLayerDiagnostics, "promptLayerDiagnosticsText"]
+  ])("writes %s's own line and the Settings log, and no other tool", (_tool, setter, ownLine) => {
+    // Settings is the catch-all on purpose: it shows what every tool reported.
+    expect(diagnosticsReach(setter).sort()).toEqual([ownLine, "settingsDiagnosticsText"].sort());
+  });
+});
+
+describe("error fan-out", () => {
+  it("puts a panel-wide error on Settings and Text to Image", () => {
+    // Settings is where the server URL that fixes a connection error lives, and
+    // Text to Image is the screen most likely to be open when startup falls back
+    // to the built-in model list. Deliberately asymmetric with the diagnostics
+    // rule above: an unreported startup warning is worse than a duplicated one.
+    expect(errorReach(setGlobalError).sort()).toEqual(["errorMessage", "settingsErrorMessage"].sort());
+  });
+
+  it.each([
+    ["text to image", setTextToImageError, "errorMessage"],
+    ["image to image", setImageError, "imgErrorMessage"],
+    ["sketch to image", setSketchError, "sketchErrorMessage"],
+    ["inpaint", setInpaintError, "inpaintErrorMessage"],
+    ["outpaint", setOutpaintError, "outpaintErrorMessage"],
+    ["upscale", setUpscaleError, "upscaleErrorMessage"],
+    ["prompt from layer", setPromptLayerError, "promptLayerErrorMessage"]
+  ])("keeps %s's error on its own screen", (_tool, setter, ownLine) => {
+    // Text to Image used to write the Settings error line as well, so "Enter a
+    // prompt before generating." greeted anyone who opened Settings next.
+    expect(errorReach(setter)).toEqual([ownLine]);
+  });
+
+  it("hides an error line when the message is cleared", () => {
+    const lines = createLines();
+    const elements = lines as unknown as AppElements;
+
+    setTextToImageError(elements, "Generation failed.");
+    expect(lines.errorMessage.hidden).toBe(false);
+
+    setTextToImageError(elements, "");
+    expect(lines.errorMessage.hidden).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes the last known limitation published in v0.8.0 and v0.8.1: `setDiagnostics` wrote all eight diagnostics lines and `setError` wrote both the Text to Image and the Settings error line. It is the same defect `setStatus` had before #39, and it takes the same fix.

Text to Image owns the unprefixed elements from back when it was the only tool in the panel, so its own messages — "Generate pressed at 09:14:22.", "Seed used: 12345.", "Layer created: …", "Enter a prompt before generating." — were broadcast into Inpaint's, Upscale's, Outpaint's, Sketch's, Image to Image's and Prompt from Layer's diagnostics lines, and its errors onto the Settings screen.

### Three commits

1. **Split the setters.** `setDiagnostics` → `setGlobalDiagnostics`, `setError` → `setGlobalError`, both keeping their bodies and every call site, plus two new per-tool setters that nothing calls yet. Behaviour-identical rename.
2. **Retarget the call sites.** 51 sites moved to their real owner. This is the commit a regression would be in.
3. **Docs.** README + a v0.9 draft CHANGELOG section.

### The rules that came out of it

- Each tool writes **its own line plus the Settings line**. Settings stays the panel-wide log — that catch-all is deliberate and was already how the six other tools behaved.
- Each tool keeps its **errors on its own screen**. No tool error reaches Settings any more.
- `setGlobalDiagnostics` writes **Settings only**, where `setGlobalStatus` still paints every bar. A status bar reports state and "ComfyUI is offline" is true of every tool; a diagnostics line reports the last thing that happened, has no idle state to clear it, and a GPU report produced on Settings did not happen on the Upscale screen.
- `setGlobalError` deliberately still writes the Text to Image line as well as Settings. A startup that falls back to the built-in model list has no other way to say so outside Settings. **This is the one judgement call worth overruling if you disagree.**

### Two visible changes to expect

- Each tool screen now **keeps its opening hint** ("Capture a Photoshop selection to prepare inpainting.") until that tool is used, instead of losing it to the first unrelated message during startup.
- The **"Event received: `<action>`" breadcrumb no longer appears on tool screens.** It stays on Settings and in the UXP console, where `console.log` already writes it. Say the word if you use it on-panel while testing.

### Gates

`npm run typecheck`, `npm test` (439 tests, 52 files), `npm run lint`, `npm run build` all pass. New `tests/ui/statusBarFanOut.test.ts` records the reach of all sixteen setters; verified by reintroducing the fan-out and watching it fail.

### Smoke test in Photoshop

**1 — the hint survives startup**

1. Reload the panel. Do not click anything.
2. Open Inpaint, Outpaint, Upscale, Sketch to Image, Image to Image, Prompt from Layer in turn.
3. Each diagnostics line (the small grey line under the status bar) should still read its own opening hint — "Capture a Photoshop selection to prepare inpainting.", "Capture a source, then extend it with Flux Fill outpaint.", and so on. **Before this change they all read a Text to Image or startup message.**

**2 — Text to Image no longer leaks**

4. On Text to Image, type a prompt and click **Generate**. Let it finish.
5. While it runs and after it completes, switch to **Inpaint** and **Upscale**. Their diagnostics lines must still show their own hints — no "Generate pressed at …", no "Seed used: …".
6. Back on Text to Image, its own diagnostics line should have shown the seed and workflow as before.

**3 — Text to Image errors stay on Text to Image**

7. Clear the prompt box on Text to Image and click **Generate**. Red "Enter a prompt before generating." appears there.
8. Open **Settings**. Its error line must be empty. **Before this change it showed the same red message.**

**4 — Settings still reports everything**

9. On Settings, click **Check ComfyUI**, then **Find ComfyUI Active Port**, then **Detect GPU & Recommend Models**, then **Check Workflow Health**, then **Copy Diagnostics**, then **Save Settings**, then change the theme dropdown.
10. Each one must update the Settings diagnostics line as before — the port scan progress, the GPU report, the health summary, "Copied a compact OpenLayer diagnostics report to the clipboard.", the theme name.
11. After each, check **Inpaint** — its diagnostics line should be unchanged. **Before this change the GPU report was parked there.**

**5 — connection errors are still visible where they matter**

12. Stop ComfyUI. On Settings, click **Check ComfyUI**.
13. Red error on Settings, and the same red error on Text to Image. Every tool's *status bar* should also say the check failed (that is `setGlobalStatus`, unchanged).
14. Restart ComfyUI, click **Check ComfyUI**, confirm both error lines clear.

**6 — the other six tools still report their own work**

15. Run one generation on **Image to Image** and one on **Inpaint** (or capture a source and hit a validation error, if quicker). Each tool's diagnostics line should update on its own screen, and the same message should also appear on the **Settings** diagnostics line.
16. Confirm neither one appears on the other's screen.

**7 — Layer Tools**

17. Open **Layer Tools** and run one export. It has no diagnostics or error line, so nothing should change there — this is a check that nothing broke, not that anything moved.
