### PR TITLE
Setup tab, part 2: the screen

### DIFF
--- a/src/comfy/workflowHealth.ts
+++ b/src/comfy/workflowHealth.ts
@@ -40,7 +40,7 @@ const STATE_LABELS: Record<WorkflowHealthState, string> = {
   experimental: "Experimental",
   "missing-model": "Missing model",
   "missing-node": "Missing ComfyUI node",
-  "missing-workflow": "Missing workflow JSON",
+  "missing-workflow": "Needs workflow JSON",
   "setup-required": "Setup required"
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -704,12 +704,18 @@ a:hover {
   white-space: nowrap;
 }
 
-.workflow-health-state.is-ready {
+/* The Setup screen reuses this pill rather than defining a second badge, so its
+   tones join the existing groups instead of restating the colours. A setup row
+   that is merely in the wrong folder shares the amber of "experimental" on
+   purpose: the file is present, so red would read as "download this again". */
+.workflow-health-state.is-ready,
+.workflow-health-state.is-setup-ready {
   background: rgba(58, 148, 94, 0.28);
   color: #a6e6bb;
 }
 
-.workflow-health-state.is-experimental {
+.workflow-health-state.is-experimental,
+.workflow-health-state.is-setup-warning {
   background: rgba(215, 182, 75, 0.2);
   color: #ffe08a;
 }
@@ -717,7 +723,8 @@ a:hover {
 .workflow-health-state.is-missing-model,
 .workflow-health-state.is-missing-node,
 .workflow-health-state.is-missing-workflow,
-.workflow-health-state.is-setup-required {
+.workflow-health-state.is-setup-required,
+.workflow-health-state.is-setup-error {
   background: rgba(181, 72, 72, 0.28);
   color: #ffb0b0;
 }
@@ -740,6 +747,120 @@ a:hover {
   overflow: hidden;
   margin-top: 3px;
   color: #9f9f9f;
+}
+
+/* ---------------------------------------------------------------------------
+   Setup screen.
+   Rows reuse .workflow-health-item, so the card frame, the compact-theme
+   treatment and the status pill all come for free. Everything below is only the
+   parts a requirement row has and a health card does not: a field list, notes,
+   and copy buttons.
+   Note these paragraphs deliberately opt out of the .diagnostics-line clamp via
+   .setup-paragraph -- that clamp truncates to one line with an ellipsis, which
+   is right for the status lines it was written for and wrong for a sentence.
+--------------------------------------------------------------------------- */
+.setup-paragraph {
+  max-height: none;
+  overflow: visible;
+  white-space: normal;
+  text-overflow: clip;
+}
+
+/* Explicit margins rather than flex gap throughout this block: UXP does not
+   honor gap consistently in the compact panel, which is why the rest of this
+   file avoids it too. */
+.setup-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 0 4px;
+}
+
+.setup-filter-chip {
+  min-height: 0;
+  margin: 0 4px 4px 0;
+  border: 1px solid #4a4a4a;
+  border-radius: 999px;
+  padding: 3px 10px;
+  background: #333333;
+  color: #b4b4b4;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.setup-filter-chip.is-active {
+  border-color: #6a6a6a;
+  background: #4a4a4a;
+  color: #f0f0f0;
+}
+
+.setup-row-subtitle {
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, Consolas, "Courier New", monospace;
+  font-size: 10.5px;
+}
+
+.setup-row-fields {
+  display: flex;
+  flex-direction: column;
+  margin-top: 6px;
+}
+
+.setup-row-field {
+  display: flex;
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.setup-row-field + .setup-row-field {
+  margin-top: 2px;
+}
+
+.setup-row-field-label {
+  flex: 0 0 68px;
+  margin-right: 6px;
+  color: #8f8f8f;
+}
+
+.setup-row-field-value {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: #d6d6d6;
+}
+
+.setup-row-note {
+  margin-top: 6px;
+  color: #b0b0b0;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.setup-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.setup-row-action {
+  width: auto;
+  min-height: 26px;
+  flex: 0 1 auto;
+  margin: 4px 6px 0 0;
+  padding: 4px 10px;
+  font-size: 11px;
+}
+
+.setup-installed-group {
+  margin-top: 8px;
+}
+
+.setup-installed-summary {
+  padding: 5px 2px;
+  color: #a0a0a0;
+  font-size: 11px;
+}
+
+.setup-row.is-collapsed {
+  margin-top: 6px;
 }
 
 .diagnostics-report {
@@ -1147,16 +1268,19 @@ a:hover {
   line-height: 1;
 }
 
-.diagnostic-summary-card.is-ready {
+.diagnostic-summary-card.is-ready,
+.diagnostic-summary-card.is-setup-ready {
   border-color: rgba(86, 159, 103, 0.52);
 }
 
-.diagnostic-summary-card.is-experimental {
+.diagnostic-summary-card.is-experimental,
+.diagnostic-summary-card.is-setup-warning {
   border-color: rgba(215, 182, 75, 0.58);
 }
 
 .diagnostic-summary-card.is-setup,
-.diagnostic-summary-card.is-future {
+.diagnostic-summary-card.is-future,
+.diagnostic-summary-card.is-setup-error {
   border-color: rgba(181, 72, 72, 0.45);
 }
 
@@ -7272,6 +7396,29 @@ body,
   margin-bottom: 9px !important;
   white-space: normal !important;
   text-overflow: clip !important;
+}
+
+/* Same story on the Setup screen, and the base-theme `.setup-paragraph` rule
+   further up cannot do this job: one class loses to
+   `.app-shell.theme-compact .diagnostics-line`, and that block is `!important`
+   besides. The summary and the download total are sentences, so they wrap. */
+.app-shell.theme-compact .setup-paragraph {
+  max-height: none !important;
+  overflow: visible !important;
+  white-space: normal !important;
+  text-overflow: clip !important;
+}
+
+/* The copy buttons are the one place in the panel where two controls share a
+   line and neither should fill it. `.app-shell.theme-compact .button` sets
+   `width: 100%`, and it outranks the plain `.setup-row-action` class, so each
+   button would otherwise span the panel and stack -- three full-width buttons
+   under every missing model. */
+.app-shell.theme-compact .setup-row-action {
+  width: auto !important;
+  min-height: 26px !important;
+  margin: 4px 6px 0 0 !important;
+  padding: 4px 10px !important;
 }
 
 /* v0.6 final UXP hardening.

--- a/src/styles.css
+++ b/src/styles.css
@@ -785,19 +785,25 @@ a:hover {
 .setup-filter-row {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
   margin: 0 0 4px;
 }
 
+/* Fixed height with a matching half-height radius, rather than letting padding
+   decide. A chip whose height grows past twice its radius stops being a pill
+   and becomes an ellipse, which is the same trap the toggle-button block warns
+   about, and UXP is more predictable with explicit pixel sizing anyway. */
 .setup-filter-chip {
+  height: 22px;
   min-height: 0;
   margin: 0 4px 4px 0;
   border: 1px solid #4a4a4a;
-  border-radius: 999px;
-  padding: 3px 10px;
+  border-radius: 11px;
+  padding: 0 10px;
   background: #333333;
   color: #b4b4b4;
   font-size: 11px;
-  line-height: 1.3;
+  line-height: 20px;
 }
 
 .setup-filter-chip.is-active {
@@ -7219,11 +7225,19 @@ body,
    rather than dropping the attribute keeps the state readable to a screen
    reader. */
 .app-shell.theme-compact button.setup-filter-chip[aria-pressed] {
+  box-sizing: border-box !important;
+  width: auto !important;
+  height: 22px !important;
+  min-height: 0 !important;
+  margin: 0 4px 4px 0 !important;
   border: 1px solid #4a4a4a !important;
-  border-radius: 999px !important;
+  border-radius: 11px !important;
+  padding: 0 10px !important;
   background: #333333 !important;
   color: #b4b4b4 !important;
+  font-size: 11px !important;
   font-weight: 600 !important;
+  line-height: 20px !important;
 }
 
 .app-shell.theme-compact button.setup-filter-chip[aria-pressed="true"] {

--- a/src/styles.css
+++ b/src/styles.css
@@ -689,18 +689,31 @@ a:hover {
   white-space: nowrap;
 }
 
+/* A squared chip rather than a full pill, set in small caps. The uppercase is
+   what makes a short status read as a label instead of a word, but it is also
+   wider per character, so the size drops to 9px and the cap rises from 118px --
+   at 118px and 10px, "NEEDS WORKFLOW JSON" clips to an ellipsis, which is the
+   exact fault this badge was just fixed for.
+   Measured rather than estimated, in Arial 9px/0.04em, the shell font: the two
+   worst labels are NEEDS WORKFLOW JSON at 136px and MISSING COMFYUI NODE at
+   132px, and every setup label is under 100px. The cap is set above those with
+   room to spare, and it only clamps -- the badge is flex: 0 0 auto, so a label
+   that fits is never widened by it. If you add a longer state label, measure it
+   before trusting this. */
 .workflow-health-state {
   flex: 0 0 auto;
-  max-width: 118px;
+  max-width: 158px;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: 4px;
   padding: 3px 7px;
   background: #414141;
   color: #d0d0d0;
-  font-size: 10px;
-  font-weight: 760;
-  line-height: 1.1;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.15;
   text-overflow: ellipsis;
+  text-transform: uppercase;
   white-space: nowrap;
 }
 
@@ -7196,6 +7209,27 @@ body,
   border-color: rgba(255, 198, 41, 0.55) !important;
   background: rgba(255, 198, 41, 0.16) !important;
   color: var(--ol-gold) !important;
+}
+
+/* The Setup filter chips are buttons carrying aria-pressed, which is correct
+   for them and also opts them into the toggle styling directly above -- so they
+   rendered as gold 7px rectangles like an Import Automatically switch rather
+   than as pills. The gold means "this switch is on"; a chip only says which
+   slice of a list you are looking at, and it should not shout. Overriding here
+   rather than dropping the attribute keeps the state readable to a screen
+   reader. */
+.app-shell.theme-compact button.setup-filter-chip[aria-pressed] {
+  border: 1px solid #4a4a4a !important;
+  border-radius: 999px !important;
+  background: #333333 !important;
+  color: #b4b4b4 !important;
+  font-weight: 600 !important;
+}
+
+.app-shell.theme-compact button.setup-filter-chip[aria-pressed="true"] {
+  border-color: #6a6a6a !important;
+  background: #4a4a4a !important;
+  color: #f0f0f0 !important;
 }
 
 /* #4: brief green pulse behind import-success text. */

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -89,6 +89,18 @@ import {
   WorkflowHealthItem,
   WorkflowHealthReport
 } from "../comfy/workflowHealth";
+import {
+  evaluateSetupRequirements,
+  SetupRequirementsReport
+} from "../comfy/setupRequirements";
+import {
+  createSetupTabView,
+  SetupFilterView,
+  SetupRowAction,
+  SetupRowView,
+  SetupSectionView,
+  SetupTallyView
+} from "./setupTabModel";
 import type { WorkflowPhotoshopInputAvailability } from "../comfy/workflowCompatibility";
 import { GeneratedImageResult, WorkflowPresetDefinition } from "../comfy/types";
 import {
@@ -242,6 +254,7 @@ import {
   setInpaintStatus,
   setOutpaintDiagnostics,
   setLayerToolsStatus,
+  setSetupStatus,
   setOutpaintError,
   setOutpaintStatus,
   setPromptLayerDiagnostics,
@@ -340,6 +353,16 @@ export function renderApp(rootElement: HTMLElement) {
   let livePreviewZoomed = false;
   let hardwareReport: HardwareRecommendationReport | null = null;
   let workflowHealthReport: WorkflowHealthReport | null = null;
+  // The Setup screen keeps its own report because it asks the server a
+  // different question than workflow health does, and it must render before any
+  // check has run: an unchecked report is still the full list of what is needed.
+  // Built lazily rather than at startup -- getModelTargetFolder throws by design
+  // for a preset whose loader has no mapped folder, and that must fail the Setup
+  // screen, not the whole panel.
+  let setupReport: SetupRequirementsReport | null = null;
+  let setupActiveToolLabel: string | null = null;
+  let setupCheckedAtLabel: string | null = null;
+  let hasCheckedSetup = false;
   const historyEntries: HistoryEntry[] = [];
   const objectUrls = createObjectUrlRegistry();
 
@@ -699,6 +722,7 @@ export function renderApp(rootElement: HTMLElement) {
     findPort: createActionRunner(elements, "findPort", handleFindComfyPort),
     detectHardware: createActionRunner(elements, "detectHardware", handleDetectHardware),
     checkWorkflowHealth: createActionRunner(elements, "checkWorkflowHealth", handleCheckWorkflowHealth),
+    checkSetup: createActionRunner(elements, "checkSetup", handleCheckSetup),
     copyDiagnostics: createActionRunner(elements, "copyDiagnostics", handleCopyDiagnostics),
     exportLayerToFile: createActionRunner(elements, "exportLayerToFile", () => handleLayerExport("layer", "file")),
     exportLayerToComfyUI: createActionRunner(elements, "exportLayerToComfyUI", () => handleLayerExport("layer", "comfyui")),
@@ -773,6 +797,7 @@ export function renderApp(rootElement: HTMLElement) {
   bindActionControl(elements.findPortButton, actionHandlers.findPort);
   bindActionControl(elements.detectHardwareButton, actionHandlers.detectHardware);
   bindActionControl(elements.checkWorkflowHealthButton, actionHandlers.checkWorkflowHealth);
+  bindActionControl(elements.setupCheck, actionHandlers.checkSetup);
   bindActionControl(elements.copyDiagnosticsButton, actionHandlers.copyDiagnostics);
   bindActionControl(elements.exportLayerFileButton, actionHandlers.exportLayerToFile);
   bindActionControl(elements.exportLayerComfyButton, actionHandlers.exportLayerToComfyUI);
@@ -1093,6 +1118,85 @@ export function renderApp(rootElement: HTMLElement) {
       setGlobalDiagnostics(elements, "Start ComfyUI, confirm the server URL, then run Check Workflow Health again.");
     } finally {
       updateSettingsReport(elements);
+    }
+  }
+
+  async function handleCheckSetup() {
+    setSetupStatus(elements, "Checking what is installed...", "idle");
+
+    try {
+      const presets = listWorkflowPresets();
+      const client = new ComfyClient(elements.serverUrl.value);
+      await client.checkOnline();
+      // Both halves or neither. If only the model inventory arrived, every node
+      // row would report "not checked" while the tallies counted models as if
+      // the whole picture were known, and the numbers would quietly stop adding
+      // up to the number of requirements on screen.
+      const inventory = await client.getModelInventory();
+      const nodeAvailability = await client.getWorkflowNodeAvailability(presets);
+
+      setupReport = evaluateSetupRequirements({
+        pluginVersion: APP_VERSION,
+        inventory,
+        nodeAvailability
+      });
+      hasCheckedSetup = true;
+      setupCheckedAtLabel = `Checked ${formatClockTime(new Date())}`;
+      renderSetupTab();
+
+      const outstanding = setupReport.counts.missing + setupReport.counts["wrong-folder"];
+      setSetupStatus(
+        elements,
+        outstanding === 0 ? "Everything OpenLayer needs is installed." : setupReport.summaryLine,
+        outstanding === 0 ? "ready" : "idle"
+      );
+    } catch (caughtError) {
+      // An unreachable server is not an error state for this screen. The list is
+      // built from the preset registry and is exactly as useful offline, which
+      // matters because somebody asking what to download often has not started
+      // ComfyUI yet.
+      setupReport = createUncheckedSetupReport();
+      hasCheckedSetup = false;
+      setupCheckedAtLabel = null;
+      renderSetupTab();
+      // Reported on this screen's own bar and nowhere else. Writing the reason
+      // to the panel-wide error line would put a red Setup message on Settings
+      // and Text to Image, which is the bleed the v0.9 status split removed.
+      // Check ComfyUI on Settings is where a connection is diagnosed.
+      setSetupStatus(
+        elements,
+        `Could not reach ComfyUI, so nothing below is checked. ${getErrorMessage(caughtError)}`,
+        "error"
+      );
+    }
+  }
+
+  function renderSetupTab() {
+    setupReport ??= createUncheckedSetupReport();
+
+    const view = createSetupTabView(setupReport, {
+      checkedAtLabel: setupCheckedAtLabel,
+      activeToolLabel: setupActiveToolLabel
+    });
+
+    elements.setupCheckedLabel.textContent = view.checkedLabel;
+    elements.setupSummaryLine.textContent = view.summaryLine;
+    elements.setupDownloadLine.textContent = view.downloadLine;
+
+    renderSetupTallies(elements.setupTallies, view.tallies);
+    renderSetupFilters(elements.setupFilters, view.filters, (toolLabel) => {
+      setupActiveToolLabel = toolLabel;
+      renderSetupTab();
+    });
+    renderSetupSections(elements.setupSections, view.sections, handleSetupCopy);
+  }
+
+  async function handleSetupCopy(action: SetupRowAction) {
+    try {
+      await navigator.clipboard.writeText(action.value);
+      setSetupStatus(elements, action.copiedMessage, "ready");
+    } catch (caughtError) {
+      setSetupStatus(elements, `Could not copy to the clipboard. ${getErrorMessage(caughtError)}`, "error");
     }
   }
 
@@ -3855,11 +3959,26 @@ export function renderApp(rootElement: HTMLElement) {
     elements.upscaleView.hidden = currentView !== "upscale";
     elements.livePaintingView.hidden = currentView !== "live-painting";
     elements.settingsView.hidden = currentView !== "settings";
+    elements.setupView.hidden = currentView !== "setup";
     elements.historyView.hidden = currentView !== "history";
     elements.layerToolsView.hidden = currentView !== "layer-tools";
 
     if (currentView === "settings") {
       void refreshDocumentStatus(elements);
+    }
+
+    if (currentView === "setup") {
+      // Draw the requirements immediately from the registry, then check them
+      // against the server once per panel session. Re-checking on every visit
+      // would make walking back and forth between screens hit the server for no
+      // new information; the Check Again button is there for after a download.
+      renderSetupTab();
+
+      if (!hasCheckedSetup) {
+        // The handler directly, not the action runner: the runner logs an
+        // "Event received" diagnostics line, and nobody pressed anything.
+        void handleCheckSetup();
+      }
     }
 
     if (currentView === "history") {
@@ -4670,6 +4789,201 @@ function renderWorkflowHealthSummary(elements: AppElements, report: WorkflowHeal
 
     elements.settingsWorkflowHealthSummary.append(cardElement);
   }
+}
+
+/**
+ * The requirements list with nothing checked against a server. This is the
+ * screen's starting state and its offline state, and it is deliberately not an
+ * empty or error state: every name, folder, size and link is known without a
+ * server, so the list is fully useful before ComfyUI has ever been started.
+ */
+function createUncheckedSetupReport(): SetupRequirementsReport {
+  return evaluateSetupRequirements({ pluginVersion: APP_VERSION });
+}
+
+function formatClockTime(when: Date): string {
+  return `${String(when.getHours()).padStart(2, "0")}:${String(when.getMinutes()).padStart(2, "0")}`;
+}
+
+function renderSetupTallies(container: HTMLElement, tallies: readonly SetupTallyView[]) {
+  container.innerHTML = "";
+
+  for (const tally of tallies) {
+    const cell = document.createElement("div");
+    cell.className = `diagnostic-summary-card is-setup-${tally.tone}`;
+
+    const label = document.createElement("span");
+    label.textContent = tally.label;
+    cell.append(label);
+
+    const value = document.createElement("strong");
+    value.textContent = tally.value;
+    cell.append(value);
+
+    container.append(cell);
+  }
+}
+
+function renderSetupFilters(
+  container: HTMLElement,
+  filters: readonly SetupFilterView[],
+  onSelect: (toolLabel: string) => void
+) {
+  container.innerHTML = "";
+
+  for (const filter of filters) {
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = `setup-filter-chip${filter.active ? " is-active" : ""}`;
+    chip.textContent = filter.toolLabel;
+    chip.setAttribute("aria-pressed", filter.active ? "true" : "false");
+    chip.addEventListener("click", () => onSelect(filter.toolLabel));
+    container.append(chip);
+  }
+}
+
+function renderSetupSections(
+  container: HTMLElement,
+  sections: readonly SetupSectionView[],
+  onCopy: (action: SetupRowAction) => void
+) {
+  container.innerHTML = "";
+
+  for (const section of sections) {
+    const sectionElement = document.createElement("section");
+    sectionElement.className = "panel-section settings-panel diagnostic-section diagnostic-scroll-safe";
+    sectionElement.setAttribute("aria-label", section.title);
+
+    const heading = document.createElement("div");
+    heading.className = "section-heading";
+
+    const title = document.createElement("span");
+    title.className = "label";
+    title.textContent = section.title;
+    heading.append(title);
+
+    const meta = document.createElement("span");
+    meta.className = "muted-label";
+    meta.textContent = section.meta;
+    heading.append(meta);
+
+    sectionElement.append(heading);
+
+    if (section.rows.length === 0 && section.collapsedRows.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "diagnostics-line setup-paragraph";
+      empty.textContent = section.emptyMessage;
+      sectionElement.append(empty);
+    }
+
+    for (const row of section.rows) {
+      sectionElement.append(createSetupRowElement(row, onCopy));
+    }
+
+    if (section.collapsedRows.length > 0) {
+      // Installed rows are the answer to a question nobody asked twice, so they
+      // start folded away -- except when there is nothing else on screen, where
+      // confirming what was found is the only content there is.
+      const details = document.createElement("details");
+      details.className = "setup-installed-group";
+      details.open = section.rows.length === 0;
+
+      const summary = document.createElement("summary");
+      summary.className = "setup-installed-summary";
+      summary.textContent = section.collapsedSummary;
+      details.append(summary);
+
+      for (const row of section.collapsedRows) {
+        details.append(createSetupRowElement(row, onCopy));
+      }
+
+      sectionElement.append(details);
+    }
+
+    container.append(sectionElement);
+  }
+}
+
+function createSetupRowElement(row: SetupRowView, onCopy: (action: SetupRowAction) => void) {
+  // Deliberately reuses the workflow-health card and pill classes rather than
+  // introducing a parallel set. They already carry the compact theme's
+  // treatment, and a second badge system would drift from the first one.
+  const rowElement = document.createElement("div");
+  rowElement.className = `workflow-health-item setup-row${row.collapsed ? " is-collapsed" : ""}`;
+
+  const heading = document.createElement("div");
+  heading.className = "workflow-health-heading";
+
+  const titleBlock = document.createElement("div");
+  titleBlock.className = "workflow-health-title-block";
+
+  const title = document.createElement("div");
+  title.className = "workflow-health-title";
+  title.textContent = row.title;
+  titleBlock.append(title);
+
+  const subtitle = document.createElement("div");
+  subtitle.className = "workflow-health-tool setup-row-subtitle";
+  subtitle.textContent = row.subtitle;
+  titleBlock.append(subtitle);
+
+  heading.append(titleBlock);
+
+  const badge = document.createElement("div");
+  badge.className = `workflow-health-state is-setup-${row.badgeTone}`;
+  badge.textContent = row.badgeLabel;
+  heading.append(badge);
+
+  rowElement.append(heading);
+
+  if (row.fields.length > 0) {
+    const fields = document.createElement("div");
+    fields.className = "setup-row-fields";
+
+    for (const field of row.fields) {
+      const fieldRow = document.createElement("div");
+      fieldRow.className = "setup-row-field";
+
+      const label = document.createElement("span");
+      label.className = "setup-row-field-label";
+      label.textContent = field.label;
+      fieldRow.append(label);
+
+      const value = document.createElement("span");
+      value.className = "setup-row-field-value";
+      value.textContent = field.value;
+      fieldRow.append(value);
+
+      fields.append(fieldRow);
+    }
+
+    rowElement.append(fields);
+  }
+
+  for (const note of row.notes) {
+    const noteElement = document.createElement("div");
+    noteElement.className = "setup-row-note";
+    noteElement.textContent = note;
+    rowElement.append(noteElement);
+  }
+
+  if (row.actions.length > 0) {
+    const actions = document.createElement("div");
+    actions.className = "setup-row-actions";
+
+    for (const action of row.actions) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "button setup-row-action";
+      button.textContent = action.label;
+      button.addEventListener("click", () => onCopy(action));
+      actions.append(button);
+    }
+
+    rowElement.append(actions);
+  }
+
+  return rowElement;
 }
 
 function createWorkflowHealthGroups(items: readonly WorkflowHealthItem[]) {

--- a/src/ui/appBindings.ts
+++ b/src/ui/appBindings.ts
@@ -23,6 +23,7 @@ export type ActionName =
   | "findPort"
   | "detectHardware"
   | "checkWorkflowHealth"
+  | "checkSetup"
   | "copyDiagnostics"
   | "saveSettings"
   | "resetSettings"

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -62,6 +62,7 @@ export type AppView =
   | "upscale"
   | "live-painting"
   | "settings"
+  | "setup"
   | "history"
   | "layer-tools";
 export type ToolCardStatus = "available" | "experimental" | "coming-soon";
@@ -193,6 +194,14 @@ export const TOOL_CARDS: ToolCard[] = [
     view: "history"
   },
   {
+    id: "setup",
+    title: "Setup",
+    subtitle: "Models and nodes you still need",
+    icon: "control",
+    status: "available",
+    view: "setup"
+  },
+  {
     id: "settings",
     title: "Settings",
     subtitle: "Defaults, ports, paths, and diagnostics",
@@ -217,6 +226,6 @@ export const HOME_TOOL_SECTIONS = [
   },
   {
     title: "Preferences",
-    toolIds: ["settings"]
+    toolIds: ["setup", "settings"]
   }
 ];

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -43,6 +43,16 @@ export type AppElements = {
   promptFromLayerView: HTMLElement;
   upscaleView: HTMLElement;
   settingsView: HTMLElement;
+  setupView: HTMLElement;
+  setupCheckedLabel: HTMLElement;
+  setupTallies: HTMLElement;
+  setupSummaryLine: HTMLElement;
+  setupDownloadLine: HTMLElement;
+  setupCheck: HTMLButtonElement;
+  setupStatusText: HTMLElement;
+  setupStatusPill: HTMLElement;
+  setupFilters: HTMLElement;
+  setupSections: HTMLElement;
   historyView: HTMLElement;
   layerToolsView: HTMLElement;
   exportLayerFileButton: HTMLElement;
@@ -1194,6 +1204,37 @@ export function createAppMarkup() {
         </section>
       </section>
 
+      <section class="setup-view" id="setup-view" aria-label="Setup" hidden>
+        <div class="screen-nav">
+          <div class="back-button screen-back-control" role="button" tabindex="0" data-openlayer-view="home">Back to Tools</div>
+          <div class="screen-title-block">
+            ${createScreenIconMarkup("control", "Setup")}
+            <span class="screen-title">Setup</span>
+          </div>
+        </div>
+
+        <section class="panel-section settings-panel diagnostic-section diagnostic-scroll-safe" aria-label="Setup requirements">
+          <div class="section-heading">
+            <span class="label">Requirements</span>
+            <span class="muted-label" id="setup-checked-label">Not checked yet.</span>
+          </div>
+          <div class="diagnostic-summary-grid" id="setup-tallies" aria-label="Setup requirement counts"></div>
+          <div class="diagnostics-line setup-paragraph" id="setup-summary-line">
+            Open this screen to check what OpenLayer needs.
+          </div>
+          <div class="diagnostics-line setup-paragraph" id="setup-download-line"></div>
+          <button class="button action-control" id="setup-check" data-openlayer-action="checkSetup" type="button">Check Again</button>
+          <div class="status-bar" role="status">
+            <span class="status-text" id="setup-status-text">Setup ready.</span>
+            <span class="status-pill idle" id="setup-status-pill">Status</span>
+          </div>
+        </section>
+
+        <div class="setup-filter-row" id="setup-filters" aria-label="Filter requirements by tool"></div>
+
+        <div id="setup-sections"></div>
+      </section>
+
       <section class="history-view" id="history-view" aria-label="History" hidden>
         <div class="screen-nav">
           <div class="back-button screen-back-control" role="button" tabindex="0" data-openlayer-view="home">Back to Tools</div>
@@ -1349,6 +1390,16 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     promptFromLayerView: getElement<HTMLElement>(rootElement, "prompt-from-layer-view"),
     upscaleView: getElement<HTMLElement>(rootElement, "upscale-view"),
     settingsView: getElement<HTMLElement>(rootElement, "settings-view"),
+    setupView: getElement<HTMLElement>(rootElement, "setup-view"),
+    setupCheckedLabel: getElement<HTMLElement>(rootElement, "setup-checked-label"),
+    setupTallies: getElement<HTMLElement>(rootElement, "setup-tallies"),
+    setupSummaryLine: getElement<HTMLElement>(rootElement, "setup-summary-line"),
+    setupDownloadLine: getElement<HTMLElement>(rootElement, "setup-download-line"),
+    setupCheck: getElement<HTMLButtonElement>(rootElement, "setup-check"),
+    setupStatusText: getElement<HTMLElement>(rootElement, "setup-status-text"),
+    setupStatusPill: getElement<HTMLElement>(rootElement, "setup-status-pill"),
+    setupFilters: getElement<HTMLElement>(rootElement, "setup-filters"),
+    setupSections: getElement<HTMLElement>(rootElement, "setup-sections"),
     historyView: getElement<HTMLElement>(rootElement, "history-view"),
     layerToolsView: getElement<HTMLElement>(rootElement, "layer-tools-view"),
     exportLayerFileButton: getElement<HTMLElement>(rootElement, "export-layer-file"),

--- a/src/ui/setupTabModel.ts
+++ b/src/ui/setupTabModel.ts
@@ -1,0 +1,363 @@
+import {
+  SetupModelRequirement,
+  SetupNodeRequirement,
+  SetupRequirementStatus,
+  SetupRequirementsReport
+} from "../comfy/setupRequirements";
+
+export type SetupBadgeTone = "ready" | "warning" | "error" | "neutral";
+export type SetupRowActionId =
+  | "copy-download-link"
+  | "copy-folder-path"
+  | "copy-source-page";
+export type SetupRowAction = {
+  id: SetupRowActionId;
+  label: string;
+  value: string;
+  copiedMessage: string;
+};
+export type SetupRowField = { label: string; value: string };
+export type SetupRowView = {
+  key: string;
+  title: string;
+  subtitle: string;
+  badgeLabel: string;
+  badgeTone: SetupBadgeTone;
+  fields: SetupRowField[];
+  notes: string[];
+  actions: SetupRowAction[];
+  collapsed: boolean;
+};
+export type SetupSectionView = {
+  id: "models" | "custom-nodes";
+  title: string;
+  meta: string;
+  rows: SetupRowView[];
+  collapsedRows: SetupRowView[];
+  collapsedSummary: string;
+  emptyMessage: string;
+};
+export type SetupTallyView = {
+  label: string;
+  value: string;
+  tone: SetupBadgeTone;
+};
+export type SetupFilterView = { toolLabel: string; active: boolean };
+export type SetupTabView = {
+  tallies: SetupTallyView[];
+  summaryLine: string;
+  downloadLine: string;
+  checkedLabel: string;
+  filters: SetupFilterView[];
+  sections: SetupSectionView[];
+  hasActionableRows: boolean;
+};
+
+const EVERYTHING_FILTER = "Everything";
+
+const BADGES: Record<
+  SetupRequirementStatus,
+  { label: string; tone: SetupBadgeTone }
+> = {
+  installed: { label: "Installed", tone: "ready" },
+  "wrong-folder": { label: "Wrong folder", tone: "warning" },
+  missing: { label: "Missing", tone: "error" },
+  "not-checked": { label: "Not checked", tone: "neutral" }
+};
+
+export function createSetupTabView(
+  report: SetupRequirementsReport,
+  options?: {
+    checkedAtLabel?: string | null;
+    activeToolLabel?: string | null;
+  }
+): SetupTabView {
+  const activeToolLabel = options?.activeToolLabel ?? EVERYTHING_FILTER;
+  const filterActive = activeToolLabel !== EVERYTHING_FILTER;
+  const activeFilter = filterActive
+    ? report.toolFilters.find((filter) => filter.toolLabel === activeToolLabel)
+    : undefined;
+  const visibleModelKeys = new Set(activeFilter?.modelKeys ?? []);
+  const visibleNodeNames = new Set(activeFilter?.customNodeNames ?? []);
+
+  const modelViews = report.models
+    .filter((model) => !filterActive || visibleModelKeys.has(model.key))
+    .map(createModelRow);
+  const nodeViews = report.customNodes
+    .filter((node) => !filterActive || visibleNodeNames.has(node.name))
+    .map(createNodeRow);
+
+  const sections = [
+    createSection(
+      "models",
+      "Models",
+      modelViews,
+      activeToolLabel,
+      filterActive,
+      "model",
+      "models"
+    ),
+    createSection(
+      "custom-nodes",
+      "Custom nodes",
+      nodeViews,
+      activeToolLabel,
+      filterActive,
+      "node package",
+      "custom node packages"
+    )
+  ];
+
+  // Tallies and summary lines intentionally describe the whole report. A tool
+  // filter narrows only the requirement lists and must not change the totals.
+  const tallyValue = (status: "missing" | "wrong-folder" | "installed") =>
+    report.checked ? String(report.counts[status]) : "-";
+
+  return {
+    tallies: [
+      { label: "Missing", value: tallyValue("missing"), tone: "error" },
+      {
+        label: "Wrong folder",
+        value: tallyValue("wrong-folder"),
+        tone: "warning"
+      },
+      { label: "Installed", value: tallyValue("installed"), tone: "ready" }
+    ],
+    summaryLine: report.summaryLine,
+    downloadLine: createDownloadLine(report),
+    checkedLabel: options?.checkedAtLabel ?? "Not checked yet.",
+    filters: [EVERYTHING_FILTER, ...report.toolFilters.map((filter) => filter.toolLabel)].map(
+      (toolLabel) => ({
+        toolLabel,
+        active: toolLabel === activeToolLabel
+      })
+    ),
+    sections,
+    hasActionableRows: sections.some((section) => section.rows.length > 0)
+  };
+}
+
+function createModelRow(model: SetupModelRequirement): SetupRowView {
+  const badge = BADGES[model.status];
+  const installed = model.status === "installed";
+  const wrongFolder = model.status === "wrong-folder";
+  const fields: SetupRowField[] = [];
+
+  if (wrongFolder) {
+    fields.push({
+      label: "Found in",
+      value: joinWithAnd(model.foundInFolders.map((folder) => `models/${folder}/`))
+    });
+  }
+
+  if (!installed) {
+    fields.push({ label: "Goes in", value: `models/${model.targetFolder}/` });
+  }
+
+  if (!installed && !wrongFolder) {
+    fields.push({ label: "Download", value: model.formattedSize });
+  }
+
+  if (!installed && model.unlocksToolLabels.length > 0) {
+    fields.push({ label: "Unlocks", value: model.unlocksToolLabels.join(", ") });
+  }
+
+  return {
+    key: model.key,
+    title: model.label,
+    subtitle: model.modelName,
+    badgeLabel: badge.label,
+    badgeTone: badge.tone,
+    fields,
+    notes: createModelNotes(model),
+    actions: installed ? [] : createModelActions(model),
+    collapsed: installed
+  };
+}
+
+function createModelNotes(model: SetupModelRequirement): string[] {
+  const notes: string[] = [];
+
+  if (model.status === "wrong-folder") {
+    notes.push(
+      "You already have this file. Move it, then refresh ComfyUI. Nothing to download."
+    );
+  }
+
+  if (model.licenseGated) {
+    notes.push(
+      "Accept the licence on the model page before downloading. This file is not available without signing in."
+    );
+  }
+
+  if (model.layout === "repo-folder") {
+    notes.push(
+      "Clone the whole repository folder, not a single file. This loader opens a directory."
+    );
+  }
+
+  if (
+    model.status !== "installed" &&
+    model.status !== "not-checked" &&
+    model.acceptedModelNames.length > 0
+  ) {
+    const alternatives = joinWithAnd(model.acceptedModelNames);
+    notes.push(
+      model.acceptedModelNames.length === 1
+        ? `${alternatives} also works.`
+        : `${alternatives} also work.`
+    );
+  }
+
+  return notes;
+}
+
+function createModelActions(model: SetupModelRequirement): SetupRowAction[] {
+  const actions: SetupRowAction[] = [];
+
+  if (model.downloadUrl) {
+    actions.push({
+      id: "copy-download-link",
+      label: "Copy Link",
+      value: model.downloadUrl,
+      copiedMessage: `Copied the download link for ${model.modelName}.`
+    });
+  }
+
+  actions.push({
+    id: "copy-folder-path",
+    label: "Copy Folder Path",
+    value: model.targetPath,
+    copiedMessage: `Copied the folder path for ${model.modelName}.`
+  });
+
+  if (model.sourcePageUrl && model.sourcePageUrl !== model.downloadUrl) {
+    actions.push({
+      id: "copy-source-page",
+      label: "Copy Page",
+      value: model.sourcePageUrl,
+      copiedMessage: `Copied the source page for ${model.modelName}.`
+    });
+  }
+
+  return actions;
+}
+
+function createNodeRow(node: SetupNodeRequirement): SetupRowView {
+  const badge = BADGES[node.status];
+  const installed = node.status === "installed";
+  const fields: SetupRowField[] = [];
+
+  if (!installed) {
+    fields.push({ label: "Goes in", value: "custom_nodes/" });
+  }
+
+  fields.push({ label: "Provides", value: node.classTypes.join(", ") });
+
+  if (!installed && node.unlocksToolLabels.length > 0) {
+    fields.push({ label: "Unlocks", value: node.unlocksToolLabels.join(", ") });
+  }
+
+  return {
+    key: node.name,
+    title: node.name,
+    subtitle: node.repoUrl.replace(/^https:\/\//, ""),
+    badgeLabel: badge.label,
+    badgeTone: badge.tone,
+    fields,
+    notes: createNodeNotes(node),
+    actions: installed
+      ? []
+      : [
+          {
+            id: "copy-download-link",
+            label: "Copy Link",
+            value: node.repoUrl,
+            copiedMessage: `Copied the repository link for ${node.name}.`
+          }
+        ],
+    collapsed: installed
+  };
+}
+
+function createNodeNotes(node: SetupNodeRequirement): string[] {
+  if (node.status !== "missing") {
+    return [];
+  }
+
+  const notes = [
+    "Install it, then restart ComfyUI. New nodes are not picked up by a refresh."
+  ];
+
+  if (
+    node.missingClassTypes.length > 0 &&
+    node.missingClassTypes.length < node.classTypes.length
+  ) {
+    notes.push(
+      `Part of this package is loaded but ${node.missingClassTypes.join(", ")} is not, which usually means a broken or half-finished install.`
+    );
+  }
+
+  return notes;
+}
+
+function createSection(
+  id: SetupSectionView["id"],
+  title: string,
+  views: SetupRowView[],
+  activeToolLabel: string,
+  filterActive: boolean,
+  singularName: string,
+  pluralName: string
+): SetupSectionView {
+  const rows = views.filter((row) => !row.collapsed);
+  const collapsedRows = views.filter((row) => row.collapsed);
+
+  return {
+    id,
+    title,
+    meta: formatCount(views.length, singularName, pluralName),
+    rows,
+    collapsedRows,
+    collapsedSummary: formatInstalledSummary(id, collapsedRows.length),
+    emptyMessage: filterActive
+      ? `${activeToolLabel} needs no ${pluralName}.`
+      : `No ${pluralName} are required.`
+  };
+}
+
+function formatInstalledSummary(id: SetupSectionView["id"], count: number): string {
+  if (count === 0) {
+    return "";
+  }
+
+  if (id === "models") {
+    return `${count} installed ${count === 1 ? "model" : "models"}`;
+  }
+
+  return `${count} installed ${count === 1 ? "node package" : "node packages"}`;
+}
+
+function formatCount(count: number, singularName: string, pluralName: string): string {
+  return `${count} ${count === 1 ? singularName : pluralName}`;
+}
+
+function createDownloadLine(report: SetupRequirementsReport): string {
+  if (!report.checked) {
+    return `${report.formattedRemainingDownload} across ${report.models.length} models if you are starting from nothing.`;
+  }
+
+  if (report.remainingDownloadBytes === 0) {
+    return "Nothing left to download.";
+  }
+
+  return `${report.formattedRemainingDownload} left to download.`;
+}
+
+function joinWithAnd(values: readonly string[]): string {
+  if (values.length <= 1) {
+    return values[0] ?? "";
+  }
+
+  return `${values.slice(0, -1).join(", ")} and ${values[values.length - 1]}`;
+}

--- a/src/ui/statusBars.ts
+++ b/src/ui/statusBars.ts
@@ -316,6 +316,13 @@ export function setLayerToolsStatus(elements: AppElements, status: string, tone:
   applyStatusPill(elements.layerToolsStatusPill, status, tone);
 }
 
+// Setup is a read-only inspection of the server, for the same reason: its own
+// bar and nothing else.
+export function setSetupStatus(elements: AppElements, status: string, tone: StatusTone) {
+  elements.setupStatusText.textContent = status;
+  applyStatusPill(elements.setupStatusPill, status, tone);
+}
+
 function applyToolError(errorMessage: HTMLElement, message: string) {
   errorMessage.textContent = message;
   errorMessage.hidden = !message;

--- a/tests/comfy/workflowHealth.test.ts
+++ b/tests/comfy/workflowHealth.test.ts
@@ -161,7 +161,7 @@ describe("workflow health", () => {
     });
 
     expect(item.state).toBe("missing-workflow");
-    expect(item.stateLabel).toBe("Missing workflow JSON");
+    expect(item.stateLabel).toBe("Needs workflow JSON");
     expect(item.canRun).toBe(false);
   });
 

--- a/tests/ui/setupTabModel.test.ts
+++ b/tests/ui/setupTabModel.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+import { listRequiredModelsForPresets } from "../../src/comfy/modelFolders";
+import { listRunnableWorkflowPresets } from "../../src/comfy/presetRegistry";
+import {
+  SetupRequirementsReport,
+  evaluateSetupRequirements
+} from "../../src/comfy/setupRequirements";
+import {
+  ComfyModelInventory,
+  WorkflowPresetDefinition,
+  WorkflowRequiredModel
+} from "../../src/comfy/types";
+import { WorkflowNodeAvailability } from "../../src/comfy/workflowCompatibility";
+import {
+  SetupRowView,
+  SetupSectionView,
+  SetupTabView,
+  createSetupTabView
+} from "../../src/ui/setupTabModel";
+
+const PLUGIN_VERSION = "9.9.9";
+const FIXED_TIMESTAMP = "2026-07-31T00:00:00.000Z";
+
+describe("setup tab model", () => {
+  it("treats a wrong-folder model as already downloaded", () => {
+    const presets = [getRunnablePreset("txt2img-krea2-turbo")];
+    const inventory = createCompleteInventory(presets);
+    const modelName = "krea2_turbo_fp8_scaled.safetensors";
+    inventory.diffusionModels = inventory.diffusionModels.filter(
+      (name) => name !== modelName
+    );
+    inventory.checkpoints.push(modelName);
+    const report = evaluateReport(presets, { inventory });
+    const requirement = getReportModel(report, `diffusion_models/${modelName}`);
+    const row = getRow(createSetupTabView(report), requirement.key);
+
+    expect(row.badgeLabel).toBe("Wrong folder");
+    expect(row.badgeTone).toBe("warning");
+    expect(row.fields.find((field) => field.label === "Found in")).toEqual({
+      label: "Found in",
+      value: "models/checkpoints/"
+    });
+    expect(row.fields.some((field) => field.label === "Download")).toBe(false);
+    expect(row.notes[0]).toBe(
+      "You already have this file. Move it, then refresh ComfyUI. Nothing to download."
+    );
+  });
+
+  it("gives a missing model its install details and folder action", () => {
+    const presets = [getRunnablePreset("upscale-basic")];
+    const report = evaluateReport(presets, { inventory: createEmptyInventory() });
+    const requirement = report.models[0];
+    const row = getRow(createSetupTabView(report), requirement.key);
+
+    expect(row.badgeLabel).toBe("Missing");
+    expect(row.fields.map((field) => field.label)).toEqual([
+      "Goes in",
+      "Download",
+      "Unlocks"
+    ]);
+    expect(row.actions.find((action) => action.id === "copy-folder-path")).toEqual({
+      id: "copy-folder-path",
+      label: "Copy Folder Path",
+      value: requirement.targetPath,
+      copiedMessage: `Copied the folder path for ${requirement.modelName}.`
+    });
+  });
+
+  it("moves installed rows into collapsedRows without actions", () => {
+    const presets = [getRunnablePreset("upscale-basic")];
+    const report = evaluateReport(presets, {
+      inventory: createCompleteInventory(presets)
+    });
+    const section = getSection(createSetupTabView(report), "models");
+
+    expect(section.rows).toEqual([]);
+    expect(section.collapsedRows).toHaveLength(1);
+    expect(section.collapsedRows[0].collapsed).toBe(true);
+    expect(section.collapsedRows[0].actions).toEqual([]);
+    expect(section.collapsedRows[0].fields).toEqual([]);
+  });
+
+  it("keeps an unavailable server neutral while preserving the shopping list", () => {
+    const presets = [getRunnablePreset("prompt-from-layer-florence2")];
+    const report = evaluateReport(presets);
+    const view = createSetupTabView(report);
+    const rows = view.sections.flatMap((section) => section.rows);
+
+    expect(report.checked).toBe(false);
+    expect(view.tallies.map((tally) => tally.value)).toEqual(["-", "-", "-"]);
+    expect(rows).not.toHaveLength(0);
+    expect(rows.every((row) => row.badgeLabel === "Not checked")).toBe(true);
+    expect(rows.every((row) => row.badgeTone === "neutral")).toBe(true);
+    expect(view.downloadLine).toBe(
+      `${report.formattedRemainingDownload} across ${report.models.length} models if you are starting from nothing.`
+    );
+    expect(view.downloadLine).toContain("starting from nothing");
+  });
+
+  it("filters requirement rows without changing whole-report totals or summary", () => {
+    const presets = [
+      getRunnablePreset("txt2img-krea2-turbo"),
+      getRunnablePreset("upscale-basic"),
+      getRunnablePreset("prompt-from-layer-florence2")
+    ];
+    const report = evaluateReport(presets, {
+      inventory: createEmptyInventory(),
+      nodeAvailability: {}
+    });
+    const unfiltered = createSetupTabView(report);
+    const filtered = createSetupTabView(report, { activeToolLabel: "Text to Image" });
+
+    expect(getSection(filtered, "models").rows.length).toBeLessThan(
+      getSection(unfiltered, "models").rows.length
+    );
+    expect(getSection(filtered, "custom-nodes").rows).toEqual([]);
+    expect(getSection(filtered, "custom-nodes").emptyMessage).toBe(
+      "Text to Image needs no custom node packages."
+    );
+    expect(filtered.tallies).toEqual(unfiltered.tallies);
+    expect(filtered.summaryLine).toBe(unfiltered.summaryLine);
+    expect(filtered.downloadLine).toBe(unfiltered.downloadLine);
+  });
+
+  it("keeps licence and repository-folder instructions on their model rows", () => {
+    const presets = [
+      getRunnablePreset("txt2img-flux1-dev-fp8"),
+      getRunnablePreset("prompt-from-layer-florence2")
+    ];
+    const report = evaluateReport(presets, {
+      inventory: createEmptyInventory(),
+      nodeAvailability: {}
+    });
+    const view = createSetupTabView(report);
+    const licenceModel = report.models.find((model) => model.licenseGated);
+    const folderModel = report.models.find((model) => model.layout === "repo-folder");
+
+    expect(licenceModel).toBeDefined();
+    expect(folderModel).toBeDefined();
+    expect(getRow(view, licenceModel!.key).notes).toContain(
+      "Accept the licence on the model page before downloading. This file is not available without signing in."
+    );
+    expect(getRow(view, folderModel!.key).notes).toContain(
+      "Clone the whole repository folder, not a single file. This loader opens a directory."
+    );
+  });
+
+  it("explains a partially installed custom node package", () => {
+    const presets = [getRunnablePreset("prompt-from-layer-florence2")];
+    const report = evaluateReport(presets, {
+      nodeAvailability: { Florence2ModelLoader: [] }
+    });
+    const row = getRow(createSetupTabView(report), "ComfyUI-Florence2");
+
+    expect(report.customNodes[0].missingClassTypes).toEqual(["Florence2Run"]);
+    expect(row.notes).toEqual([
+      "Install it, then restart ComfyUI. New nodes are not picked up by a refresh.",
+      "Part of this package is loaded but Florence2Run is not, which usually means a broken or half-finished install."
+    ]);
+  });
+
+  it("uses singular and plural installed summaries for models and node packages", () => {
+    const singleModelPresets = [getRunnablePreset("upscale-basic")];
+    const singleModelView = createSetupTabView(
+      evaluateReport(singleModelPresets, {
+        inventory: createCompleteInventory(singleModelPresets)
+      })
+    );
+    const pluralModelPresets = [getRunnablePreset("txt2img-krea2-turbo")];
+    const pluralModelView = createSetupTabView(
+      evaluateReport(pluralModelPresets, {
+        inventory: createCompleteInventory(pluralModelPresets)
+      })
+    );
+    const singleNodePresets = [getRunnablePreset("prompt-from-layer-florence2")];
+    const singleNodeView = createSetupTabView(
+      evaluateReport(singleNodePresets, {
+        nodeAvailability: createCompleteNodeAvailability(singleNodePresets)
+      })
+    );
+    const pluralNodePresets = [
+      getRunnablePreset("prompt-from-layer-florence2"),
+      getRunnablePreset("sketch2img-linecn-basic")
+    ];
+    const pluralNodeView = createSetupTabView(
+      evaluateReport(pluralNodePresets, {
+        nodeAvailability: createCompleteNodeAvailability(pluralNodePresets)
+      })
+    );
+
+    expect(getSection(singleModelView, "models").collapsedSummary).toBe(
+      "1 installed model"
+    );
+    expect(getSection(pluralModelView, "models").collapsedSummary).toBe(
+      "3 installed models"
+    );
+    expect(getSection(singleNodeView, "custom-nodes").collapsedSummary).toBe(
+      "1 installed node package"
+    );
+    expect(getSection(pluralNodeView, "custom-nodes").collapsedSummary).toBe(
+      "2 installed node packages"
+    );
+  });
+
+  it("keeps every string in the complete view plain text", () => {
+    const presets = listRunnableWorkflowPresets();
+    const unchecked = createSetupTabView(evaluateReport(presets));
+    const missing = createSetupTabView(
+      evaluateReport(presets, {
+        inventory: createEmptyInventory(),
+        nodeAvailability: {}
+      }),
+      { checkedAtLabel: "Checked just now", activeToolLabel: "Everything" }
+    );
+    const installed = createSetupTabView(
+      evaluateReport(presets, {
+        inventory: createCompleteInventory(presets),
+        nodeAvailability: createCompleteNodeAvailability(presets)
+      })
+    );
+
+    for (const value of collectStrings([unchecked, missing, installed])) {
+      expect(value).not.toMatch(/[`\u2014\u2026]/u);
+      expect(value).not.toMatch(/\p{Extended_Pictographic}/u);
+    }
+  });
+});
+
+function evaluateReport(
+  presets: readonly WorkflowPresetDefinition[],
+  availability: {
+    inventory?: ComfyModelInventory;
+    nodeAvailability?: WorkflowNodeAvailability;
+  } = {}
+): SetupRequirementsReport {
+  return evaluateSetupRequirements({
+    pluginVersion: PLUGIN_VERSION,
+    presets,
+    generatedAt: FIXED_TIMESTAMP,
+    ...availability
+  });
+}
+
+function getRunnablePreset(id: string): WorkflowPresetDefinition {
+  const preset = listRunnableWorkflowPresets().find((candidate) => candidate.id === id);
+
+  if (!preset) {
+    throw new Error(`Expected runnable preset ${id}.`);
+  }
+
+  return preset;
+}
+
+function getReportModel(report: SetupRequirementsReport, key: string) {
+  const model = report.models.find((candidate) => candidate.key === key);
+
+  if (!model) {
+    throw new Error(`Expected setup model ${key}.`);
+  }
+
+  return model;
+}
+
+function getSection(view: SetupTabView, id: SetupSectionView["id"]): SetupSectionView {
+  const section = view.sections.find((candidate) => candidate.id === id);
+
+  if (!section) {
+    throw new Error(`Expected setup section ${id}.`);
+  }
+
+  return section;
+}
+
+function getRow(view: SetupTabView, key: string): SetupRowView {
+  const row = view.sections
+    .flatMap((section) => [...section.rows, ...section.collapsedRows])
+    .find((candidate) => candidate.key === key);
+
+  if (!row) {
+    throw new Error(`Expected setup row ${key}.`);
+  }
+
+  return row;
+}
+
+function createEmptyInventory(): ComfyModelInventory {
+  return {
+    checkpoints: [],
+    diffusionModels: [],
+    clipModels: [],
+    vaeModels: [],
+    controlNetModels: [],
+    visionLanguageModels: [],
+    upscaleModels: [],
+    missingSources: []
+  };
+}
+
+function createCompleteInventory(
+  presets: readonly WorkflowPresetDefinition[]
+): ComfyModelInventory {
+  const inventory = createEmptyInventory();
+
+  for (const model of listRequiredModelsForPresets(presets)) {
+    getInventoryBucket(inventory, model).push(model.modelName);
+  }
+
+  return inventory;
+}
+
+function getInventoryBucket(
+  inventory: ComfyModelInventory,
+  model: WorkflowRequiredModel
+): string[] {
+  switch (model.kind) {
+    case "checkpoint":
+      return inventory.checkpoints;
+    case "diffusion-model-stack":
+      return inventory.diffusionModels;
+    case "clip":
+      return inventory.clipModels;
+    case "vae":
+      return inventory.vaeModels;
+    case "controlnet":
+      return inventory.controlNetModels;
+    case "vision-language":
+      return inventory.visionLanguageModels;
+    case "upscale":
+      return inventory.upscaleModels;
+  }
+}
+
+function createCompleteNodeAvailability(
+  presets: readonly WorkflowPresetDefinition[]
+): WorkflowNodeAvailability {
+  return Object.fromEntries(
+    presets.flatMap((preset) =>
+      preset.requiredNodes.map((requirement) => [
+        requirement.classType,
+        requirement.requiredInputs
+      ])
+    )
+  );
+}
+
+function collectStrings(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(collectStrings);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).flatMap(collectStrings);
+  }
+
+  return [];
+}


### PR DESCRIPTION
Roadmap item 2, finished. Part 1 (#62) built the data; this builds the screen against the [agreed design](https://claude.ai/code/artifact/97470c93-3353-45c3-9084-a61e16a52f2d).

Codex wrote the view model (first commit), Claude wrote the DOM, wiring and CSS (second commit) — the split follows the delegation boundary in `docs/ORCHESTRATION.md` §5a: the table-driven pure module is delegable, the `renderApp` closure and the compact theme are not.

## What you get

A **Setup** card on Home, under Preferences next to Settings. It lists every model and custom node package OpenLayer needs, with the folder each belongs in, the download size, which tools it unlocks, and a live status. Filter chips scope the list to one tool.

The check runs once when you first open the screen, not on every visit — walking between screens should not keep re-asking the server. **Check Again** is for after you have actually downloaded something.

## Three decisions worth knowing about

**Wrong folder is amber and carries no download size.** It is the one state where the expensive part is already done. Red would say "fetch 12 GB again"; the row says "You already have this file. Move it, then refresh ComfyUI."

**Unreachable ComfyUI is not an error state.** The list comes from the preset registry, so it is exactly as useful offline — every name, folder, size and link still shows, the badges go grey, and the tallies show a dash rather than 0. A count of "0 missing" against a server that never answered reads as good news when it is no news. Someone asking "what do I need to download" often has not started ComfyUI yet, and a screen that shows only an error fails precisely that person.

**Rows reuse the shipped `workflow-health-item` card and `workflow-health-state` pill** rather than a new badge system — which is the fix for the shape mismatch you spotted between the mockup and the real panel. Same pill, same colors, and it inherits the compact theme automatically.

## The compact-theme work

Three rules are duplicated into `theme-compact` with `!important` and that is not redundant. `theme-compact` is the active theme and declares `.diagnostics-line` and `.button` at higher specificity *and* `!important`, so the base-theme versions are inert: without the overrides the summary truncates mid-sentence and every copy button spans the panel and stacks — three full-width buttons under each missing model. Flex `gap` is avoided throughout for the same class of reason; spacing is explicit margins, as the rest of the file already does.

Also: the report is built lazily rather than at panel startup, because `getModelTargetFolder` throws by design for a preset with an unmapped loader. That should fail this screen, not the whole panel.

## Smoke test

1. **Home** — there is a **Setup** card under Preferences, above Settings. Open it.
2. It should check automatically. With everything installed you should see **0 / 0 / 13**, "All setup requirements are installed", and **"Nothing left to download."** — specifically *not* the word "unknown", which was the bug fixed in #62.
3. Both sections show a folded **"13 installed models"** / **"2 installed node packages"** group. Expand one and confirm rows read as a name plus a filename.
4. Press **Check Again** — the timestamp in the header updates.
5. Tap a filter chip, say **Inpaint**. The lists narrow. **The three tallies and the summary must not change** — a filter is a lens, not a different answer. Tap **Everything** to restore.
6. On a missing or wrong-folder row, press **Copy Link** and **Copy Folder Path**, and paste somewhere. The status line names what was copied. Confirm the buttons sit **side by side, not stacked full width**.
7. **Stop ComfyUI**, press Check Again. Badges go to "Not checked", tallies show **-**, and every row keeps its folder, size and buttons. The status bar explains it. This must not look like a broken screen.
8. Confirm the summary and download lines **wrap to multiple lines** rather than truncating with an ellipsis.
9. Go to Settings and confirm nothing from Setup leaked onto its status, error or diagnostics lines.

To see a wrong-folder row for real, move one model file into the wrong folder (for example `krea2_turbo_fp8_scaled.safetensors` from `models/diffusion_models/` into `models/checkpoints/`), refresh ComfyUI, then Check Again. Move it back afterwards.

## Gates

`npm run typecheck`, `npm test`, `npm run build`, `npx eslint .` all pass. 481 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)