### PR TITLE
Release v0.10.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.10.0-alpha - 2026-07-31
+
+The first OpenLayer release whose plugin zip is built to the ZIP specification, which matters more than a packaging note usually would: every release from v0.1.0 to v0.9.0-alpha wrote its entry paths with backslashes, and macOS refuses to unpack those into folders. Everything else here follows from the same question — what happens to somebody setting this up without anyone to ask. Workflow health now tells you which folder your "missing" model is actually sitting in, missing nodes name the package that provides them, and Live Painting stops looking half-finished.
+
+### Added
+
+- **Check Workflow Health now answers "the file is missing, or is it just in the wrong folder?"** When a preset's model is absent from the folder its loader reads, the report searches the other model folders and names where it found it: "Found <model> in models/diffusion_models/, but this workflow reads it from models/checkpoints/. Move the file, then refresh ComfyUI." `CheckpointLoaderSimple` reads `models/checkpoints/` and `UNETLoader` reads `models/diffusion_models/`, and a file in the wrong one of those is invisible to the workflow while looking exactly like a file that was never downloaded. This has already been the real cause of several reported "bugs".
+- **A missing custom node now names the repository that provides it**, and where to put it, instead of only naming the class that was absent. Nodes that ship with ComfyUI itself say so instead, because for those the answer is an outdated or partially broken install rather than a download.
+- **Live Painting has a negative prompt**, collapsed behind a disclosure button like the one on Text to Image. Both live tiers already had a CLIP text encoder wired into the sampler as its negative conditioning with the text hardcoded to empty; this makes it an input. Left blank, it produces exactly the workflow earlier releases submitted.
+
+### Fixed
+
+- **Release zips now store entry paths with forward slashes, as the ZIP specification requires.** Packaging used to shell out to PowerShell's `Compress-Archive`, which writes backslashes. Windows Explorer and the UXP Developer Tool tolerate that, which is how it survived nine releases unnoticed; macOS `unzip` does not, and treats the whole string as a single filename, unpacking a flat directory with no `assets/` folder so the panel cannot render. Both archives now come from the same spec-correct writer the setup pack already used, and neither depends on a platform binary being installed. **If you are on macOS and an earlier release gave you a blank panel, this was why — use this release.**
+- Fixed Start Live Session and Stop Live Session rendering flush against each other, at different heights. They were the only button pair in the panel with no container, and the compact theme gives a top margin to primary buttons and nothing to plain ones.
+- Fixed both of Live Painting's explanatory hints being cut off after their first clause. The shared status-line style truncates to one line with an ellipsis, which is correct for the eight status bars it was written for and wrong for a paragraph, so the two hints now opt out on their own class rather than the shared style being loosened.
+- Fixed the gap above "Import Refined as Layer", which had the same cause as the Start/Stop pair one section further down.
+
+### Changed
+
+- Live Painting's dependency hint now says which model the live tier will use and what to do when none is chosen, instead of implying the dependency. It runs whatever is selected in the Model dropdown on Text to Image, and until this release the sentence explaining that was one of the ones being truncated.
+
+### Known limitations
+
+- **Live Painting is experimental.** The live tier needs an SD 1.5 LCM LoRA in `models/loras/`, and Start Live Session reports an error naming it if none is found. The Refine tier additionally needs the three Krea-2 Turbo files (diffusion model, text encoder, VAE); without them the live tier still works and Refine reports what is missing. Auto-import fires when you stop the session, by design.
+- Installation still requires the UXP Developer Tool. Whether a `.ccx` double-click install works on a machine that has never had developer mode enabled is documented as an open question in `docs/DISTRIBUTION_SPIKE.md` and needs a clean second machine to answer.
+- The Layer Tools card on Home does not dim when ComfyUI is unreachable, unlike the generation tools. Saving to a file works with ComfyUI stopped; Send to ComfyUI will fail and report the connection error on the Layer Tools status line.
+- Layer, canvas, selection, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
+- The Preview panel offers each tool's primary import only. Live Painting's second action, "Import Refined as Layer", is not on the panel, because the refined result is a separate image and the panel shows one at a time.
+- The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the list and the downloader instead — an internet connection is required.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+- CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
+
 ## v0.9.0-alpha - 2026-07-27
 
 Adds the eighth tool, and finishes the status cleanup the 0.8 releases started. Layer Tools is the first thing OpenLayer does that is not a generation: it moves pixels *out* of Photoshop, into a file or into ComfyUI's input folder, which is the step that has until now meant leaving the panel.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.9.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
+`v0.10.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
 
-New in `v0.9.0-alpha`:
+New in `v0.10.0-alpha`:
+
+- **The plugin zip is built to the ZIP specification for the first time.** Every release from v0.1.0 to v0.9.0-alpha stored entry paths with backslashes, which macOS `unzip` unpacks as a flat directory with no `assets/` folder, so the panel could not render. **If an earlier release gave you a blank panel on macOS, this was why — use this one.**
+- **Check Workflow Health finds models that are in the wrong folder.** When a preset's model is missing from the folder its loader reads, the report searches the other model folders and names where it found it, so "missing" and "downloaded, but one directory over" stop looking identical. It also names the repository that provides a missing custom node.
+- **Live Painting has a negative prompt** and a round of interface fixes: the session buttons no longer touch, and both of its explanatory hints are readable instead of being cut off after their first clause. It remains experimental.
+
+Also new in `v0.9.0-alpha`:
 
 - **Layer Tools**, the eighth tool and the first that is not a generation. Export the active layer, the current selection, or the selection mask, either to a file you pick with a Photoshop save dialog or straight into ComfyUI's input folder where a workflow can reference it by name.
 - Each tool's diagnostics line and error text now stay on that tool's screen. Settings remains the panel-wide log and still shows what every tool reported.
@@ -93,7 +99,14 @@ The earlier card-based dashboard established OpenLayer's honest available/experi
 
 </details>
 
-v0.9.0-alpha tester focus:
+v0.10.0-alpha tester focus:
+
+- Unzip the release package and confirm it expands into folders, with an `assets/` directory beside `index.html` — not a flat pile of files with backslashes in their names. **On macOS this is the single most useful thing to report.**
+- Put a model in the wrong folder on purpose — move a checkpoint into `models/diffusion_models/`, say — then run **Check Workflow Health** and confirm the report names the folder it actually found it in and the folder the workflow wants.
+- Open **Live Painting**. Confirm Start and Stop Live Session have a gap between them and are the same height, and that the two explanatory hints read as full paragraphs rather than ending in an ellipsis.
+- Set a Live Painting negative prompt, start a session, and paint. Then run one session with the field left blank and confirm it behaves as it did before.
+
+Also worth rechecking from v0.9.0-alpha:
 
 - Open **Layer Tools** from Home. With a layer selected, save it to a file, then send it to ComfyUI and confirm it appears in ComfyUI's `input` folder under the name the status line reports.
 - Make a selection, then run both the **Selection** and **Selection mask** exports. The mask is the one an inpainting workflow wants; confirm it is a black-and-white image matching what you selected.
@@ -109,7 +122,7 @@ v0.9.0-alpha tester focus:
 - Run `npm run setup-pack` and confirm it reports no source/API mismatches at all.
 - Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
-Known v0.9.0-alpha boundaries:
+Known v0.10.0-alpha boundaries:
 
 - Image to Image is an early foundation path, not a full production workflow yet.
 - Sketch to Image is limited to the first SD 1.x LINECN starter workflow.
@@ -270,7 +283,7 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.9.0-alpha.zip
+packages/openlayer-v0.10.0-alpha.zip
 ```
 
 ## Loading In UXP Developer Tool
@@ -397,7 +410,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.9.0-alpha test result:
+Use this quick pass before reporting a v0.10.0-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,10 +33,10 @@
       "operatingSystem": "Windows, macOS",
       "applicationCategory": "DesignApplication",
       "applicationSubCategory": "Adobe Photoshop plugin",
-      "softwareVersion": "0.9.0-alpha",
+      "softwareVersion": "0.10.0-alpha",
       "description": "Open-source Photoshop UXP plugin that connects to a local ComfyUI server for AI image generation: text to image, image to image, sketch to image, inpaint, outpaint, and upscale with Stable Diffusion, SDXL, and Flux models.",
       "url": "https://mehran-ahmadi.com/OpenLayer/",
-      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.9.0-alpha",
+      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.10.0-alpha",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Mehran Ahmadi", "url": "https://github.com/MehranMarxian" }
     }
@@ -65,7 +65,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.9.0 · free &amp; open source</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.10.0 · free &amp; open source</p>
           <h1 id="hero-title">Local AI layers,<br><span class="grad">inside Photoshop.</span></h1>
           <p class="hero-lede">
             OpenLayer connects Photoshop to <strong>your own ComfyUI server</strong>.
@@ -74,7 +74,7 @@
             <strong>No cloud. No credits. No subscription.</strong>
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.9.0-alpha">Download alpha</a>
+            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.10.0-alpha">Download alpha</a>
             <a class="button button-secondary" href="https://github.com/MehranMarxian/OpenLayer">Star on GitHub</a>
           </div>
           <ul class="signal-list" aria-label="Project signals">
@@ -92,15 +92,16 @@
 
       <section class="intro" aria-labelledby="intro-title">
         <div class="section-inner">
-          <p class="eyebrow">v0.9 layer tools</p>
+          <p class="eyebrow">v0.10 setup that explains itself</p>
           <h2 id="intro-title">Local generation that now feels at home inside Photoshop.</h2>
           <p class="intro-lede">
             OpenLayer starts with dependable local workflows — text to image, image to image,
             sketch to image, experimental inpaint and outpaint, pixel upscale, lossless PNG
             source capture, live previews, diagnostics, and clean import into the active document.
-            v0.9 adds Layer Tools, the first tool that sends pixels the other way: export the active
-            layer, the current selection, or the selection mask to a file you pick or straight into
-            ComfyUI's input folder. Each tool's diagnostics and errors now stay on its own screen.
+            v0.10 turns to the part nobody enjoys: setup. Workflow Health now tells you when a
+            "missing" model is really just one folder over, and names the repository behind a missing
+            custom node. The plugin zip is also built to spec for the first time, which is what makes
+            it unpack correctly on macOS.
           </p>
         </div>
       </section>
@@ -149,12 +150,12 @@
             </article>
             <article class="tool-card">
               <span class="tool-icon"><img src="assets/tools/live-painting.png" alt=""></span>
-              <div><h3>Live Painting</h3><span class="chip chip-ready">New in v0.9</span></div>
+              <div><h3>Live Painting</h3><span class="chip chip-exp">Experimental</span></div>
               <p>Keep painting and OpenLayer keeps repainting — a fast local preview tier that follows your strokes, plus a slower Krea-2 Turbo refine pass on demand.</p>
             </article>
             <article class="tool-card">
               <span class="tool-icon"><img src="assets/tools/layer-tools.png" alt=""></span>
-              <div><h3>Layer Tools</h3><span class="chip chip-ready">New in v0.9</span></div>
+              <div><h3>Layer Tools</h3><span class="chip chip-ready">Stable</span></div>
               <p>Send pixels the other way. Export the active layer, the current selection, or the selection mask — to a file you pick, or straight into ComfyUI's input folder where a workflow can use it.</p>
             </article>
             <article class="tool-card">
@@ -322,11 +323,11 @@ npm run build</code></pre>
             </article>
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.9.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.10.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
-              <p>v0.9.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
+              <p>v0.10.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
             </article>
             <article class="status-card">
               <h3>Flux Fill is experimental</h3>
@@ -349,7 +350,7 @@ npm run build</code></pre>
               <li>Inpaint and Outpaint should be tested on duplicate layers first.</li>
               <li>Prompt from Layer requires the local Florence-2 PromptGen model and the comfyui-florence2 nodes. The custom-scripts pack is no longer needed.</li>
               <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.9.0 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.10.0 keeps the shared metadata foundation and session-history wiring.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
               <li>Progress is shown in the generation status panel rather than pinned to the screen header, so it scrolls with the form.</li>
@@ -391,6 +392,10 @@ npm run build</code></pre>
               <p>Export the active layer, the current selection, or the selection mask to a file or straight into ComfyUI's input folder — and every tool's messages finally stay on its own screen.</p>
             </article>
             <article>
+              <h3>v0.10 · Setup diagnostics</h3>
+              <p>Workflow Health finds models sitting in the wrong folder and names the repository behind a missing node — and the plugin zip is finally built to spec, so it unpacks correctly on macOS.</p>
+            </article>
+            <article>
               <h3>Next · Reliability and artist control</h3>
               <p>Finish Inpaint and Outpaint alignment, strengthen workflow validation, and turn the metadata foundation into repeatable layer-level iteration.</p>
             </article>
@@ -419,7 +424,7 @@ npm run build</code></pre>
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.9.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.10.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a>
       </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlayer",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlayer",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.openlayer.photoshop",
   "name": "OpenLayer",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "index.html",
   "host": [
     {

--- a/src/styles.css
+++ b/src/styles.css
@@ -7257,16 +7257,16 @@ body,
   margin-top: 8px !important;
 }
 
-/* The Live Painting dependency hint is a paragraph, not a status line, and it
-   is the one `.diagnostics-line` in the panel that has to wrap. The compact
-   theme truncates that class to a single line (`white-space: nowrap` plus
-   `text-overflow: ellipsis`, with `max-height: 34px` and `overflow: hidden`
-   from earlier blocks), which is right for the seven status bars and wrong
-   here -- everything after the first clause has never been readable. Opting
-   out on its own class keeps all eight status lines exactly as they are.
+/* The two Live Painting hints are paragraphs, not status lines, and they are
+   the only `.diagnostics-line` elements in the panel that have to wrap. The
+   compact theme truncates that class to a single line (`white-space: nowrap`
+   plus `text-overflow: ellipsis`, with `max-height: 34px` and `overflow:
+   hidden` from earlier blocks), which is right for the eight status bars and
+   wrong here -- everything after the first clause has never been readable.
+   Opting out on its own class keeps those status lines exactly as they are.
    The `overflow-wrap: anywhere !important` set alongside those rules is inert
    while nowrap wins and starts working once it does. */
-.app-shell.theme-compact .live-dependency-hint {
+.app-shell.theme-compact .live-hint {
   max-height: none !important;
   overflow: visible !important;
   margin-bottom: 9px !important;

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -1,7 +1,7 @@
 import { OpenLayerTheme } from "../utils/preferences";
 
 export const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-export const APP_VERSION = "0.9.0";
+export const APP_VERSION = "0.10.0";
 export const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 export const HISTORY_LIMIT = 5;
 export const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -354,7 +354,7 @@ export function createAppMarkup() {
             <span class="label">Live session</span>
             <span class="muted-label">Two-tier session</span>
           </div>
-          <div class="diagnostics-line live-dependency-hint">
+          <div class="diagnostics-line live-hint">
             The live tier runs the model picked in the Model dropdown on the Text to Image screen,
             paired with your local SD 1.5 LCM LoRA. Refine uses Krea-2 Turbo.
             If no model is selected there yet, open Text to Image, choose a workflow and a model,
@@ -399,7 +399,7 @@ export function createAppMarkup() {
             <button class="button action-control" id="live-auto-import-toggle" data-openlayer-action="toggleLiveAutoImport" type="button" aria-pressed="false">Import Automatically</button>
           </div>
           <button class="button live-refined-import-button action-control" id="import-live-refined" data-openlayer-action="importLiveRefined" type="button">Import Refined as Layer</button>
-          <div class="diagnostics-line">
+          <div class="diagnostics-line live-hint">
             Import Automatically brings the latest live result into Photoshop as a new layer when you stop the session.
           </div>
         </section>


### PR DESCRIPTION
Release paperwork for v0.10.0-alpha. Three commits: version bump, one last code fix, release notes.

## What's in the release

| PR | Change | User-facing |
|---|---|---|
| #57 | Release zips written with forward slashes | **Yes — the macOS blank-panel fix** |
| #58 | Setup diagnostics Phase 1: cross-folder model search, custom-node repo names | Yes |
| #60 | Live Painting polish: negative prompt, button spacing, hint truncation | Yes |
| #24 | `.ccx` packaging spike | No — documentation only |
| #59 | WFL agent | No — contributor tooling under `.claude/` |

The last two are deliberately absent from the release notes.

## Commits

1. **b77be3f** version bump to 0.10.0 in all four locations, first so the panel footer reads v0.10.0 while you smoke-test.
2. **60296d1** the second Live Painting hint, which had the same truncation as the one fixed in #60. `.live-dependency-hint` becomes `.live-hint`, since the old name would be a misnomer on a hint about auto-import.
3. **a5678a4** CHANGELOG, README, landing page.

## Verified, not asserted

`npm run package` output inspected directly: **47 entries, 0 with backslashes**, `assets/index-….css` with forward slashes. Setup pack likewise, 29 entries, 0 backslashes. This is the claim the release leads with, so it was measured rather than trusted.

Every note checked against `git log v0.9.0-alpha..HEAD` and the code, per the v0.8.0 lesson about drafted notes describing a fix a later PR had replaced.

## One truth-check correction

The landing page had Live Painting on a `chip-ready` "New in v0.9" chip, which reads as stable beside Inpaint and Outpaint. Given it needs an SD 1.5 LCM LoRA to start at all, it now carries the same **Experimental** chip they do, and the known limitations name both that LoRA and the three Krea-2 files the refine tier wants. Layer Tools moves to Stable.

## Smoke checklist

1. Panel footer reads **v0.10.0**.
2. Live Painting: gap between Start and Stop, both same height; gap above **Import Refined as Layer**; **both** hints read as full paragraphs — the one under "Live session" and the one under the import buttons, which is the newly fixed one.
3. Move a checkpoint into `models/diffusion_models/`, run **Check Workflow Health**, confirm it names the folder it found it in and the folder the workflow wants. Move it back.
4. Trigger a missing-node message and confirm it names a repository to install from.
5. Unzip `packages/openlayer-v0.10.0-alpha.zip` somewhere fresh and confirm an `assets/` folder exists beside `index.html`.
6. Load that build in UDT and run one Text to Image generate + import, to confirm the repacked zip is loadable.

Not merging until you have passed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)