### PR TITLE
Write release zips with forward slashes

### DIFF
--- a/scripts/lib/zipWriter.mjs
+++ b/scripts/lib/zipWriter.mjs
@@ -4,12 +4,17 @@ import { writeFile } from "node:fs/promises";
 /**
  * A minimal, spec-correct ZIP writer.
  *
- * Why not `Compress-Archive`, which `scripts/package.mjs` uses? Because Windows
- * PowerShell 5.1 runs on .NET Framework, which stores entry paths with
- * backslashes. The ZIP specification requires forward slashes, and the existing
- * release zips carry 40 such entries. Windows tooling tolerates it; other
- * unzippers are entitled not to. The setup pack goes to strangers' machines and
- * gets opened by whatever they have, so it is written correctly here instead.
+ * Why not `Compress-Archive`? Because Windows PowerShell 5.1 runs on .NET
+ * Framework, which stores entry paths with backslashes. The ZIP specification
+ * requires forward slashes. Windows tooling tolerates the difference; other
+ * unzippers are entitled not to, and macOS `unzip` in particular unpacks such
+ * an archive as a flat directory of files with backslashes in their names.
+ *
+ * This started as the setup pack's writer, because that pack goes to strangers'
+ * machines and gets opened by whatever they have. `scripts/package.mjs` used
+ * `Compress-Archive` until v0.9.0 and shipped nine releases of malformed
+ * plugin zips before anyone looked; it now uses this writer too, so both
+ * published archives come out of one implementation.
  */
 
 const CRC_TABLE = (() => {

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -1,27 +1,79 @@
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, readdir, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { writeZip } from "./lib/zipWriter.mjs";
 
-const execFileAsync = promisify(execFile);
+/**
+ * Builds the plugin zip that is attached to a GitHub Release and loaded through
+ * the UXP Developer Tool.
+ *
+ * This used to shell out to `Compress-Archive` on Windows and `zip` on
+ * everything else. PowerShell 5.1's `Compress-Archive` writes entry paths with
+ * backslashes, which the ZIP spec forbids: every release zip from v0.1.0 to
+ * v0.9.0-alpha stored `assets\index-….js` rather than `assets/index-….js`.
+ * Windows Explorer and UDT tolerate that, which is why it survived nine
+ * releases unnoticed, but macOS `unzip` does not — it treats the whole string
+ * as one filename and unpacks a flat directory with no `assets/` folder, so the
+ * plugin simply fails to render. See `docs/DISTRIBUTION_SPIKE.md`, Finding 2.
+ *
+ * `writeZip` is the same spec-correct writer the setup pack already uses, so
+ * both archives now come out of one implementation and neither depends on a
+ * platform binary being installed.
+ */
+
 const root = fileURLToPath(new URL("..", import.meta.url));
+const distDir = resolve(root, "dist");
 const packagesDir = resolve(root, "packages");
 const packageJson = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
 const releaseLabel = process.env.OPENLAYER_RELEASE_LABEL ?? `v${packageJson.version}-alpha`;
 const zipPath = resolve(packagesDir, `openlayer-${releaseLabel}.zip`);
 
-await mkdir(packagesDir, { recursive: true });
-await rm(zipPath, { force: true });
+/**
+ * Every file under `dist/`, as archive entries rooted at the archive itself —
+ * `manifest.json` must sit at the top level for UDT to recognise the plugin.
+ * Paths are joined with "/" rather than `path.join` so the archive is identical
+ * whichever platform built it.
+ *
+ * @param {string} directory absolute path to walk
+ * @param {string} prefix in-archive path of `directory`, "" at the root
+ * @returns {Promise<{ path: string, data: Buffer }[]>}
+ */
+async function collectEntries(directory, prefix = "") {
+  const dirEntries = await readdir(directory, { withFileTypes: true });
+  /** @type {{ path: string, data: Buffer }[]} */
+  const entries = [];
 
-if (process.platform === "win32") {
-  await execFileAsync("powershell.exe", [
-    "-NoProfile",
-    "-Command",
-    `Compress-Archive -Path '${resolve(root, "dist")}\\*' -DestinationPath '${zipPath}' -Force`
-  ]);
-} else {
-  await execFileAsync("zip", ["-r", zipPath, "."], { cwd: resolve(root, "dist") });
+  // Sorted so entry order is deterministic: readdir order is filesystem order,
+  // which differs between machines. This does not make the zip byte-identical
+  // across builds — `writeZip` stamps entries with the current time — but it
+  // does make two archives diffable entry by entry.
+  for (const dirEntry of [...dirEntries].sort((left, right) => left.name.localeCompare(right.name))) {
+    const absolutePath = resolve(directory, dirEntry.name);
+    const archivePath = prefix ? `${prefix}/${dirEntry.name}` : dirEntry.name;
+
+    if (dirEntry.isDirectory()) {
+      entries.push(...(await collectEntries(absolutePath, archivePath)));
+      continue;
+    }
+
+    entries.push({ path: archivePath, data: await readFile(absolutePath) });
+  }
+
+  return entries;
 }
 
+const entries = await collectEntries(distDir);
+
+if (!entries.some((entry) => entry.path === "manifest.json")) {
+  throw new Error(
+    `No manifest.json at the root of ${distDir}. Run \`npm run build\` before packaging — ` +
+      "a zip without a top-level manifest is not a loadable UXP plugin."
+  );
+}
+
+await mkdir(packagesDir, { recursive: true });
+await rm(zipPath, { force: true });
+await writeZip(zipPath, entries);
+
 console.log(`Created ${zipPath}`);
+console.log(`  ${entries.length} files`);

--- a/tests/scripts/zipWriter.test.ts
+++ b/tests/scripts/zipWriter.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// @ts-expect-error -- scripts/ is plain .mjs and sits outside the tsconfig `include`.
+import { writeZip } from "../../scripts/lib/zipWriter.mjs";
+
+const END_OF_CENTRAL_DIRECTORY = Buffer.from([0x50, 0x4b, 0x05, 0x06]);
+const CENTRAL_FILE_HEADER = Buffer.from([0x50, 0x4b, 0x01, 0x02]);
+
+/**
+ * Reads entry names straight out of the ZIP central directory.
+ *
+ * Deliberately not an unzip library: the bug this suite exists to prevent is
+ * backslash entry paths, and most readers normalize those away silently —
+ * Python's `zipfile` does. A normalizing reader reports a malformed archive as
+ * clean, which is how nine OpenLayer releases shipped with the defect and how
+ * the first check for it returned the wrong answer. Only the raw bytes prove
+ * what is stored. See `docs/DISTRIBUTION_SPIKE.md`, Finding 2.
+ */
+function findEndOfCentralDirectory(archive: Buffer): number {
+  const offset = archive.lastIndexOf(END_OF_CENTRAL_DIRECTORY);
+
+  if (offset < 0) {
+    throw new Error("No end-of-central-directory record: this is not a zip.");
+  }
+
+  return offset;
+}
+
+function readCentralDirectoryNames(archive: Buffer): string[] {
+  const endOfCentralDirectory = findEndOfCentralDirectory(archive);
+  const total = archive.readUInt16LE(endOfCentralDirectory + 10);
+  const names: string[] = [];
+  let offset = archive.readUInt32LE(endOfCentralDirectory + 16);
+
+  for (let index = 0; index < total; index += 1) {
+    if (!archive.subarray(offset, offset + 4).equals(CENTRAL_FILE_HEADER)) {
+      throw new Error(`Corrupt central directory header at entry ${index}.`);
+    }
+
+    const nameLength = archive.readUInt16LE(offset + 28);
+    const extraLength = archive.readUInt16LE(offset + 30);
+    const commentLength = archive.readUInt16LE(offset + 32);
+
+    names.push(archive.toString("utf8", offset + 46, offset + 46 + nameLength));
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+
+  return names;
+}
+
+/** CRC-32 of the first entry, read from its central directory header. */
+function readFirstEntryCrc(archive: Buffer): number {
+  const centralOffset = archive.readUInt32LE(findEndOfCentralDirectory(archive) + 16);
+  return archive.readUInt32LE(centralOffset + 16);
+}
+
+async function writeToTempZip(entries: { path: string; data: Buffer | string }[]) {
+  const directory = await mkdtemp(join(tmpdir(), "openlayer-zip-"));
+  const zipPath = join(directory, "test.zip");
+
+  try {
+    await writeZip(zipPath, entries);
+    return await readFile(zipPath);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+/** Textbook CRC-32, written independently so it cannot share a bug with the writer. */
+function referenceCrc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+
+  for (const byte of buffer) {
+    crc ^= byte;
+
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    }
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+describe("writeZip", () => {
+  it("stores nested paths with forward slashes", async () => {
+    const archive = await writeToTempZip([
+      { path: "manifest.json", data: "{}" },
+      { path: "assets/index-abc123.js", data: "console.log(1);" },
+      { path: "icons/dark/icon_D.png", data: Buffer.from([0x89, 0x50, 0x4e, 0x47]) }
+    ]);
+
+    const names = readCentralDirectoryNames(archive);
+
+    expect(names).toEqual(["manifest.json", "assets/index-abc123.js", "icons/dark/icon_D.png"]);
+    expect(names.filter((name) => name.includes("\\"))).toEqual([]);
+  });
+
+  it("normalizes a backslash path handed to it, rather than storing it", async () => {
+    // The failure mode that shipped: a caller building paths with `path.join`
+    // on Windows produces "assets\\index.js". The writer must not pass that
+    // through, because the archive gets opened on machines that are not Windows.
+    const archive = await writeToTempZip([{ path: "assets\\index.js", data: "x" }]);
+
+    expect(readCentralDirectoryNames(archive)).toEqual(["assets/index.js"]);
+  });
+
+  it("refuses absolute and traversing paths", async () => {
+    await expect(writeToTempZip([{ path: "/etc/passwd", data: "x" }])).rejects.toThrow(/unsafe/i);
+    await expect(writeToTempZip([{ path: "../outside.txt", data: "x" }])).rejects.toThrow(/unsafe/i);
+    // Backslash traversal is normalized first, so it must still be caught after.
+    await expect(writeToTempZip([{ path: "..\\outside.txt", data: "x" }])).rejects.toThrow(/unsafe/i);
+  });
+
+  it("records a CRC that matches the uncompressed payload", async () => {
+    const payload = Buffer.from("the quick brown fox".repeat(50), "utf8");
+    const archive = await writeToTempZip([{ path: "body.txt", data: payload }]);
+
+    expect(readFirstEntryCrc(archive)).toBe(referenceCrc32(payload));
+  });
+
+  it("stores payloads that deflate badly without corrupting them", async () => {
+    // Pseudo-random bytes grow under deflate, so the writer stores them
+    // uncompressed. Both branches must yield an entry with an honest CRC.
+    const incompressible = Buffer.from(
+      Array.from({ length: 512 }, (_unused, index) => (index * 2654435761) % 256)
+    );
+    const archive = await writeToTempZip([{ path: "noise.bin", data: incompressible }]);
+
+    expect(readFirstEntryCrc(archive)).toBe(referenceCrc32(incompressible));
+    expect(readCentralDirectoryNames(archive)).toEqual(["noise.bin"]);
+  });
+});


### PR DESCRIPTION
Follows up Finding 2 of `docs/DISTRIBUTION_SPIKE.md`, merged in #24, which recorded the backslash entry-path problem and parked it as harmless. Re-measuring it against the current release shows it is neither historical nor harmless.

## What is wrong

`openlayer-v0.9.0-alpha.zip` — the file on the release page right now — stores **44 of its 47 entries with backslash paths** (`assets\index-CFWhxO2q.js`). So does every release zip back to v0.1.0. The ZIP specification requires forward slashes; `scripts/package.mjs` shelled out to PowerShell 5.1's `Compress-Archive` on Windows, and .NET Framework writes backslashes.

It survived nine releases because the only unzippers pointed at it were Windows Explorer and the UXP Developer Tool, and both tolerate it. **macOS `unzip` does not** — it treats the whole string as one filename and unpacks a flat directory of files literally called `assets\index-….js`, giving a plugin folder with no `assets/` directory and a panel that cannot load.

macOS is the one platform with no coverage. This would have arrived as an unreproducible bug report from the first Mac tester — the exact kind of failure the current tester push is meant to surface, and the exact kind nobody can act on.

## The fix

No new dependency, and no dependence on the `.ccx` question #24 leaves open. `scripts/lib/zipWriter.mjs` is already a spec-correct pure-Node writer, already used by `scripts/build-setup-pack.mjs` — which is why `openlayer-comfyui-setup-0.9.0.zip` has been clean all along while the plugin zip beside it was not.

`package.mjs` now walks `dist/` and calls it. The win32/posix branch is gone, so both platforms produce the same archive and packaging no longer needs a `zip` or `pwsh` binary installed (this machine has neither).

Two additions beyond the swap:
- **Entries are sorted.** `readdir` returns filesystem order, which differs between machines; sorting makes two builds of one commit diffable entry by entry. It does not make them byte-identical — `writeZip` stamps the current time.
- **Packaging fails loudly if `dist/` has no top-level `manifest.json`.** A zip without one is not a loadable plugin, and the old script would produce it happily.

## Verification

Rebuilt and repackaged locally. The new `openlayer-v0.9.0-alpha.zip`: 47 entries, **0 backslashes**, `manifest.json` / `index.html` / `panelBootstrap.js` at the root, every CRC valid, and all 47 payloads SHA-256-identical to the files in `dist/`.

`npm run typecheck`, `npm test` (444 passing, 53 files), `npm run build`, `npx eslint .` — all green.

`tests/scripts/zipWriter.test.ts` is new and covers the writer both scripts now share: forward-slash storage, backslash normalization, unsafe-path rejection, CRC correctness on both the deflated and stored branches.

**The test reads the ZIP central directory raw rather than through an unzip library, and that is the point.** Python's `zipfile` normalizes backslashes away on read, so the obvious check reports a malformed archive as clean — that is what made the first measurement of this bug return the opposite of the truth. Mutation-verified: removing the normalization in `zipWriter.mjs` makes it fail.

## Smoke test

Packaging changes how every future release is built, so this wants a real check rather than CI alone:

1. `npm run build && npm run package`
2. Unzip `packages/openlayer-v0.9.0-alpha.zip` to a fresh folder — confirm there is a real `assets\` **folder**, not files with backslashes in their names.
3. UXP Developer Tool → **Add Plugin** → point at that folder's `manifest.json`.
4. **Plugins → OpenLayer** — panel renders, tool grid appears, Home cards are intact.
5. Sanity-check one generation end to end so the bundled JS/CSS is confirmed to be the real build.

Nothing in `src/` changed, so no Photoshop behaviour should differ — step 5 only confirms the archive carries a working build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)