### PR TITLE
Tell artists which folder a missing model is actually in

### DIFF
--- a/src/comfy/modelFolders.ts
+++ b/src/comfy/modelFolders.ts
@@ -1,4 +1,9 @@
-import { WorkflowModelFolder, WorkflowPresetDefinition, WorkflowRequiredModel } from "./types";
+import {
+  ComfyModelInventory,
+  WorkflowModelFolder,
+  WorkflowPresetDefinition,
+  WorkflowRequiredModel
+} from "./types";
 import { createOpenLayerError } from "../utils/errors";
 
 /**
@@ -29,6 +34,19 @@ export const MODEL_FOLDER_BY_OBJECT_INFO_NODE = {
   UpscaleModelLoader: "upscale_models",
   Florence2ModelLoader: "LLM"
 } as const satisfies Record<string, WorkflowModelFolder>;
+
+export type ComfyModelInventoryBucket = Exclude<keyof ComfyModelInventory, "missingSources">;
+
+/** Which folder under `models/` supplies each model inventory bucket. */
+export const MODEL_FOLDER_BY_INVENTORY_BUCKET = {
+  checkpoints: "checkpoints",
+  diffusionModels: "diffusion_models",
+  clipModels: "text_encoders",
+  vaeModels: "vae",
+  controlNetModels: "controlnet",
+  visionLanguageModels: "LLM",
+  upscaleModels: "upscale_models"
+} as const satisfies Record<ComfyModelInventoryBucket, WorkflowModelFolder>;
 
 export type MappedModelLoaderNode = keyof typeof MODEL_FOLDER_BY_OBJECT_INFO_NODE;
 

--- a/src/comfy/modelPlacementDiagnostics.ts
+++ b/src/comfy/modelPlacementDiagnostics.ts
@@ -1,0 +1,119 @@
+import {
+  ComfyModelInventoryBucket,
+  getModelTargetFolder,
+  isMappedModelLoaderNode,
+  MODEL_FOLDER_BY_INVENTORY_BUCKET
+} from "./modelFolders";
+import { ComfyModelInventory, WorkflowModelFolder, WorkflowRequiredModel } from "./types";
+import { getAcceptedModelNames } from "./workflowModelRequirements";
+
+/**
+ * Answers "the file is missing — is it actually just in the wrong folder?".
+ *
+ * Every string here is rendered with `textContent` (see `createWorkflowHealthCard`
+ * in `src/ui/App.ts`), so it is plain text. No markdown, no backticks, no
+ * em dashes: whatever is written here is exactly what the artist reads.
+ */
+
+const MODEL_INVENTORY_BUCKET_ORDER = [
+  "checkpoints",
+  "diffusionModels",
+  "clipModels",
+  "vaeModels",
+  "controlNetModels",
+  "visionLanguageModels",
+  "upscaleModels"
+] as const satisfies readonly ComfyModelInventoryBucket[];
+
+export type MisplacedModel = {
+  modelName: string;
+  folders: WorkflowModelFolder[];
+  requiredFolder: WorkflowModelFolder;
+};
+
+export function findMisplacedModel(
+  inventory: Partial<ComfyModelInventory>,
+  model: WorkflowRequiredModel
+): MisplacedModel | null {
+  // `getModelTargetFolder` throws for a loader that has no mapped folder, and
+  // this runs inside the workflow health report: one unmappable preset must not
+  // take down the whole check. If we cannot say where the file belongs, we
+  // cannot say it is in the wrong place, so say nothing and let the plain
+  // "missing" message stand.
+  if (!model.targetFolder && !isMappedModelLoaderNode(model.objectInfoNode)) {
+    return null;
+  }
+
+  const acceptedNames = getAcceptedModelNames(model);
+  const targetFolder = getModelTargetFolder(model);
+  const folders: WorkflowModelFolder[] = [];
+  let matchedModelName: string | null = null;
+
+  for (const bucket of MODEL_INVENTORY_BUCKET_ORDER) {
+    const folder = MODEL_FOLDER_BY_INVENTORY_BUCKET[bucket];
+
+    if (folder === targetFolder) {
+      continue;
+    }
+
+    const bucketMatch = (inventory[bucket] ?? []).find((candidate) =>
+      acceptedNames.some((acceptedName) => modelNameMatches(candidate, acceptedName))
+    );
+
+    if (!bucketMatch) {
+      continue;
+    }
+
+    matchedModelName ??= bucketMatch;
+    folders.push(folder);
+  }
+
+  return matchedModelName
+    ? { modelName: matchedModelName, folders, requiredFolder: targetFolder }
+    : null;
+}
+
+export function formatMisplacedModelMessage(misplacedModel: MisplacedModel): string {
+  const foundFolders = formatFolderList(misplacedModel.folders);
+  const requiredFolder = formatModelFolder(misplacedModel.requiredFolder);
+
+  return `Found ${misplacedModel.modelName} in ${foundFolders}, but this workflow reads it from ${requiredFolder}. Move the file, then refresh ComfyUI.`;
+}
+
+function modelNameMatches(candidate: string, acceptedName: string): boolean {
+  const normalizedCandidate = normalizeModelPath(candidate);
+  const normalizedAcceptedName = normalizeModelPath(acceptedName);
+  const candidateName = normalizedAcceptedName.includes("/")
+    ? normalizedCandidate
+    : getBaseName(normalizedCandidate);
+
+  return candidateName.toLowerCase() === normalizedAcceptedName.toLowerCase();
+}
+
+function normalizeModelPath(modelName: string): string {
+  return modelName.replace(/\\/g, "/");
+}
+
+function getBaseName(modelName: string): string {
+  return modelName.slice(modelName.lastIndexOf("/") + 1);
+}
+
+function formatFolderList(folders: readonly WorkflowModelFolder[]): string {
+  const formattedFolders = folders.map(formatModelFolder);
+
+  if (formattedFolders.length <= 1) {
+    return formattedFolders[0] ?? "";
+  }
+
+  if (formattedFolders.length === 2) {
+    return `${formattedFolders[0]} and ${formattedFolders[1]}`;
+  }
+
+  return `${formattedFolders.slice(0, -1).join(", ")}, and ${
+    formattedFolders[formattedFolders.length - 1]
+  }`;
+}
+
+function formatModelFolder(folder: WorkflowModelFolder): string {
+  return `models/${folder}/`;
+}

--- a/src/comfy/workflowCompatibility.ts
+++ b/src/comfy/workflowCompatibility.ts
@@ -1,4 +1,9 @@
 import { detectCheckpointFamily } from "./modelCompatibility";
+import {
+  findMisplacedModel,
+  formatMisplacedModelMessage
+} from "./modelPlacementDiagnostics";
+import { CUSTOM_NODE_PACKAGES } from "./setupManifest";
 import { getWorkflowCapability } from "./workflowCapabilities";
 import {
   ComfyModelInventory,
@@ -146,7 +151,7 @@ function addNodeIssues(
       issues.push({
         level: "setup-required",
         code: "COMFY_NODE_MISSING",
-        artistMessage: `ComfyUI is missing the ${requirement.classType} node required by ${preset.label}.`,
+        artistMessage: formatMissingNodeMessage(requirement.classType, preset.label),
         technicalMessage: `Missing node class: ${requirement.classType}.`
       });
       continue;
@@ -176,14 +181,37 @@ function addModelFileIssues(
 
   for (const model of getRequiredModels(preset)) {
     if (!hasRequiredModel(context.availableModels, model)) {
+      const missingModelMessage = formatMissingRequiredModelMessage(model);
+      const misplacedModel = findMisplacedModel(context.availableModels, model);
+
       issues.push({
         level: "setup-required",
         code: "MODEL_FILE_MISSING",
-        artistMessage: formatMissingRequiredModelMessage(model),
+        artistMessage: misplacedModel
+          ? `${missingModelMessage} ${formatMisplacedModelMessage(misplacedModel)}`
+          : missingModelMessage,
         technicalMessage: model.setupHint
       });
     }
   }
+}
+
+/**
+ * Rendered with `textContent`, so this is plain text: no markdown, no backticks.
+ * The opening sentence is deliberately byte-identical to the one this message
+ * has always had, so a reader who has seen it before still recognises it.
+ */
+function formatMissingNodeMessage(classType: string, presetLabel: string): string {
+  const openingSentence = `ComfyUI is missing the ${classType} node required by ${presetLabel}.`;
+  const customNodePackage = CUSTOM_NODE_PACKAGES[classType];
+
+  if (customNodePackage) {
+    return `${openingSentence} Install ${customNodePackage.name} from ${customNodePackage.repoUrl} into ComfyUI/custom_nodes/, then restart ComfyUI.`;
+  }
+
+  // Absence from CUSTOM_NODE_PACKAGES means core ComfyUI (see its doc comment),
+  // which is a different diagnosis: there is nothing to install.
+  return `${openingSentence} This node ships with ComfyUI itself, so your ComfyUI install is likely out of date or partially broken.`;
 }
 
 function addPhotoshopInputIssues(

--- a/tests/comfy/modelFolders.test.ts
+++ b/tests/comfy/modelFolders.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  MODEL_FOLDER_BY_INVENTORY_BUCKET,
   MODEL_FOLDER_BY_OBJECT_INFO_NODE,
   getModelTargetFolder,
   getModelTargetPath,
@@ -38,6 +39,24 @@ describe("model folder mapping", () => {
       UpscaleModelLoader: "upscale_models",
       Florence2ModelLoader: "LLM"
     });
+  });
+
+  it("freezes every inventory bucket folder and keeps it consistent with loader folders", () => {
+    expect(MODEL_FOLDER_BY_INVENTORY_BUCKET).toEqual({
+      checkpoints: "checkpoints",
+      diffusionModels: "diffusion_models",
+      clipModels: "text_encoders",
+      vaeModels: "vae",
+      controlNetModels: "controlnet",
+      visionLanguageModels: "LLM",
+      upscaleModels: "upscale_models"
+    });
+
+    const loaderFolders = Object.values(MODEL_FOLDER_BY_OBJECT_INFO_NODE);
+
+    for (const folder of Object.values(MODEL_FOLDER_BY_INVENTORY_BUCKET)) {
+      expect(loaderFolders).toContain(folder);
+    }
   });
 
   it("builds install paths relative to the ComfyUI root", () => {

--- a/tests/comfy/modelPlacementDiagnostics.test.ts
+++ b/tests/comfy/modelPlacementDiagnostics.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  findMisplacedModel,
+  formatMisplacedModelMessage
+} from "../../src/comfy/modelPlacementDiagnostics";
+import { WorkflowRequiredModel } from "../../src/comfy/types";
+
+function model(overrides: Partial<WorkflowRequiredModel> = {}): WorkflowRequiredModel {
+  return {
+    kind: "vae",
+    objectInfoNode: "VAELoader",
+    inputName: "vae_name",
+    label: "Flux VAE",
+    modelName: "ae.safetensors",
+    ...overrides
+  };
+}
+
+describe("model placement diagnostics", () => {
+  it("reports one wrong folder and the folder the workflow requires", () => {
+    const requiredModel = model();
+    const misplacedModel = findMisplacedModel(
+      { checkpoints: ["ae.safetensors"] },
+      requiredModel
+    );
+
+    expect(misplacedModel).toEqual({
+      modelName: "ae.safetensors",
+      folders: ["checkpoints"],
+      requiredFolder: "vae"
+    });
+    expect(formatMisplacedModelMessage(misplacedModel!)).toBe(
+      "Found ae.safetensors in models/checkpoints/, but this workflow reads it from models/vae/. Move the file, then refresh ComfyUI."
+    );
+  });
+
+  it("reports multiple wrong folders in fixed inventory order across runs", () => {
+    const requiredModel = model();
+    const inventory = {
+      controlNetModels: ["ae.safetensors"],
+      checkpoints: ["ae.safetensors"]
+    };
+    const results = Array.from({ length: 5 }, () =>
+      findMisplacedModel(inventory, requiredModel)
+    );
+
+    for (const misplacedModel of results) {
+      expect(misplacedModel).toEqual({
+        modelName: "ae.safetensors",
+        folders: ["checkpoints", "controlnet"],
+        requiredFolder: "vae"
+      });
+      expect(formatMisplacedModelMessage(misplacedModel!)).toBe(
+        "Found ae.safetensors in models/checkpoints/ and models/controlnet/, but this workflow reads it from models/vae/. Move the file, then refresh ComfyUI."
+      );
+    }
+  });
+
+  it("searches accepted model names as well as the preferred name", () => {
+    const misplacedModel = findMisplacedModel(
+      { checkpoints: ["fallback.safetensors"] },
+      model({
+        modelName: "preferred.safetensors",
+        acceptedModelNames: ["fallback.safetensors"]
+      })
+    );
+
+    expect(misplacedModel).toEqual({
+      modelName: "fallback.safetensors",
+      folders: ["checkpoints"],
+      requiredFolder: "vae"
+    });
+  });
+
+  it("matches case-insensitively and preserves ComfyUI's spelling", () => {
+    const requiredModel = model();
+    const misplacedModel = findMisplacedModel(
+      { checkpoints: ["AE.safetensors"] },
+      requiredModel
+    );
+
+    expect(misplacedModel?.modelName).toBe("AE.safetensors");
+    expect(formatMisplacedModelMessage(misplacedModel!)).toContain(
+      "Found AE.safetensors"
+    );
+  });
+
+  it("matches a nested ComfyUI path by basename", () => {
+    const misplacedModel = findMisplacedModel(
+      { diffusionModels: ["lcm/SD1.5/ae.safetensors"] },
+      model()
+    );
+
+    expect(misplacedModel).toEqual({
+      modelName: "lcm/SD1.5/ae.safetensors",
+      folders: ["diffusion_models"],
+      requiredFolder: "vae"
+    });
+  });
+
+  it("matches the full path when an accepted model name contains a slash", () => {
+    const requiredModel = model({ modelName: "expected/ae.safetensors" });
+
+    expect(
+      findMisplacedModel(
+        { checkpoints: ["other/expected/ae.safetensors"] },
+        requiredModel
+      )
+    ).toBeNull();
+    expect(
+      findMisplacedModel(
+        { checkpoints: ["expected/AE.safetensors"] },
+        requiredModel
+      )
+    ).toEqual({
+      modelName: "expected/AE.safetensors",
+      folders: ["checkpoints"],
+      requiredFolder: "vae"
+    });
+  });
+
+  it("stays silent instead of throwing when the loader has no mapped folder", () => {
+    // getModelTargetFolder throws for an unmapped loader, and this runs inside
+    // the workflow health report: one unmappable preset must not fail the whole
+    // check. No mapped folder means no opinion about where the file belongs.
+    const unmapped = model({ objectInfoNode: "SomeFutureLoader" });
+
+    expect(() => findMisplacedModel({ checkpoints: ["ae.safetensors"] }, unmapped)).not.toThrow();
+    expect(findMisplacedModel({ checkpoints: ["ae.safetensors"] }, unmapped)).toBeNull();
+  });
+
+  it("still advises when an unmapped loader declares its folder explicitly", () => {
+    const explicit = model({ objectInfoNode: "SomeFutureLoader", targetFolder: "vae" });
+
+    expect(findMisplacedModel({ checkpoints: ["ae.safetensors"] }, explicit)).toEqual({
+      modelName: "ae.safetensors",
+      folders: ["checkpoints"],
+      requiredFolder: "vae"
+    });
+  });
+
+  it("never scans missing inventory source diagnostics as model filenames", () => {
+    expect(
+      findMisplacedModel(
+        { missingSources: ["ae.safetensors"] },
+        model()
+      )
+    ).toBeNull();
+  });
+});

--- a/tests/comfy/workflowCompatibility.test.ts
+++ b/tests/comfy/workflowCompatibility.test.ts
@@ -95,6 +95,87 @@ describe("workflow compatibility", () => {
     expect(result.recommendedAction).toContain("Missing LineArt ControlNet");
   });
 
+  it("produces no model issue when a required model is in its correct bucket", () => {
+    const preset = getWorkflowPreset("inpaint-flux-fill-basic");
+    const result = evaluateWorkflowCompatibility(preset, {
+      availableNodes: createAvailableNodes(preset),
+      availableModels: createFluxFillInventory()
+    });
+
+    expect(result.issues.filter((issue) => issue.code === "MODEL_FILE_MISSING")).toEqual([]);
+  });
+
+  it("keeps the exact missing-model message when the file is absent everywhere", () => {
+    const preset = getWorkflowPreset("inpaint-flux-fill-basic");
+    const result = evaluateWorkflowCompatibility(preset, {
+      availableNodes: createAvailableNodes(preset),
+      availableModels: createFluxFillInventory({ vaeModels: [] })
+    });
+    const issue = result.issues.find((candidate) => candidate.code === "MODEL_FILE_MISSING");
+
+    expect(issue?.artistMessage).toBe("Missing Flux VAE: ae.safetensors.");
+  });
+
+  it("adds wrong-folder guidance to the missing-model message", () => {
+    const preset = getWorkflowPreset("inpaint-flux-fill-basic");
+    const result = evaluateWorkflowCompatibility(preset, {
+      availableNodes: createAvailableNodes(preset),
+      availableModels: createFluxFillInventory({
+        checkpoints: ["ae.safetensors"],
+        vaeModels: []
+      })
+    });
+    const issue = result.issues.find((candidate) => candidate.code === "MODEL_FILE_MISSING");
+
+    expect(issue?.artistMessage).toBe(
+      "Missing Flux VAE: ae.safetensors. Found ae.safetensors in models/checkpoints/, but this workflow reads it from models/vae/. Move the file, then refresh ComfyUI."
+    );
+  });
+
+  it("names the repository for a missing mapped custom node", () => {
+    const preset = getWorkflowPreset("prompt-from-layer-florence2");
+    const availableNodes = createAvailableNodes(preset);
+    delete availableNodes.Florence2ModelLoader;
+
+    const result = evaluateWorkflowCompatibility(preset, {
+      availableNodes,
+      availableModels: createInventory({
+        visionLanguageModels: ["Florence-2-base-PromptGen-v2.0"]
+      })
+    });
+    const issue = result.issues.find((candidate) => candidate.code === "COMFY_NODE_MISSING");
+
+    expect(issue?.artistMessage).toContain("Install ComfyUI-Florence2 from");
+    expect(issue?.artistMessage).toContain("https://github.com/kijai/ComfyUI-Florence2");
+  });
+
+  it("diagnoses a missing core node as an outdated or broken ComfyUI install", () => {
+    const preset = getWorkflowPreset("txt2img-basic");
+    const availableNodes = createAvailableNodes(preset);
+    delete availableNodes.KSampler;
+
+    const result = evaluateWorkflowCompatibility(preset, { availableNodes });
+    const issue = result.issues.find((candidate) => candidate.code === "COMFY_NODE_MISSING");
+
+    expect(issue?.artistMessage).toContain(
+      "This node ships with ComfyUI itself, so your ComfyUI install is likely out of date or partially broken."
+    );
+    expect(issue?.artistMessage).not.toContain("github.com");
+  });
+
+  it("leaves the present-node missing-input message unchanged", () => {
+    const preset = getWorkflowPreset("txt2img-basic");
+    const availableNodes = createAvailableNodes(preset);
+    availableNodes.KSampler = [];
+
+    const result = evaluateWorkflowCompatibility(preset, { availableNodes });
+    const issue = result.issues.find((candidate) => candidate.code === "COMFY_NODE_INPUT_MISSING");
+
+    expect(issue?.artistMessage).toBe(
+      "A ComfyUI node used by txt2img-basic is missing expected inputs."
+    );
+  });
+
   it("accepts the preferred Flux Fill T5 encoder when the model stack is present", () => {
     const preset = getWorkflowPreset("inpaint-flux-fill-basic");
 

--- a/tests/comfy/workflowHealth.test.ts
+++ b/tests/comfy/workflowHealth.test.ts
@@ -130,6 +130,29 @@ describe("workflow health", () => {
     expect(item.summary).toContain("LineArtPreprocessor");
   });
 
+  it("keeps enriched setup issues routed to missing-model and missing-node states", () => {
+    const modelPreset = getWorkflowPreset("inpaint-flux-fill-basic");
+    const modelItem = createWorkflowHealthItem(modelPreset, {
+      availableNodes: createAvailableNodes(modelPreset),
+      availableModels: createFluxFillInventory({
+        checkpoints: ["ae.safetensors"],
+        vaeModels: []
+      })
+    });
+    const nodePreset = getWorkflowPreset("prompt-from-layer-florence2");
+    const availableNodes = createAvailableNodes(nodePreset);
+    delete availableNodes.Florence2ModelLoader;
+    const nodeItem = createWorkflowHealthItem(nodePreset, {
+      availableNodes,
+      availableModels: createInventory({
+        visionLanguageModels: ["Florence-2-base-PromptGen-v2.0"]
+      })
+    });
+
+    expect(modelItem.state).toBe("missing-model");
+    expect(nodeItem.state).toBe("missing-node");
+  });
+
   it("reports future Flux presets as missing workflow JSON before model or node details", () => {
     const preset = getWorkflowPreset("txt2img-flux1-dev");
     const item = createWorkflowHealthItem(preset, {


### PR DESCRIPTION
Roadmap item 1 in `docs/ORCHESTRATION.md` §6, "ComfyUI setup diagnostics, Phase 1".

## Why this one

**Check Workflow Health** could only ever say:

> Missing Flux VAE: ae.safetensors.

True and useless. The most common OpenLayer setup failure is not an absent file — it is a file in the wrong folder. `CheckpointLoaderSimple` reads `models/checkpoints/` while `UNETLoader` reads `models/diffusion_models/`, so a model dropped one directory over is invisible to the workflow that needs it. `src/comfy/modelFolders.ts` has carried a comment warning about exactly this since it was written; now the panel acts on it.

Same for nodes: the repo has known which repository each custom node comes from since the setup pack was built, and simply never said so.

## What it does now

**Model in the wrong folder:**

> Missing Flux VAE: ae.safetensors. Found ae.safetensors in models/checkpoints/, but this workflow reads it from models/vae/. Move the file, then refresh ComfyUI.

Found in more than one place, deterministically ordered:

> ... Found ae.safetensors in models/checkpoints/ and models/controlnet/, but this workflow reads it from models/vae/. ...

**Missing custom node:**

> ComfyUI is missing the Florence2ModelLoader node required by Prompt from Layer (Florence-2). Install ComfyUI-Florence2 from https://github.com/kijai/ComfyUI-Florence2 into ComfyUI/custom_nodes/, then restart ComfyUI.

**Missing core node** — a different diagnosis, because there is nothing to install:

> ComfyUI is missing the KSampler node required by txt2img-basic. This node ships with ComfyUI itself, so your ComfyUI install is likely out of date or partially broken.

**Genuinely absent file:** byte-identical to the old message. A tester with a real absence should see no new noise, and that is asserted against the literal string.

## Design notes

- The search is **case-insensitive** (Windows filesystems are) but echoes the filename **as ComfyUI spelled it**, not as the registry spells it.
- It matches nested ComfyUI paths (`lcm/SD1.5/foo.safetensors`) by basename, and full-string when the accepted name itself contains a slash.
- It searches **all accepted names**, not just `modelName`, or a file present under an alias would still be called missing.
- `missingSources` is a diagnostics list, not a model bucket, and is never scanned.
- **No issue codes changed**, so `missing-model` / `missing-node` health states and labels route exactly as before. `hasRequiredModel` is untouched — whether a model counts as usable is as strict as it was. This only enriches the explanation.
- Logic lives in a new pure module, `src/comfy/modelPlacementDiagnostics.ts`; `workflowCompatibility.ts` only wires it in.

## Provenance

Implemented by Codex against a written brief, then reviewed and amended here in three places:

1. **Backticks and `--` removed.** Every one of these strings is rendered with `textContent` by `createWorkflowHealthCard`, so the panel shows plain text — the draft's `` `ae.safetensors` `` would have appeared on screen with the backticks visible. No user-facing string in this codebase has ever used a backtick or a double hyphen; both appear only in comments.
2. **The node message's opening sentence restored byte-for-byte**, so a reader who has seen it before still recognises it.
3. **`findMisplacedModel` returns early for a loader with no mapped folder**, instead of letting `getModelTargetFolder` throw. That call sits inside the health report, so one unmappable preset would have failed the *entire* check rather than degrading to the plain missing-model message. All eight loaders the presets use are mapped today, so this is latent — but the evaluator did not throw before and should not start. Mutation-verified.

## Verification

`npm run typecheck`, `npm test` (**456 passing, 53 files** — 439 on main), `npm run build`, `npx eslint .` — all green.

New `tests/comfy/modelPlacementDiagnostics.test.ts` plus additions to the compatibility, health, and folder suites cover: correct-bucket no-op, absent-everywhere exact string, one wrong folder, two wrong folders in fixed order, accepted-name match, case-insensitive match preserving spelling, nested-path basename match, `missingSources` never scanned, the unmapped-loader guard both ways, the seven bucket→folder pairs frozen and cross-checked against the loader map, both node messages, `COMFY_NODE_INPUT_MISSING` unchanged, and health-state routing.

## Smoke test

Needs ComfyUI on 8190. Nothing in `src/photoshop/*` changed, so no Photoshop behaviour should differ.

1. Settings → **Check Workflow Health** with everything installed — confirm the report reads as it always has, no new noise on ready presets.
2. Move one model into the wrong folder (e.g. `models/vae/ae.safetensors` → `models/checkpoints/`), restart or refresh ComfyUI, run Check Workflow Health again. Expect the "Found ... but this workflow reads it from ..." sentence naming both folders.
3. Confirm the text shows **no backtick characters** — that is the review fix above, and it is the one thing only a real panel can prove.
4. Move the file back, re-check, confirm the preset returns to Ready.
5. Optional: disable a custom node folder (e.g. `ComfyUI-Florence2`), restart ComfyUI, confirm Prompt from Layer names the repo URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)