### PR TITLE
Setup tab, part 1: the requirements data layer

### DIFF
--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -862,6 +862,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "txt2img-basic",
     label: "txt2img-basic",
+    displayName: "Standard checkpoint",
     mode: "txt2img",
     description: "Basic local text-to-image generation through ComfyUI.",
     workflowFile: "workflows/api/txt2img-basic.json",
@@ -910,6 +911,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "txt2img-flux1-dev-fp8",
     label: "txt2img-flux1-dev-fp8",
+    displayName: "Flux1-dev fp8",
     mode: "txt2img",
     description: "Experimental Flux1-dev fp8 text-to-image workflow using a checkpoint-style ComfyUI graph.",
     workflowFile: "workflows/api/txt2img-flux1-dev-fp8.json",
@@ -970,6 +972,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "img2img-basic",
     label: "img2img-basic",
+    displayName: "Standard checkpoint",
     mode: "img2img",
     description: "Basic local image-to-image generation using an uploaded source image.",
     workflowFile: "workflows/api/img2img-basic.json",
@@ -1023,6 +1026,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "prompt-from-layer-florence2",
     label: "prompt-from-layer-florence2",
+    displayName: "Florence-2 PromptGen",
     mode: "prompt",
     description: "Experimental Florence-2 PromptGen workflow that describes a captured Photoshop layer or canvas.",
     workflowFile: "workflows/api/prompt-from-layer-florence2.json",
@@ -1062,6 +1066,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "upscale-basic",
     label: "upscale-basic",
+    displayName: "Standard upscaler",
     mode: "upscale",
     description: "Experimental pixel upscale through ComfyUI UpscaleModelLoader and ImageUpscaleWithModel.",
     workflowFile: "workflows/api/upscale-basic.json",
@@ -1101,6 +1106,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "sketch2img-linecn-basic",
     label: "sketch2img-linecn-basic",
+    displayName: "LineArt ControlNet",
     mode: "sketch2img",
     description: "Experimental SD 1.x LineArt ControlNet sketch guidance workflow.",
     workflowFile: "workflows/api/sketch2img-linecn-basic.json",
@@ -1184,6 +1190,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "inpaint-basic",
     label: "inpaint-basic",
+    displayName: "Standard checkpoint",
     mode: "inpaint",
     description: "Experimental SD 1.x inpainting workflow using a Photoshop selection source and mask.",
     workflowFile: "workflows/api/inpaint-basic.json",
@@ -1253,6 +1260,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "inpaint-flux-fill-basic",
     label: "inpaint-flux-fill-basic",
+    displayName: "Flux Fill",
     mode: "inpaint",
     description: "Experimental Flux Fill inpainting workflow using a diffusion model stack.",
     workflowFile: "workflows/api/inpaint-flux-fill-basic.json",
@@ -1334,6 +1342,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "outpaint-flux-fill-basic",
     label: "outpaint-flux-fill-basic",
+    displayName: "Flux Fill",
     mode: "outpaint",
     description: "Experimental Flux Fill outpainting workflow using ImagePadForOutpaint.",
     workflowFile: "workflows/api/outpaint-flux-fill-basic.json",
@@ -1420,6 +1429,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "txt2img-z-image-turbo",
     label: "txt2img-z-image-turbo",
+    displayName: "Z_image_Turbo",
     mode: "txt2img",
     description: "Experimental text-to-image preset for the Z_image_Turbo diffusion model stack.",
     workflowFile: "workflows/api/txt2img-z-image-turbo.json",
@@ -1491,6 +1501,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "img2img-z-image-turbo",
     label: "img2img-z-image-turbo",
+    displayName: "Z_image_Turbo",
     mode: "img2img",
     description: "Experimental image-to-image preset for the Z_image_Turbo diffusion model stack.",
     workflowFile: "workflows/api/img2img-z-image-turbo.json",
@@ -1567,6 +1578,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "txt2img-krea2-turbo",
     label: "txt2img-krea2-turbo",
+    displayName: "Krea-2 Turbo",
     mode: "txt2img",
     description: "Experimental text-to-image preset for the Krea-2 Turbo diffusion model stack.",
     workflowFile: "workflows/api/txt2img-krea2-turbo.json",
@@ -1632,6 +1644,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "img2img-krea2-turbo",
     label: "img2img-krea2-turbo",
+    displayName: "Krea-2 Turbo",
     mode: "img2img",
     description: "Experimental image-to-image preset for the Krea-2 Turbo diffusion model stack.",
     workflowFile: "workflows/api/img2img-krea2-turbo.json",
@@ -1702,6 +1715,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "txt2img-flux1-dev",
     label: "txt2img-flux1-dev",
+    displayName: "Flux1-dev",
     mode: "txt2img",
     description: "Future text-to-image preset for Flux.1-dev style diffusion model stacks.",
     workflowFile: "workflows/api/txt2img-flux1-dev.json",
@@ -1736,6 +1750,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
   {
     id: "img2img-flux1-dev",
     label: "img2img-flux1-dev",
+    displayName: "Flux1-dev",
     mode: "img2img",
     description: "Future image-to-image preset for Flux.1-dev style diffusion model stacks.",
     workflowFile: "workflows/api/img2img-flux1-dev.json",

--- a/src/comfy/setupManifest.ts
+++ b/src/comfy/setupManifest.ts
@@ -79,6 +79,7 @@ export type SetupManifestCustomNode = {
 export type SetupManifestPreset = {
   id: string;
   label: string;
+  displayName: string;
   mode: string;
   status: string;
   description: string;
@@ -205,6 +206,7 @@ export function buildSetupManifest(options: BuildSetupManifestOptions): SetupMan
     manifestPresets.push({
       id: preset.id,
       label: preset.label,
+      displayName: preset.displayName,
       mode: preset.mode,
       status: preset.status,
       description: preset.description,

--- a/src/comfy/setupRequirements.ts
+++ b/src/comfy/setupRequirements.ts
@@ -11,6 +11,7 @@ import { getAvailableRequiredModelName } from "./workflowModelRequirements";
 import { findMisplacedModel } from "./modelPlacementDiagnostics";
 import { getWorkflowCapability } from "./workflowCapabilities";
 import { WorkflowNodeAvailability } from "./workflowCompatibility";
+import { createOpenLayerError } from "../utils/errors";
 
 export type SetupRequirementStatus = "installed" | "wrong-folder" | "missing" | "not-checked";
 
@@ -99,7 +100,11 @@ export function evaluateSetupRequirements(
       const requiredModel = requiredModelsByKey.get(manifestModel.key);
 
       if (!requiredModel) {
-        throw new Error(`Setup manifest model ${manifestModel.key} has no matching registry model.`);
+        throw createOpenLayerError(
+          "WORKFLOW_INVALID",
+          `No registry model matches the setup requirement ${manifestModel.key}.`,
+          "The setup manifest and the preset registry disagree about a required model key."
+        );
       }
 
       return evaluateModelRequirement(
@@ -143,7 +148,12 @@ export function evaluateSetupRequirements(
         .filter((model) => model.status === "missing")
         .reduce((total, model) => total + (model.sizeBytes ?? 0), 0)
     : models.reduce((total, model) => total + (model.sizeBytes ?? 0), 0);
-  const formattedRemainingDownload = formatBytes(remainingDownloadBytes);
+  // formatBytes answers "how big is this model?", where zero means the size was
+  // never published — so it returns "unknown" for zero. Here zero means the
+  // opposite and is the best possible news, so it must not be routed through it:
+  // a fully set up machine would otherwise read "unknown left to download".
+  const formattedRemainingDownload =
+    remainingDownloadBytes > 0 ? formatBytes(remainingDownloadBytes) : "Nothing";
 
   return {
     checked,

--- a/src/comfy/setupRequirements.ts
+++ b/src/comfy/setupRequirements.ts
@@ -1,0 +1,311 @@
+import {
+  ComfyModelInventory,
+  WorkflowModelFolder,
+  WorkflowPresetDefinition,
+  WorkflowRequiredModel
+} from "./types";
+import { listRunnableWorkflowPresets } from "./presetRegistry";
+import { buildSetupManifest, formatBytes, SetupManifestModel } from "./setupManifest";
+import { getRequiredModelKey, listRequiredModelsForPresets } from "./modelFolders";
+import { getAvailableRequiredModelName } from "./workflowModelRequirements";
+import { findMisplacedModel } from "./modelPlacementDiagnostics";
+import { getWorkflowCapability } from "./workflowCapabilities";
+import { WorkflowNodeAvailability } from "./workflowCompatibility";
+
+export type SetupRequirementStatus = "installed" | "wrong-folder" | "missing" | "not-checked";
+
+export type SetupModelRequirement = {
+  key: string;
+  label: string;
+  modelName: string;
+  status: SetupRequirementStatus;
+  targetFolder: WorkflowModelFolder;
+  targetPath: string;
+  foundInFolders: WorkflowModelFolder[];
+  detectedModelName: string | null;
+  downloadUrl?: string;
+  sourcePageUrl?: string;
+  sizeBytes?: number;
+  formattedSize: string;
+  layout: "file" | "repo-folder";
+  licenseGated: boolean;
+  acceptedModelNames: string[];
+  setupHint?: string;
+  usedByPresets: string[];
+  unlocksToolLabels: string[];
+};
+
+export type SetupNodeRequirement = {
+  name: string;
+  repoUrl: string;
+  status: SetupRequirementStatus;
+  classTypes: string[];
+  missingClassTypes: string[];
+  usedByPresets: string[];
+  unlocksToolLabels: string[];
+};
+
+export type SetupToolFilter = {
+  toolLabel: string;
+  presetIds: string[];
+  modelKeys: string[];
+  customNodeNames: string[];
+};
+
+export type SetupRequirementsReport = {
+  checked: boolean;
+  models: SetupModelRequirement[];
+  customNodes: SetupNodeRequirement[];
+  toolFilters: SetupToolFilter[];
+  counts: Record<SetupRequirementStatus, number>;
+  remainingDownloadBytes: number;
+  formattedRemainingDownload: string;
+  summaryLine: string;
+};
+
+export type EvaluateSetupRequirementsOptions = {
+  pluginVersion: string;
+  presets?: readonly WorkflowPresetDefinition[];
+  inventory?: Partial<ComfyModelInventory> | null;
+  nodeAvailability?: WorkflowNodeAvailability | null;
+  generatedAt?: string;
+};
+
+const STATUS_RANK: Record<SetupRequirementStatus, number> = {
+  missing: 0,
+  "wrong-folder": 1,
+  "not-checked": 2,
+  installed: 3
+};
+
+export function evaluateSetupRequirements(
+  options: EvaluateSetupRequirementsOptions
+): SetupRequirementsReport {
+  const presets = options.presets ?? listRunnableWorkflowPresets();
+  const manifest = buildSetupManifest({
+    pluginVersion: options.pluginVersion,
+    presets,
+    generatedAt: options.generatedAt
+  });
+  const requiredModelsByKey = new Map<string, WorkflowRequiredModel>(
+    listRequiredModelsForPresets(presets).map((model) => [getRequiredModelKey(model), model])
+  );
+  const presetsById = new Map(presets.map((preset) => [preset.id, preset]));
+  const inventorySupplied = options.inventory != null;
+  const nodeAvailabilitySupplied = options.nodeAvailability != null;
+
+  const models = manifest.models
+    .map((manifestModel) => {
+      const requiredModel = requiredModelsByKey.get(manifestModel.key);
+
+      if (!requiredModel) {
+        throw new Error(`Setup manifest model ${manifestModel.key} has no matching registry model.`);
+      }
+
+      return evaluateModelRequirement(
+        manifestModel,
+        requiredModel,
+        presetsById,
+        inventorySupplied ? options.inventory ?? {} : null
+      );
+    })
+    .sort(compareModels);
+
+  const customNodes = manifest.customNodes
+    .map((node) => {
+      const classTypes = [...node.classTypes].sort();
+      const missingClassTypes = nodeAvailabilitySupplied
+        ? classTypes.filter((classType) => !(classType in (options.nodeAvailability ?? {})))
+        : [];
+      const status: SetupRequirementStatus = !nodeAvailabilitySupplied
+        ? "not-checked"
+        : missingClassTypes.length === 0
+          ? "installed"
+          : "missing";
+
+      return {
+        name: node.name,
+        repoUrl: node.repoUrl,
+        status,
+        classTypes,
+        missingClassTypes,
+        usedByPresets: [...node.usedByPresets],
+        unlocksToolLabels: getToolLabels(node.usedByPresets, presetsById)
+      };
+    })
+    .sort(compareNodes);
+
+  const checked = inventorySupplied || nodeAvailabilitySupplied;
+  const counts = countStatuses(models, customNodes);
+  const remainingDownloadBytes = inventorySupplied
+    ? models
+        // A wrong-folder model is already downloaded, so it must never prompt another download.
+        .filter((model) => model.status === "missing")
+        .reduce((total, model) => total + (model.sizeBytes ?? 0), 0)
+    : models.reduce((total, model) => total + (model.sizeBytes ?? 0), 0);
+  const formattedRemainingDownload = formatBytes(remainingDownloadBytes);
+
+  return {
+    checked,
+    models,
+    customNodes,
+    toolFilters: createToolFilters(presets, manifest.presets),
+    counts,
+    remainingDownloadBytes,
+    formattedRemainingDownload,
+    summaryLine: createSummaryLine(checked, counts, formattedRemainingDownload)
+  };
+}
+
+function evaluateModelRequirement(
+  manifestModel: SetupManifestModel,
+  requiredModel: WorkflowRequiredModel,
+  presetsById: ReadonlyMap<string, WorkflowPresetDefinition>,
+  inventory: Partial<ComfyModelInventory> | null
+): SetupModelRequirement {
+  let status: SetupRequirementStatus = "not-checked";
+  let foundInFolders: WorkflowModelFolder[] = [];
+  let detectedModelName: string | null = null;
+
+  if (inventory) {
+    const availableModelName = getAvailableRequiredModelName(inventory, requiredModel);
+
+    if (availableModelName) {
+      status = "installed";
+      detectedModelName = availableModelName;
+    } else {
+      const misplacedModel = findMisplacedModel(inventory, requiredModel);
+
+      if (misplacedModel) {
+        status = "wrong-folder";
+        foundInFolders = [...misplacedModel.folders];
+        detectedModelName = misplacedModel.modelName;
+      } else {
+        status = "missing";
+      }
+    }
+  }
+
+  return {
+    key: getRequiredModelKey(requiredModel),
+    label: manifestModel.label,
+    modelName: manifestModel.modelName,
+    status,
+    targetFolder: manifestModel.targetFolder,
+    targetPath: manifestModel.targetPath,
+    foundInFolders,
+    detectedModelName,
+    downloadUrl: manifestModel.downloadUrl,
+    sourcePageUrl: manifestModel.sourcePageUrl,
+    sizeBytes: manifestModel.sizeBytes,
+    formattedSize:
+      manifestModel.sizeBytes === undefined ? "Size not published" : formatBytes(manifestModel.sizeBytes),
+    layout: manifestModel.layout,
+    licenseGated: Boolean(manifestModel.licenseGate),
+    acceptedModelNames: uniqueSorted(
+      (manifestModel.acceptedModelNames ?? []).filter((name) => name !== manifestModel.modelName)
+    ),
+    setupHint: manifestModel.setupHint,
+    usedByPresets: [...manifestModel.usedByPresets],
+    unlocksToolLabels: getToolLabels(manifestModel.usedByPresets, presetsById)
+  };
+}
+
+function getToolLabels(
+  presetIds: readonly string[],
+  presetsById: ReadonlyMap<string, WorkflowPresetDefinition>
+): string[] {
+  const labels = presetIds.flatMap((presetId) => {
+    const preset = presetsById.get(presetId);
+    return preset ? [getWorkflowCapability(preset).artistLabel] : [];
+  });
+
+  return uniqueSorted(labels);
+}
+
+function createToolFilters(
+  presets: readonly WorkflowPresetDefinition[],
+  manifestPresets: readonly {
+    id: string;
+    modelKeys: string[];
+    customNodePackages: string[];
+  }[]
+): SetupToolFilter[] {
+  const manifestPresetsById = new Map(manifestPresets.map((preset) => [preset.id, preset]));
+  const filtersByLabel = new Map<string, SetupToolFilter>();
+
+  for (const preset of presets) {
+    const toolLabel = getWorkflowCapability(preset).artistLabel;
+    const manifestPreset = manifestPresetsById.get(preset.id);
+    const filter = filtersByLabel.get(toolLabel) ?? {
+      toolLabel,
+      presetIds: [],
+      modelKeys: [],
+      customNodeNames: []
+    };
+
+    filter.presetIds.push(preset.id);
+    filter.modelKeys.push(...(manifestPreset?.modelKeys ?? []));
+    filter.customNodeNames.push(...(manifestPreset?.customNodePackages ?? []));
+    filtersByLabel.set(toolLabel, filter);
+  }
+
+  return [...filtersByLabel.values()]
+    .map((filter) => ({
+      toolLabel: filter.toolLabel,
+      presetIds: uniqueSorted(filter.presetIds),
+      modelKeys: uniqueSorted(filter.modelKeys),
+      customNodeNames: uniqueSorted(filter.customNodeNames)
+    }))
+    .sort((left, right) => left.toolLabel.localeCompare(right.toolLabel));
+}
+
+function countStatuses(
+  models: readonly SetupModelRequirement[],
+  customNodes: readonly SetupNodeRequirement[]
+): Record<SetupRequirementStatus, number> {
+  const counts: Record<SetupRequirementStatus, number> = {
+    installed: 0,
+    "wrong-folder": 0,
+    missing: 0,
+    "not-checked": 0
+  };
+
+  for (const requirement of [...models, ...customNodes]) {
+    counts[requirement.status] += 1;
+  }
+
+  return counts;
+}
+
+function createSummaryLine(
+  checked: boolean,
+  counts: Record<SetupRequirementStatus, number>,
+  formattedRemainingDownload: string
+): string {
+  if (!checked) {
+    return `Requirements have not been checked against a server. Total known download size is ${formattedRemainingDownload}.`;
+  }
+
+  if (counts.missing === 0 && counts["wrong-folder"] === 0 && counts["not-checked"] === 0) {
+    return "All setup requirements are installed. No downloads remain.";
+  }
+
+  return `Setup check found ${counts.missing} missing, ${counts["wrong-folder"]} in the wrong folder, ${counts["not-checked"]} not checked, and ${counts.installed} installed. Remaining download is ${formattedRemainingDownload}.`;
+}
+
+function compareModels(left: SetupModelRequirement, right: SetupModelRequirement): number {
+  return (
+    STATUS_RANK[left.status] - STATUS_RANK[right.status] ||
+    right.usedByPresets.length - left.usedByPresets.length ||
+    left.key.localeCompare(right.key)
+  );
+}
+
+function compareNodes(left: SetupNodeRequirement, right: SetupNodeRequirement): number {
+  return STATUS_RANK[left.status] - STATUS_RANK[right.status] || left.name.localeCompare(right.name);
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -312,6 +312,8 @@ export type WorkflowRecommendedSettings = {
 export type WorkflowPresetDefinition = {
   id: WorkflowPreset;
   label: string;
+  /** Artist-facing name of the model or approach; the tool name is shown separately. */
+  displayName: string;
   mode: WorkflowMode;
   description: string;
   workflowFile: string;

--- a/src/comfy/workflowHealth.ts
+++ b/src/comfy/workflowHealth.ts
@@ -73,7 +73,7 @@ export function createWorkflowHealthItem(
 
   return {
     presetId: preset.id,
-    label: preset.label,
+    label: preset.displayName,
     toolLabel: capability.artistLabel,
     state,
     stateLabel: STATE_LABELS[state],

--- a/tests/comfy/setupRequirements.test.ts
+++ b/tests/comfy/setupRequirements.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "vitest";
+import { listRequiredModelsForPresets } from "../../src/comfy/modelFolders";
+import { listRunnableWorkflowPresets, listWorkflowPresets } from "../../src/comfy/presetRegistry";
+import {
+  SetupRequirementsReport,
+  evaluateSetupRequirements
+} from "../../src/comfy/setupRequirements";
+import { buildSetupManifest } from "../../src/comfy/setupManifest";
+import { createWorkflowHealthItem } from "../../src/comfy/workflowHealth";
+import {
+  ComfyModelInventory,
+  WorkflowPresetDefinition,
+  WorkflowRequiredModel
+} from "../../src/comfy/types";
+import { WorkflowNodeAvailability } from "../../src/comfy/workflowCompatibility";
+
+const PLUGIN_VERSION = "9.9.9";
+const FIXED_TIMESTAMP = "2026-07-31T00:00:00.000Z";
+
+describe("setup requirements", () => {
+  it("keeps every requirement visible and unchecked while the server is unavailable", () => {
+    const manifest = buildSetupManifest({
+      pluginVersion: PLUGIN_VERSION,
+      generatedAt: FIXED_TIMESTAMP
+    });
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    expect(report.checked).toBe(false);
+    expect(report.models).not.toHaveLength(0);
+    expect(report.customNodes).not.toHaveLength(0);
+    expect(report.models.every((model) => model.status === "not-checked")).toBe(true);
+    expect(report.customNodes.every((node) => node.status === "not-checked")).toBe(true);
+    expect(report.remainingDownloadBytes).toBe(manifest.totals.knownDownloadBytes);
+    expect(report.summaryLine).toContain("have not been checked against a server");
+    expect(report.summaryLine).toContain(report.formattedRemainingDownload);
+  });
+
+  it("reports a complete setup positively when every model and custom node is present", () => {
+    const presets = listRunnableWorkflowPresets();
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      inventory: createCompleteInventory(presets),
+      nodeAvailability: createCompleteNodeAvailability(presets),
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    expect(report.models.every((model) => model.status === "installed")).toBe(true);
+    expect(report.customNodes.every((node) => node.status === "installed")).toBe(true);
+    expect(report.remainingDownloadBytes).toBe(0);
+    expect(report.summaryLine).toBe("All setup requirements are installed. No downloads remain.");
+  });
+
+  it("finds Krea-2 Turbo in checkpoints without asking for another download", () => {
+    const presets = [getRunnablePreset("txt2img-krea2-turbo")];
+    const inventory = createCompleteInventory(presets);
+    const modelName = "krea2_turbo_fp8_scaled.safetensors";
+    inventory.diffusionModels = inventory.diffusionModels.filter((name) => name !== modelName);
+    inventory.checkpoints.push(modelName);
+
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      inventory,
+      generatedAt: FIXED_TIMESTAMP
+    });
+    const model = getReportModel(report, `diffusion_models/${modelName}`);
+
+    expect(model.status).toBe("wrong-folder");
+    expect(model.foundInFolders).toEqual(["checkpoints"]);
+    expect(model.detectedModelName).toBe(modelName);
+    expect(report.remainingDownloadBytes).toBe(0);
+  });
+
+  it("counts a genuinely missing Krea-2 Turbo model in the remaining download", () => {
+    const presets = [getRunnablePreset("txt2img-krea2-turbo")];
+    const inventory = createCompleteInventory(presets);
+    const modelName = "krea2_turbo_fp8_scaled.safetensors";
+    inventory.diffusionModels = inventory.diffusionModels.filter((name) => name !== modelName);
+
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      inventory,
+      generatedAt: FIXED_TIMESTAMP
+    });
+    const model = getReportModel(report, `diffusion_models/${modelName}`);
+
+    expect(model.status).toBe("missing");
+    expect(model.foundInFolders).toEqual([]);
+    expect(model.detectedModelName).toBeNull();
+    expect(model.sizeBytes).toBeGreaterThan(0);
+    expect(report.remainingDownloadBytes).toBe(model.sizeBytes);
+  });
+
+  it("sorts actionable models by status, usage count, and stable key", () => {
+    const presets = [
+      getRunnablePreset("txt2img-krea2-turbo"),
+      getRunnablePreset("img2img-krea2-turbo"),
+      getRunnablePreset("upscale-basic")
+    ];
+    const inventory = createCompleteInventory(presets);
+    const misplacedName = "krea2_turbo_fp8_scaled.safetensors";
+    const sharedMissingName = "qwen3vl_4b_fp8_scaled.safetensors";
+    const singleMissingName = "4x-UltraSharp.pth";
+    inventory.diffusionModels = inventory.diffusionModels.filter((name) => name !== misplacedName);
+    inventory.checkpoints.push(misplacedName);
+    inventory.clipModels = inventory.clipModels.filter((name) => name !== sharedMissingName);
+    inventory.upscaleModels = inventory.upscaleModels.filter((name) => name !== singleMissingName);
+
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      inventory,
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    expect(report.models.map((model) => model.status)).toEqual([
+      "missing",
+      "missing",
+      "wrong-folder",
+      "installed"
+    ]);
+    expect(report.models.slice(0, 2).map((model) => model.usedByPresets.length)).toEqual([2, 1]);
+    expect(report.models.slice(0, 2).map((model) => model.modelName)).toEqual([
+      sharedMissingName,
+      singleMissingName
+    ]);
+
+    const uncheckedReport = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      generatedAt: FIXED_TIMESTAMP
+    });
+    expect(uncheckedReport.models.every((model) => model.status === "not-checked")).toBe(true);
+    expect(uncheckedReport.models.map((model) => model.usedByPresets.length)).toEqual([2, 2, 2, 1]);
+  });
+
+  it("reports a partially installed custom node package as missing", () => {
+    const presets = [getRunnablePreset("prompt-from-layer-florence2")];
+    const nodeAvailability: WorkflowNodeAvailability = {
+      Florence2ModelLoader: []
+    };
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      nodeAvailability,
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    expect(report.customNodes).toHaveLength(1);
+    expect(report.customNodes[0].name).toBe("ComfyUI-Florence2");
+    expect(report.customNodes[0].status).toBe("missing");
+    expect(report.customNodes[0].missingClassTypes).toEqual(["Florence2Run"]);
+  });
+
+  it("gives every registered preset a separate artist-facing display name", () => {
+    for (const preset of listWorkflowPresets()) {
+      expect(preset.displayName, `${preset.id} has no display name`).toBeTruthy();
+      expect(preset.displayName).not.toBe(preset.id);
+    }
+  });
+
+  it("keeps technical manifest labels while Workflow Health uses display names", () => {
+    const preset = getRunnablePreset("txt2img-krea2-turbo");
+    const manifest = buildSetupManifest({
+      pluginVersion: PLUGIN_VERSION,
+      presets: [preset],
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    expect(manifest.presets[0].label).toBe("txt2img-krea2-turbo");
+    expect(manifest.presets[0].displayName).toBe("Krea-2 Turbo");
+    expect(createWorkflowHealthItem(preset).label).toBe("Krea-2 Turbo");
+  });
+
+  it("keeps all user-visible report strings plain", () => {
+    const reports = [
+      evaluateSetupRequirements({
+        pluginVersion: PLUGIN_VERSION,
+        generatedAt: FIXED_TIMESTAMP
+      }),
+      evaluateSetupRequirements({
+        pluginVersion: PLUGIN_VERSION,
+        inventory: createEmptyInventory(),
+        nodeAvailability: {},
+        generatedAt: FIXED_TIMESTAMP
+      })
+    ];
+
+    for (const report of reports) {
+      const visibleStrings = [
+        report.summaryLine,
+        report.formattedRemainingDownload,
+        ...report.models.map((model) => model.formattedSize)
+      ];
+
+      for (const value of visibleStrings) {
+        expect(value).not.toMatch(/[`—…]/u);
+        expect(value).not.toMatch(/\p{Extended_Pictographic}/u);
+      }
+    }
+  });
+
+  it("builds deterministic tool filters from the presets and manifest relationships", () => {
+    const presets = [
+      getRunnablePreset("txt2img-krea2-turbo"),
+      getRunnablePreset("txt2img-z-image-turbo"),
+      getRunnablePreset("prompt-from-layer-florence2")
+    ];
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    expect(report.toolFilters.map((filter) => filter.toolLabel)).toEqual([
+      "Prompt from Layer",
+      "Text to Image"
+    ]);
+    expect(report.toolFilters[1].presetIds).toEqual([
+      "txt2img-krea2-turbo",
+      "txt2img-z-image-turbo"
+    ]);
+    expect(report.toolFilters[1].modelKeys).toEqual(
+      [...new Set(report.models.flatMap((model) => model.usedByPresets.some((id) => id.startsWith("txt2img-")) ? [model.key] : []))]
+        .sort((left, right) => left.localeCompare(right))
+    );
+    expect(report.toolFilters[0].customNodeNames).toEqual(["ComfyUI-Florence2"]);
+  });
+});
+
+function getRunnablePreset(id: string): WorkflowPresetDefinition {
+  const preset = listRunnableWorkflowPresets().find((candidate) => candidate.id === id);
+
+  if (!preset) {
+    throw new Error(`Expected runnable preset ${id}.`);
+  }
+
+  return preset;
+}
+
+function getReportModel(report: SetupRequirementsReport, key: string) {
+  const model = report.models.find((candidate) => candidate.key === key);
+
+  if (!model) {
+    throw new Error(`Expected setup model ${key}.`);
+  }
+
+  return model;
+}
+
+function createEmptyInventory(): ComfyModelInventory {
+  return {
+    checkpoints: [],
+    diffusionModels: [],
+    clipModels: [],
+    vaeModels: [],
+    controlNetModels: [],
+    visionLanguageModels: [],
+    upscaleModels: [],
+    missingSources: []
+  };
+}
+
+function createCompleteInventory(
+  presets: readonly WorkflowPresetDefinition[]
+): ComfyModelInventory {
+  const inventory = createEmptyInventory();
+
+  for (const model of listRequiredModelsForPresets(presets)) {
+    getInventoryBucket(inventory, model).push(model.modelName);
+  }
+
+  return inventory;
+}
+
+function getInventoryBucket(
+  inventory: ComfyModelInventory,
+  model: WorkflowRequiredModel
+): string[] {
+  switch (model.kind) {
+    case "checkpoint":
+      return inventory.checkpoints;
+    case "diffusion-model-stack":
+      return inventory.diffusionModels;
+    case "clip":
+      return inventory.clipModels;
+    case "vae":
+      return inventory.vaeModels;
+    case "controlnet":
+      return inventory.controlNetModels;
+    case "vision-language":
+      return inventory.visionLanguageModels;
+    case "upscale":
+      return inventory.upscaleModels;
+  }
+}
+
+function createCompleteNodeAvailability(
+  presets: readonly WorkflowPresetDefinition[]
+): WorkflowNodeAvailability {
+  return Object.fromEntries(
+    presets.flatMap((preset) =>
+      preset.requiredNodes.map((requirement) => [requirement.classType, requirement.requiredInputs])
+    )
+  );
+}

--- a/tests/comfy/setupRequirements.test.ts
+++ b/tests/comfy/setupRequirements.test.ts
@@ -52,6 +52,12 @@ describe("setup requirements", () => {
     expect(report.customNodes.every((node) => node.status === "installed")).toBe(true);
     expect(report.remainingDownloadBytes).toBe(0);
     expect(report.summaryLine).toBe("All setup requirements are installed. No downloads remain.");
+    // formatBytes reports zero as "unknown", because in the manifest a zero size
+    // means the size was never published. Zero remaining is the opposite of
+    // unknown, and this is the state a fully set up machine is in, so the panel
+    // must never render "unknown left to download".
+    expect(report.formattedRemainingDownload).toBe("Nothing");
+    expect(report.formattedRemainingDownload).not.toBe("unknown");
   });
 
   it("finds Krea-2 Turbo in checkpoints without asking for another download", () => {


### PR DESCRIPTION
Roadmap item 2 (Setup tab / requirements manifest), split in two. This is the data layer only — **no UI, no markup, no CSS**. The screen itself is part 2, and the agreed design for it is settled: models are the primary list with presets as a cross-reference, the manifest is static with server status as an overlay, and status is shown as text badges rather than emoji.

Written by Codex against a written brief (first commit), reviewed and fixed by Claude (second commit), so the two contributions stay separately visible.

## What this adds

`evaluateSetupRequirements` merges two things that were never joined up: the static manifest built from the preset registry, and whatever the running ComfyUI reports. It returns one sorted list of requirements with a status each.

Three decisions worth calling out:

- **Status is four-valued, not three.** `not-checked` is what everything reports when no server answered. Somebody asking "what do I need to download" has usually not started ComfyUI yet, so the screen has to work as a shopping list with the server down — a screen that shows only an error fails exactly the person it was built for.
- **A wrong-folder model contributes zero to the remaining download.** The file is already on disk. Telling someone to re-fetch 12 GB they already have would be the worst thing this screen could do.
- **Nothing is reimplemented.** Presence still comes from `getAvailableRequiredModelName`, misplacement still from `findMisplacedModel` (shipped in #58). This module renders their structured fields; it does not restate a folder, a filename or a size anywhere.

## Presets finally have a human name

`label` has been the preset id on all fifteen entries, and the Workflow Health cards have been rendering `txt2img-krea2-turbo` at artists for several releases. `displayName` is required rather than optional, so a sixteenth preset without a name will not compile. It names the model or approach only, because the tool name is always displayed beside it — which is why "Flux Fill" is correct for both the inpaint and the outpaint preset.

## The bug the review found

`formatBytes` returns the string `"unknown"` for zero, because in the manifest a zero size means nobody published one. The remaining-download total was being routed through it, and that total is zero precisely when everything is installed — so a fully set up machine rendered **"unknown left to download"**. It only appeared in the all-good state, which is the state this machine is permanently in, so it was the least likely thing to be caught by hand. The tests missed it because the all-installed summary sentence happens not to interpolate that field; the assertion is now there.

## Smoke test

This PR has no new UI, but it does change one visible string, so it is worth a look:

1. Open OpenLayer, go to **Settings**.
2. Press **Check Workflow Health**.
3. Read the card titles. They should now say **Krea-2 Turbo**, **Z_image_Turbo**, **Flux Fill**, **Standard checkpoint**, **Florence-2 PromptGen**, **LineArt ControlNet**, **Standard upscaler**, **Flux1-dev fp8** — where they previously said `txt2img-krea2-turbo`, `inpaint-flux-fill-basic` and so on.
4. Confirm the tool name under each title is unchanged (Text to Image, Inpaint, Upscale...), so each card reads as a tool plus a model rather than repeating itself.
5. Nothing else on the screen should have moved. The state badges, counts, grouping and detail sentences are untouched.

## Gates

`npm run typecheck`, `npm test`, `npm run build`, `npx eslint .` all pass. 472 tests, up from 462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)