### PR TITLE
Polish the Live Painting screen: button spacing, a negative prompt, and a hint that is actually visible

### DIFF
--- a/src/comfy/livePainting.ts
+++ b/src/comfy/livePainting.ts
@@ -13,6 +13,7 @@ export type BuildLcmLiveWorkflowOptions = {
   checkpointName: string;
   loraName: string;
   prompt: string;
+  negativePrompt?: string;
   sourceImageName: string;
   seed: number;
   denoise: number;
@@ -20,6 +21,7 @@ export type BuildLcmLiveWorkflowOptions = {
 
 export type BuildKrea2RefineWorkflowOptions = {
   prompt: string;
+  negativePrompt?: string;
   sourceImageName: string;
   seed: number;
   denoise: number;
@@ -52,7 +54,7 @@ export function buildLcmLiveWorkflow(options: BuildLcmLiveWorkflowOptions): Comf
     },
     "7": {
       class_type: "CLIPTextEncode",
-      inputs: { text: "", clip: ["15", 1] }
+      inputs: { text: options.negativePrompt ?? "", clip: ["15", 1] }
     },
     "10": {
       class_type: "LoadImage",
@@ -123,7 +125,7 @@ export function buildKrea2RefineWorkflow(options: BuildKrea2RefineWorkflowOption
     },
     "7": {
       class_type: "CLIPTextEncode",
-      inputs: { text: "", clip: ["21", 0] }
+      inputs: { text: options.negativePrompt ?? "", clip: ["21", 0] }
     },
     "3": {
       class_type: "KSampler",

--- a/src/styles.css
+++ b/src/styles.css
@@ -7248,6 +7248,23 @@ body,
   margin-bottom: 0 !important;
 }
 
+/* The Live Painting dependency hint is a paragraph, not a status line, and it
+   is the one `.diagnostics-line` in the panel that has to wrap. The compact
+   theme truncates that class to a single line (`white-space: nowrap` plus
+   `text-overflow: ellipsis`, with `max-height: 34px` and `overflow: hidden`
+   from earlier blocks), which is right for the seven status bars and wrong
+   here -- everything after the first clause has never been readable. Opting
+   out on its own class keeps all eight status lines exactly as they are.
+   The `overflow-wrap: anywhere !important` set alongside those rules is inert
+   while nowrap wins and starts working once it does. */
+.app-shell.theme-compact .live-dependency-hint {
+  max-height: none !important;
+  overflow: visible !important;
+  margin-bottom: 9px !important;
+  white-space: normal !important;
+  text-overflow: clip !important;
+}
+
 /* v0.6 final UXP hardening.
    Keep these rules deliberately simple: Photoshop's UXP renderer is more
    reliable with explicit margins, pixel radii, and fixed textarea heights. */

--- a/src/styles.css
+++ b/src/styles.css
@@ -7248,6 +7248,15 @@ body,
   margin-bottom: 0 !important;
 }
 
+/* Import Refined as Layer sits directly under the .import-actions row and is a
+   direct child of the panel, so the compact `.generator-panel > *
+   { margin: 0 !important }` reset strips the 8px it is given in the base theme.
+   Nothing puts it back: the block that restores a top margin further down only
+   names .button-primary/.button-generate, and this is a plain .button. */
+.app-shell.theme-compact .live-refined-import-button {
+  margin-top: 8px !important;
+}
+
 /* The Live Painting dependency hint is a paragraph, not a status line, and it
    is the one `.diagnostics-line` in the panel that has to wrap. The compact
    theme truncates that class to a single line (`white-space: nowrap` plus

--- a/src/styles.css
+++ b/src/styles.css
@@ -1638,6 +1638,23 @@ a:hover {
   margin-top: 4px;
 }
 
+.live-session-actions {
+  display: block;
+  margin-top: 4px;
+}
+
+/* Start and Stop are one control in two states, so they get one height. Start
+   carries .button-generate (38px here) and Stop is a plain .button (34px). */
+.live-session-actions > .button {
+  width: 100%;
+  min-height: 38px;
+  margin-bottom: 6px;
+}
+
+.live-session-actions > .button:last-child {
+  margin-bottom: 0;
+}
+
 .live-refine-actions {
   display: flex;
   gap: 6px;
@@ -7206,6 +7223,29 @@ body,
 .app-shell.theme-compact .status-pill.live-state-badge.refined {
   background: rgba(58, 148, 94, 0.28) !important;
   color: #9fe0b5 !important;
+}
+
+/* Start and Stop Live Session. Two things have to be undone here, both from
+   the compact `.button-primary, .button-generate` block further up the file:
+   its `margin: 8px 0 0 !important` leaves Start with no bottom margin, so the
+   two buttons touch, and only Start is pinned to 34px, so Stop renders shorter
+   as a plain 30px `.button`. This block must stay after that one to win, and
+   uses explicit margins rather than flex gap, which UXP does not honor. */
+.app-shell.theme-compact .live-session-actions {
+  display: block !important;
+  margin-top: 8px !important;
+}
+
+.app-shell.theme-compact .live-session-actions > .button,
+.app-shell.theme-compact .live-session-actions > .button-primary.button-generate {
+  width: 100% !important;
+  height: 34px !important;
+  min-height: 34px !important;
+  margin: 0 0 6px !important;
+}
+
+.app-shell.theme-compact .live-session-actions > .button:last-child {
+  margin-bottom: 0 !important;
 }
 
 /* v0.6 final UXP hardening.

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -336,6 +336,7 @@ export function renderApp(rootElement: HTMLElement) {
   let liveRefinedResult: LiveGeneratedImageResult | null = null;
   let liveImportAutomatically = false;
   let liveAutoRefine = false;
+  let isLiveNegativePromptOpen = false;
   let livePreviewZoomed = false;
   let hardwareReport: HardwareRecommendationReport | null = null;
   let workflowHealthReport: WorkflowHealthReport | null = null;
@@ -757,6 +758,7 @@ export function renderApp(rootElement: HTMLElement) {
     importUpscale: createActionRunner(elements, "importUpscale", handleImportUpscale),
     toggleUpscaleAutoImport: createActionRunner(elements, "toggleUpscaleAutoImport", handleToggleUpscaleAutoImport),
     clearHistory: createActionRunner(elements, "clearHistory", handleClearHistory),
+    toggleLiveNegativePrompt: createActionRunner(elements, "toggleLiveNegativePrompt", handleToggleLiveNegativePrompt),
     startLivePainting: createActionRunner(elements, "startLivePainting", handleStartLivePainting),
     stopLivePainting: createActionRunner(elements, "stopLivePainting", handleStopLivePainting),
     refineLivePainting: createActionRunner(elements, "refineLivePainting", handleRefineLivePainting),
@@ -814,6 +816,7 @@ export function renderApp(rootElement: HTMLElement) {
   bindActionControl(elements.importUpscaleButton, actionHandlers.importUpscale);
   bindActionControl(elements.upscaleAutoImportToggle, actionHandlers.toggleUpscaleAutoImport);
   bindActionControl(elements.clearHistoryButton, actionHandlers.clearHistory);
+  bindActionControl(elements.liveNegativePromptToggle, actionHandlers.toggleLiveNegativePrompt);
   bindActionControl(elements.liveStartButton, actionHandlers.startLivePainting);
   bindActionControl(elements.liveStopButton, actionHandlers.stopLivePainting);
   bindActionControl(elements.liveRefineButton, actionHandlers.refineLivePainting);
@@ -846,6 +849,7 @@ export function renderApp(rootElement: HTMLElement) {
   setGlobalError(elements, "");
   syncBusy();
   updateNegativePromptDisclosure(elements, isNegativePromptOpen);
+  updateLiveNegativePromptDisclosure(elements, isLiveNegativePromptOpen);
   updateAutoImportToggle(elements, importAutomatically);
   updateImg2ImgAutoImportToggle(elements, imageImportAutomatically);
   updateUpscaleAutoImportToggle(elements, upscaleImportAutomatically);
@@ -3413,6 +3417,11 @@ export function renderApp(rootElement: HTMLElement) {
     updateTextCheckpointCompatibility(elements);
   }
 
+  function handleToggleLiveNegativePrompt() {
+    isLiveNegativePromptOpen = !isLiveNegativePromptOpen;
+    updateLiveNegativePromptDisclosure(elements, isLiveNegativePromptOpen);
+  }
+
   async function handleStartLivePainting() {
     if (isBusy) {
       setLiveStatus("Finish the current generation before starting a live session.");
@@ -3443,6 +3452,7 @@ export function renderApp(rootElement: HTMLElement) {
       {
         checkpointName,
         prompt,
+        negativePrompt: elements.liveNegativePrompt.value,
         denoise: Number.isFinite(denoise) ? denoise : 0.6,
         autoRefineOnPause: liveAutoRefine,
         refineDenoise: 0.45,
@@ -3917,6 +3927,13 @@ function updateNegativePromptDisclosure(elements: AppElements, isOpen: boolean) 
   elements.negativePromptToggle.textContent = isOpen ? "Hide Negative Prompt" : "Show Negative Prompt";
   elements.negativePromptToggle.setAttribute("aria-expanded", String(isOpen));
   elements.negativePromptToggle.classList.toggle("is-active", isOpen);
+}
+
+function updateLiveNegativePromptDisclosure(elements: AppElements, isOpen: boolean) {
+  elements.liveNegativePromptField.hidden = !isOpen;
+  elements.liveNegativePromptToggle.textContent = isOpen ? "Hide Negative Prompt" : "Show Negative Prompt";
+  elements.liveNegativePromptToggle.setAttribute("aria-expanded", String(isOpen));
+  elements.liveNegativePromptToggle.classList.toggle("is-active", isOpen);
 }
 
 function updateAutoImportToggle(elements: AppElements, isEnabled: boolean) {

--- a/src/ui/appBindings.ts
+++ b/src/ui/appBindings.ts
@@ -66,6 +66,7 @@ export type ActionName =
   | "exportMaskToFile"
   | "exportMaskToComfyUI"
   | "clearHistory"
+  | "toggleLiveNegativePrompt"
   | "startLivePainting"
   | "stopLivePainting"
   | "refineLivePainting"

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -242,6 +242,9 @@ export type AppElements = {
   settingsDiagnosticsReport: HTMLTextAreaElement;
   livePaintingView: HTMLElement;
   livePrompt: HTMLTextAreaElement;
+  liveNegativePrompt: HTMLTextAreaElement;
+  liveNegativePromptToggle: HTMLElement;
+  liveNegativePromptField: HTMLElement;
   liveDenoise: HTMLInputElement;
   liveStartButton: HTMLElement;
   liveStopButton: HTMLElement;
@@ -359,6 +362,13 @@ export function createAppMarkup() {
             <span class="label">Prompt</span>
             <textarea class="textarea" id="live-prompt" placeholder="Describe what your painting should become..."></textarea>
           </label>
+          <section class="negative-prompt-section" aria-label="Live Painting negative prompt">
+            <button class="button disclosure-button action-control" id="live-negative-prompt-toggle" data-openlayer-action="toggleLiveNegativePrompt" type="button">Show Negative Prompt</button>
+            <label class="field negative-prompt-field" id="live-negative-prompt-field" hidden>
+              <span class="label">Negative prompt</span>
+              <textarea class="textarea" id="live-negative-prompt" placeholder="Optional: describe what to avoid..."></textarea>
+            </label>
+          </section>
           <label class="field">
             <span class="label">Strength (denoise)</span>
             <input class="input input-compact" id="live-denoise" type="number" min="0.2" max="0.95" step="0.05" value="0.6" />
@@ -1535,6 +1545,9 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     settingsDiagnosticsReport: getElement<HTMLTextAreaElement>(rootElement, "settings-diagnostics-report"),
     livePaintingView: getElement<HTMLElement>(rootElement, "live-painting-view"),
     livePrompt: getElement<HTMLTextAreaElement>(rootElement, "live-prompt"),
+    liveNegativePrompt: getElement<HTMLTextAreaElement>(rootElement, "live-negative-prompt"),
+    liveNegativePromptToggle: getElement<HTMLElement>(rootElement, "live-negative-prompt-toggle"),
+    liveNegativePromptField: getElement<HTMLElement>(rootElement, "live-negative-prompt-field"),
     liveDenoise: getElement<HTMLInputElement>(rootElement, "live-denoise"),
     liveStartButton: getElement<HTMLElement>(rootElement, "start-live-painting"),
     liveStopButton: getElement<HTMLElement>(rootElement, "stop-live-painting"),

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -354,9 +354,12 @@ export function createAppMarkup() {
             <span class="label">Live session</span>
             <span class="muted-label">Two-tier session</span>
           </div>
-          <div class="diagnostics-line">
-            Live tier uses the Text to Image checkpoint with the local SD 1.5 LCM LoRA; Refine uses Krea-2 Turbo.
-            Start a session, then paint in the document and watch the preview follow your strokes.
+          <div class="diagnostics-line live-dependency-hint">
+            The live tier runs the model picked in the Model dropdown on the Text to Image screen,
+            paired with your local SD 1.5 LCM LoRA. Refine uses Krea-2 Turbo.
+            If no model is selected there yet, open Text to Image, choose a workflow and a model,
+            then come back here. Once the session is running, paint in the document and the preview
+            follows your strokes.
           </div>
           <label class="field">
             <span class="label">Prompt</span>

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -363,8 +363,10 @@ export function createAppMarkup() {
             <span class="label">Strength (denoise)</span>
             <input class="input input-compact" id="live-denoise" type="number" min="0.2" max="0.95" step="0.05" value="0.6" />
           </label>
-          <button class="button button-primary button-generate button-wide action-control" id="start-live-painting" data-openlayer-action="startLivePainting" type="button">Start Live Session</button>
-          <button class="button button-wide action-control" id="stop-live-painting" data-openlayer-action="stopLivePainting" type="button">Stop Live Session</button>
+          <div class="live-session-actions">
+            <button class="button button-primary button-generate button-wide action-control" id="start-live-painting" data-openlayer-action="startLivePainting" type="button">Start Live Session</button>
+            <button class="button button-wide action-control" id="stop-live-painting" data-openlayer-action="stopLivePainting" type="button">Stop Live Session</button>
+          </div>
           <div class="live-refine-actions">
             <button class="button action-control" id="refine-live-painting" data-openlayer-action="refineLivePainting" type="button">Refine Now</button>
             <button class="button action-control" id="live-auto-refine-toggle" data-openlayer-action="toggleLiveAutoRefine" type="button" aria-pressed="false">Auto Refine on Pause</button>

--- a/src/ui/tools/livePainting.ts
+++ b/src/ui/tools/livePainting.ts
@@ -49,6 +49,7 @@ export type LivePaintingV2Callbacks = {
 export type LivePaintingV2Options = {
   checkpointName: string;
   prompt: string;
+  negativePrompt?: string;
   denoise: number;
   maxDimension?: number;
   autoRefineOnPause?: boolean;
@@ -395,6 +396,7 @@ export class LivePaintingSessionV2 {
       checkpointName: this.options.checkpointName,
       loraName: this.loraName,
       prompt: this.options.prompt,
+      negativePrompt: this.options.negativePrompt,
       sourceImageName,
       seed: this.seed,
       denoise: clampLiveDenoise(this.options.denoise)
@@ -450,6 +452,7 @@ export class LivePaintingSessionV2 {
 
     const workflow = buildKrea2RefineWorkflow({
       prompt: this.options.prompt,
+      negativePrompt: this.options.negativePrompt,
       sourceImageName,
       seed: this.seed,
       denoise: clampRefineDenoise(this.options.refineDenoise ?? 0.45),

--- a/tests/comfy/livePainting.test.ts
+++ b/tests/comfy/livePainting.test.ts
@@ -67,6 +67,43 @@ describe("livePainting", () => {
     expect(workflow[LIVE_PAINTING_SAVE_NODE_ID].inputs.images).toEqual(["8", 0]);
   });
 
+  it("injects the negative prompt into both live tiers and defaults it to empty", () => {
+    const live = buildLcmLiveWorkflow({
+      checkpointName: "epicrealism_naturalSinRC1VAE.safetensors",
+      loraName: "lcm-lora-sdv1-5.safetensors",
+      prompt: "a cozy cottage at golden hour",
+      negativePrompt: "blurry, watermark",
+      sourceImageName: "openlayer-live-1.png",
+      seed: 4242,
+      denoise: 0.6
+    });
+    const refine = buildKrea2RefineWorkflow({
+      prompt: "a luminous forest city",
+      negativePrompt: "blurry, watermark",
+      sourceImageName: "openlayer-refine-source.png",
+      seed: 9876,
+      denoise: 0.45
+    });
+
+    expect(live["7"].inputs.text).toBe("blurry, watermark");
+    expect(refine["7"].inputs.text).toBe("blurry, watermark");
+
+    // The node stays wired as KSampler's negative either way, so omitting the
+    // option has to keep producing the empty string the graph shipped with.
+    expect(live["3"].inputs.negative).toEqual(["7", 0]);
+    expect(refine["3"].inputs.negative).toEqual(["7", 0]);
+    expect(
+      buildLcmLiveWorkflow({
+        checkpointName: "epicrealism_naturalSinRC1VAE.safetensors",
+        loraName: "lcm-lora-sdv1-5.safetensors",
+        prompt: "a cozy cottage at golden hour",
+        sourceImageName: "openlayer-live-1.png",
+        seed: 4242,
+        denoise: 0.6
+      })["7"].inputs.text
+    ).toBe("");
+  });
+
   it("clamps live denoise into a usable range", () => {
     expect(clampLiveDenoise(0.6)).toBe(0.6);
     expect(clampLiveDenoise(0.05)).toBe(0.2);


### PR DESCRIPTION
Three UI fixes on Live Painting plus one Mehran caught in the smoke test. Markup, CSS, and one wiring change; the session and pump logic in `livePaintingSession`/`tools/livePainting.ts` is untouched apart from passing one new optional field through.

### 1. Start and Stop no longer touch (590e75b)
They were bare siblings of the panel section, the one arrangement the compact theme has no spacing for. `.live-session-actions` wraps them, following `.live-refine-actions` / `.import-actions`, and pins both to 34px so they stop rendering at different heights.

### 2. A negative prompt (d7c7f4b)
Both live builders already carried node `"7"` — a CLIPTextEncode wired into KSampler as `negative` — with its text hardcoded to `""`. The graph does not change: an optional `negativePrompt` defaulting to `""` replaces the literal, so a blank field produces a byte-identical workflow. UI copies the Text to Image disclosure pattern.

Not added to `BUSY_ALLOWED_ACTIONS`; the frozen count in `toolDescriptors.test.ts` stays at 35. That list inventories controls from the old panel-wide busy lock, nothing reads it at runtime, and no Live Painting control is in it.

### 3. The dependency hint is visible, and says something (ee7c13e)
`.app-shell.theme-compact .diagnostics-line` truncates with `white-space: nowrap` + `text-overflow: ellipsis`, so the hint's second sentence had never been on screen. It opts out on its own class rather than the shared one being loosened, which would reflow all eight screens. The copy now names where the checkpoint comes from and what to do when none is picked. Copy only, resolution logic unchanged.

### 4. Import Refined as Layer (ad87faa)
Found in Mehran's smoke test. Same defect as #1, one section down: base `margin-top: 8px` stripped by the compact `.generator-panel > * { margin: 0 !important }` reset, and the block that restores a top margin only names `.button-primary`/`.button-generate`.

### The trap underneath all three spacing bugs
In the compact theme `.generator-panel` resolves to `display: block !important`, which makes its `gap: 12px !important` inert. Every gap between panel children is a margin the reset has to be beaten for. New rules use explicit margins, per the stylesheet's own note that UXP does not honor flex gap.

### Validation
`npm run typecheck && npm test && npm run build && npx eslint .` green after each commit and again after a rebase onto current main. 462 tests (1 new, covering the injected negative prompt on both tiers and the empty default).

### Smoke checklist
1. Live Painting: confirm a visible gap between **Start Live Session** and **Stop Live Session**, and that both are the same height.
2. Confirm a visible gap between the **Import to Layers** row and **Import Refined as Layer**.
3. Confirm the hint under "Live session" renders as a full wrapped paragraph ending in "follows your strokes", not one ellipsised line.
4. Click **Show Negative Prompt**: the field appears and the button reads "Hide Negative Prompt". Click again to collapse.
5. Type a negative prompt, start a session, paint a stroke: the live preview still updates. Then **Refine Now** with the same negative prompt.
6. Leave the negative prompt blank, start a session, paint: behaviour identical to before this PR.
7. Any other screen (Text to Image, Inpaint): its status line still truncates to one line.

Items 1-3 verified by Mehran in Photoshop on the first three commits; item 2's fix is the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)