### PR TITLE
Release paperwork for v0.9.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,33 @@
 # Changelog
 
-## Unreleased / v0.9.0-alpha draft
+## v0.9.0-alpha - 2026-07-27
 
-Section in progress. The Layer Tools screen and the rest of the v0.9 notes are written at release time; this entry is here because it closes a limitation the last two releases published.
+Adds the eighth tool, and finishes the status cleanup the 0.8 releases started. Layer Tools is the first thing OpenLayer does that is not a generation: it moves pixels *out* of Photoshop, into a file or into ComfyUI's input folder, which is the step that has until now meant leaving the panel.
+
+### Added
+
+- Added **Layer Tools**, the Home card that has said "coming soon" since it was written. Three exports — the active layer, the current selection, the selection mask — each to two destinations: a file you pick with a real Photoshop save dialog, or straight into ComfyUI's input folder where a workflow can reference it by name. Photoshop can already export a layer as PNG; what it cannot do is put one where ComfyUI can see it, and the selection mask — the export that is genuinely awkward to produce by hand — is exactly what an inpainting workflow wants.
+- The selection export uses the selection's own bounds, not the padded and snapped context bounds Inpaint uses. Inpaint pads because the model needs surrounding context; an artist exporting a selection wants what they selected.
+- Send to ComfyUI reuses the same `/upload/image` call every generation already makes, rather than new plumbing.
+
+### Changed
+
+- `exportSelectionMask` in the Photoshop adapter had been fully implemented, working, and completely unreachable for several releases — no caller anywhere in the source. Layer Tools is its first caller. The two neighbouring functions, `exportActiveLayerAsPNG` and `exportSelectionAsPNG`, were stubs that threw, carrying TODOs that named v0.4 and v0.5; both are now implemented on the existing capture path.
+- Layer Tools is the first tool written to the per-tool module shape the project has been moving toward: `src/ui/tools/layerTools.ts` takes its capture, save, upload, and message-formatting collaborators as parameters, so it contains no Photoshop, no `fetch`, and no DOM. The decisions worth arguing about — which capture runs, what the artist is told, what happens when they cancel — are unit-tested instead of being unreachable inside `renderApp`. A cancelled save is treated as neither success nor error, because colouring a change of mind red is how red stops meaning anything.
+- `readActiveSelectionInfo` now takes a label for the caller, so its no-selection message names what the artist was actually doing. It used to tell every caller to make a selection "before using Inpaint", including callers that had nothing to do with Inpaint.
 
 ### Fixed
 
 - Fixed one tool's diagnostics and error text appearing on the other tools' screens, the last part of the v0.7 status bleed. `setDiagnostics` wrote all eight diagnostics lines and `setError` wrote both the Text to Image and the Settings error line, because Text to Image owns the unprefixed elements from when it was the only tool in the panel — so "Generate pressed at 09:14:22.", "Seed used: 12345." and "Enter a prompt before generating." were broadcast to Inpaint, Upscale, Outpaint, Sketch to Image, Image to Image and Prompt from Layer. Each tool now writes its own diagnostics line plus the Settings line, which stays the panel-wide log, and keeps its errors to its own screen. Panel-wide diagnostics — the port scan, the GPU report, workflow health — report on Settings, where they are actionable. One visible consequence: each tool screen now keeps its opening hint ("Capture a Photoshop selection to prepare inpainting.") until that tool is actually used, instead of losing it to the first unrelated message.
+
+### Known limitations
+
+- The Layer Tools card on Home does not dim when ComfyUI is unreachable, unlike the generation tools. Saving to a file works with ComfyUI stopped; Send to ComfyUI will fail and report the connection error on the Layer Tools status line.
+- Layer, canvas, selection, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
+- The Preview panel offers each tool's primary import only. Live Painting's second action, "Import Refined as Layer", is not on the panel, because the refined result is a separate image and the panel shows one at a time.
+- The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the list and the downloader instead — an internet connection is required.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+- CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
 
 ## v0.8.1-alpha - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.8.1-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows and the 0.8 correctness fixes in Photoshop UXP, not for production work yet.
+`v0.9.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
 
-New in `v0.8.1-alpha`:
+New in `v0.9.0-alpha`:
 
-- The separated **OpenLayer Preview** panel now has its own **Import** buttons, so a result can be placed into the document from the large preview instead of only from the dashboard thumbnail. The buttons act on the image currently on screen, stay disabled during a run and on live sampler frames, and report the outcome on their own status line.
-- `img2img-z-image-turbo`'s editable source workflow is correct. It previously held the vendor's text-to-image demo graph, so opening it to learn the workflow showed a graph that cannot do image to image. Generation was never affected.
+- **Layer Tools**, the eighth tool and the first that is not a generation. Export the active layer, the current selection, or the selection mask, either to a file you pick with a Photoshop save dialog or straight into ComfyUI's input folder where a workflow can reference it by name.
+- Each tool's diagnostics line and error text now stay on that tool's screen. Settings remains the panel-wide log and still shows what every tool reported.
 
 Also new in the 0.8 series:
 
+- The separated **OpenLayer Preview** panel has its own **Import** buttons, so a result can be placed into the document from the large preview instead of only from the dashboard thumbnail. The buttons act on the image currently on screen, stay disabled during a run and on live sampler frames, and report the outcome on their own status line.
+- `img2img-z-image-turbo`'s editable source workflow is correct. It previously held the vendor's text-to-image demo graph, so opening it to learn the workflow showed a graph that cannot do image to image. Generation was never affected.
 - The separated **OpenLayer Preview** panel can now stay pinned to one tool instead of always following the latest generation. Its selection persists across sessions.
 - Status updates now stay with the correct tool instead of Text to Image progress appearing in Inpaint, Upscale, and the other tool screens.
 - Technical error details no longer crash while explaining a failure, and the progress bar no longer paints over the first section of the form. The bar has moved out of the sticky header and back under the status text it describes, so nothing in the header changes size when a run starts.
@@ -91,8 +93,13 @@ The earlier card-based dashboard established OpenLayer's honest available/experi
 
 </details>
 
-v0.8.1-alpha tester focus:
+v0.9.0-alpha tester focus:
 
+- Open **Layer Tools** from Home. With a layer selected, save it to a file, then send it to ComfyUI and confirm it appears in ComfyUI's `input` folder under the name the status line reports.
+- Make a selection, then run both the **Selection** and **Selection mask** exports. The mask is the one an inpainting workflow wants; confirm it is a black-and-white image matching what you selected.
+- Cancel a save dialog and confirm the status line says so without turning red — a change of mind is not an error.
+- Run a Layer Tools export with no selection, and with no open document, and confirm the message names what you were trying to do.
+- Open each tool in turn without touching anything and confirm its diagnostics line still shows its own opening hint. Then generate on Text to Image and confirm nothing from it appears on any other tool's screen.
 - Open **Plugins > OpenLayer Preview**, generate, and import the result using the panel's own **Import** button. Confirm the layer lands in the same document the generation started from, and that the panel's status line reports what happened.
 - Confirm the panel's Import button is disabled while a run is in progress and on live sampler frames, and enabled again once a result is committed.
 - Open **Plugins > OpenLayer Preview**, pin it to one tool, generate with another, and confirm the panel stays pinned and restores that choice in a later session.
@@ -102,7 +109,7 @@ v0.8.1-alpha tester focus:
 - Run `npm run setup-pack` and confirm it reports no source/API mismatches at all.
 - Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
-Known v0.8.1-alpha boundaries:
+Known v0.9.0-alpha boundaries:
 
 - Image to Image is an early foundation path, not a full production workflow yet.
 - Sketch to Image is limited to the first SD 1.x LINECN starter workflow.
@@ -132,7 +139,9 @@ Known v0.8.1-alpha boundaries:
 - Progress is no longer pinned while a tool's form is scrolled, which is the accepted cost of taking the progress bar out of the sticky header.
 - The 0.8 releases focus on correctness and maintainability. Existing generation capabilities should remain compatible with v0.7.0.
 - The Preview panel offers each tool's primary import only. Live Painting's "Import Refined as Layer" stays on the dashboard.
-- Layer, canvas, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
+- Layer, canvas, selection, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
+- Layer Tools' Send to ComfyUI puts the image in ComfyUI's `input` folder. It does not build or run a workflow for you — you reference the uploaded file from a workflow yourself.
+- The Layer Tools card on Home does not dim when ComfyUI is unreachable, unlike the generation tools. Saving to a file still works with ComfyUI stopped; Send to ComfyUI reports the connection error on the Layer Tools status line.
 - Live sampler previews require ComfyUI to be started with `--preview-method auto`, and the preview panel may flicker between steps until a future UI polish pass.
 - Classic v0.4 theme preserves the older visual feel, but it does not duplicate every old layout detail.
 - SDXL, SD3, Flux, and Z_image_Turbo Sketch to Image workflows need dedicated future presets.
@@ -261,7 +270,7 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.8.1-alpha.zip
+packages/openlayer-v0.9.0-alpha.zip
 ```
 
 ## Loading In UXP Developer Tool
@@ -388,7 +397,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.8.1-alpha test result:
+Use this quick pass before reporting a v0.9.0-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,10 +33,10 @@
       "operatingSystem": "Windows, macOS",
       "applicationCategory": "DesignApplication",
       "applicationSubCategory": "Adobe Photoshop plugin",
-      "softwareVersion": "0.8.1-alpha",
+      "softwareVersion": "0.9.0-alpha",
       "description": "Open-source Photoshop UXP plugin that connects to a local ComfyUI server for AI image generation: text to image, image to image, sketch to image, inpaint, outpaint, and upscale with Stable Diffusion, SDXL, and Flux models.",
       "url": "https://mehran-ahmadi.com/OpenLayer/",
-      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases",
+      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.9.0-alpha",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Mehran Ahmadi", "url": "https://github.com/MehranMarxian" }
     }
@@ -64,7 +64,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.8.1 · free &amp; open source</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.9.0 · free &amp; open source</p>
           <h1 id="hero-title">Local AI layers,<br><span class="grad">inside Photoshop.</span></h1>
           <p class="hero-lede">
             OpenLayer connects Photoshop to <strong>your own ComfyUI server</strong>.
@@ -73,7 +73,7 @@
             <strong>No cloud. No credits. No subscription.</strong>
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases">Download alpha</a>
+            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.9.0-alpha">Download v0.9.0-alpha</a>
             <a class="button button-secondary" href="https://github.com/MehranMarxian/OpenLayer">Star on GitHub</a>
           </div>
           <ul class="signal-list" aria-label="Project signals">
@@ -91,15 +91,15 @@
 
       <section class="intro" aria-labelledby="intro-title">
         <div class="section-inner">
-          <p class="eyebrow">v0.8 correctness and control</p>
+          <p class="eyebrow">v0.9 layer tools</p>
           <h2 id="intro-title">Local generation that now feels at home inside Photoshop.</h2>
           <p class="intro-lede">
             OpenLayer starts with dependable local workflows — text to image, image to image,
             sketch to image, experimental inpaint and outpaint, pixel upscale, lossless PNG
             source capture, live previews, diagnostics, and clean import into the active document.
-            v0.8 lets the separated preview stay pinned to one tool, fixes status and sticky-header
-            failures seen during real generations, and fills the missing editable workflow sources —
-            without adding a new generation capability or hiding the experimental edges.
+            v0.9 adds Layer Tools, the first tool that sends pixels the other way: export the active
+            layer, the current selection, or the selection mask to a file you pick or straight into
+            ComfyUI's input folder. Each tool's diagnostics and errors now stay on its own screen.
           </p>
         </div>
       </section>
@@ -145,6 +145,11 @@
               <span class="tool-icon"><img src="assets/tools/prompt-from-layer.png" alt=""></span>
               <div><h3>Prompt from Layer</h3><span class="chip chip-exp">Experimental</span></div>
               <p>Describe any layer or canvas into editable prompt text with Florence-2 PromptGen, then send it straight to Text to Image.</p>
+            </article>
+            <article class="tool-card">
+              <span class="tool-icon"><img src="assets/tools/layer-tools.png" alt=""></span>
+              <div><h3>Layer Tools</h3><span class="chip chip-ready">New in v0.9</span></div>
+              <p>Send pixels the other way. Export the active layer, the current selection, or the selection mask — to a file you pick, or straight into ComfyUI's input folder where a workflow can use it.</p>
             </article>
             <article class="tool-card">
               <span class="tool-icon"><img src="assets/tools/workflow.png" alt=""></span>
@@ -311,11 +316,11 @@ npm run build</code></pre>
             </article>
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.8.1-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.9.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
-              <p>v0.8.1 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
+              <p>v0.9.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
             </article>
             <article class="status-card">
               <h3>Flux Fill is experimental</h3>
@@ -338,7 +343,7 @@ npm run build</code></pre>
               <li>Inpaint and Outpaint should be tested on duplicate layers first.</li>
               <li>Prompt from Layer requires the local Florence-2 PromptGen model and the comfyui-florence2 nodes. The custom-scripts pack is no longer needed.</li>
               <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.8.1 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.9.0 keeps the shared metadata foundation and session-history wiring.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
               <li>Progress is shown in the generation status panel rather than pinned to the screen header, so it scrolls with the form.</li>
@@ -376,6 +381,10 @@ npm run build</code></pre>
               <p>Persistent preview pinning, the missing editable workflow sources plus a source/API drift check, four user-visible fixes to status and progress, and a smaller <code>App.ts</code>.</p>
             </article>
             <article>
+              <h3>v0.9 · Layer Tools</h3>
+              <p>Export the active layer, the current selection, or the selection mask to a file or straight into ComfyUI's input folder — and every tool's messages finally stay on its own screen.</p>
+            </article>
+            <article>
               <h3>Next · Reliability and artist control</h3>
               <p>Finish Inpaint and Outpaint alignment, strengthen workflow validation, and turn the metadata foundation into repeatable layer-level iteration.</p>
             </article>
@@ -401,7 +410,7 @@ npm run build</code></pre>
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.8.1-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.9.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a>
       </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlayer",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlayer",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.openlayer.photoshop",
   "name": "OpenLayer",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "main": "index.html",
   "host": [
     {

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -1,7 +1,7 @@
 import { OpenLayerTheme } from "../utils/preferences";
 
 export const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-export const APP_VERSION = "0.8.1";
+export const APP_VERSION = "0.9.0";
 export const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 export const HISTORY_LIMIT = 5;
 export const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];


### PR DESCRIPTION
Release paperwork for v0.9.0-alpha. No behaviour changes — the code shipped in #50, #51 and #52, each already smoke-tested.

### Three commits

1. **Version bumped to 0.9.0** in all four places: `package.json`, `package-lock.json` (twice — root and `packages.""`), `src/manifest.json`, and `APP_VERSION` in `appConstants.ts`. Bumped first so the panel footer reads 0.9.0 while you test.
2. **v0.9.0 CHANGELOG section and README refs.** Every claim checked against `git log v0.8.1-alpha..main` and the code, not the task list.
3. **Landing page synced**, plus a Layer Tools card in the tools grid and a v0.9 timeline entry.

### Two things worth a look rather than a rubber stamp

**The Layer Tools card not dimming is published as a known limitation, framed as a decision.** Saving to a file works perfectly well with ComfyUI stopped, so dimming the whole card would hide a working half of the tool. Written down so a tester who tries Send to ComfyUI with nothing listening knows what they are looking at.

**The Download button and the schema.org `downloadUrl` now point at the exact tag** rather than `/releases`. Every OpenLayer release is a prerelease, so `releases/latest` returns a 404 and the releases page shows six entries with none marked current — anyone following the download link was landing on a list and guessing. Note this means the link 404s until the v0.9.0-alpha tag is pushed, which happens right after this merges.

### Smoke test

This is paperwork, so the check is short:

1. Build and reload the panel. **Footer reads `v0.9.0`.**
2. Open Settings → **Copy Diagnostics**. The report names 0.9.0.
3. Open Home and confirm all eight tool cards still render, Layer Tools included.
4. Run one generation and one import to confirm nothing in the bump broke the build.
5. Open `docs/index.html` in a browser: hero badge says Alpha v0.9.0, the tools grid has a Layer Tools card, the Download button points at `releases/tag/v0.9.0-alpha`.

### After merge

Tag, package both zips, generate SHA-256 checksums, and publish the release. I'll do that on your go — but **merge #54 first** so the landing page's tester link is live when the release notes point at it.
