### PR TITLE
Setup tab: what will run well on this GPU

### DIFF
--- a/src/comfy/hardwareAdvisor.ts
+++ b/src/comfy/hardwareAdvisor.ts
@@ -50,7 +50,7 @@ export function createHardwareRecommendationReport(
   presets: WorkflowPresetDefinition[]
 ): HardwareRecommendationReport {
   const primaryDevice = choosePrimaryDevice(systemStats.devices);
-  const vramTotalBytes = primaryDevice?.vramTotalBytes ?? primaryDevice?.torchVramTotalBytes;
+  const vramTotalBytes = getPrimaryDeviceVramTotalBytes(systemStats) ?? undefined;
   const vramFreeBytes = primaryDevice?.vramFreeBytes ?? primaryDevice?.torchVramFreeBytes;
   const tier = getHardwareTier(vramTotalBytes);
   const detectedFamilies = summarizeDetectedFamilies(inventory);
@@ -265,6 +265,11 @@ function choosePrimaryDevice(devices: ComfyHardwareDevice[]) {
   return devices.find((device) => device.type.toLowerCase().includes("cuda"))
     ?? devices.find((device) => Boolean(device.vramTotalBytes ?? device.torchVramTotalBytes))
     ?? devices[0];
+}
+
+export function getPrimaryDeviceVramTotalBytes(systemStats: ComfySystemStats): number | null {
+  const primaryDevice = choosePrimaryDevice(systemStats.devices);
+  return primaryDevice?.vramTotalBytes ?? primaryDevice?.torchVramTotalBytes ?? null;
 }
 
 function hasFamily(inventory: ComfyModelInventory, family: ModelFamily) {

--- a/src/comfy/presetFootprint.ts
+++ b/src/comfy/presetFootprint.ts
@@ -1,0 +1,196 @@
+import { getRequiredModelKey, listPresetRequiredModels } from "./modelFolders";
+import { listRunnableWorkflowPresets } from "./presetRegistry";
+import { buildSetupManifest, formatBytes } from "./setupManifest";
+import { WorkflowPresetDefinition } from "./types";
+import { getWorkflowCapability } from "./workflowCapabilities";
+
+export type PresetSizeConfidence = "complete" | "partial" | "checkpoint-dependent";
+export type VramExpectation = "comfortable" | "tight" | "offloads" | "unknown";
+
+export type PresetFootprint = {
+  presetId: string;
+  displayName: string;
+  toolLabel: string;
+  modelCount: number;
+  totalBytes: number;
+  largestModelBytes: number;
+  largestModelName: string | null;
+  unknownSizeCount: number;
+  confidence: PresetSizeConfidence;
+  formattedTotal: string;
+  formattedLargest: string;
+};
+
+export type PresetVramOutlook = PresetFootprint & {
+  expectation: VramExpectation;
+  expectationLabel: string;
+  expectationNote: string;
+};
+
+const EXPECTATION_LABELS: Record<VramExpectation, string> = {
+  comfortable: "Comfortable",
+  tight: "Tight",
+  offloads: "Will offload",
+  unknown: "Not known"
+};
+
+const EXPECTATION_RANK: Record<VramExpectation, number> = {
+  comfortable: 0,
+  tight: 1,
+  offloads: 2,
+  unknown: 3
+};
+
+export function createPresetFootprints(options: {
+  pluginVersion: string;
+  presets?: readonly WorkflowPresetDefinition[];
+  generatedAt?: string;
+}): PresetFootprint[] {
+  const presets = options.presets ?? listRunnableWorkflowPresets();
+  const manifest = buildSetupManifest({
+    pluginVersion: options.pluginVersion,
+    presets,
+    generatedAt: options.generatedAt
+  });
+  const manifestModelsByKey = new Map(manifest.models.map((model) => [model.key, model]));
+
+  return presets.map((preset) => {
+    const requiredModels = listPresetRequiredModels(preset);
+    let totalBytes = 0;
+    let largestModelBytes = 0;
+    let largestModelName: string | null = null;
+    let unknownSizeCount = 0;
+
+    for (const requiredModel of requiredModels) {
+      const key = getRequiredModelKey(requiredModel);
+      const manifestModel = manifestModelsByKey.get(key);
+
+      if (!manifestModel) {
+        throw new Error(`The setup manifest is missing the required model ${key}.`);
+      }
+
+      if (manifestModel.sizeBytes === undefined) {
+        unknownSizeCount += 1;
+        continue;
+      }
+
+      totalBytes += manifestModel.sizeBytes;
+
+      if (manifestModel.sizeBytes > largestModelBytes) {
+        largestModelBytes = manifestModel.sizeBytes;
+        largestModelName = manifestModel.modelName;
+      }
+    }
+
+    const confidence = getSizeConfidence(requiredModels.length, unknownSizeCount);
+
+    return {
+      presetId: preset.id,
+      displayName: preset.displayName,
+      toolLabel: getWorkflowCapability(preset).artistLabel,
+      modelCount: requiredModels.length,
+      totalBytes,
+      largestModelBytes,
+      largestModelName,
+      unknownSizeCount,
+      confidence,
+      formattedTotal: formatFootprintBytes(totalBytes, confidence),
+      formattedLargest: formatFootprintBytes(largestModelBytes, confidence)
+    };
+  });
+}
+
+export function rankPresetsByVramOutlook(options: {
+  pluginVersion: string;
+  presets?: readonly WorkflowPresetDefinition[];
+  vramTotalBytes?: number | null;
+  generatedAt?: string;
+}): PresetVramOutlook[] {
+  return createPresetFootprints(options)
+    .map((footprint) => {
+      // ComfyUI can load components at different times and offload them between
+      // stages. The largest single file is therefore a better proxy for the
+      // dominant resident chunk than the sum. The sum instead describes the
+      // total download and the amount of model data that may need streaming.
+      const expectation = getVramExpectation(footprint, options.vramTotalBytes);
+
+      return {
+        ...footprint,
+        expectation,
+        expectationLabel: EXPECTATION_LABELS[expectation],
+        expectationNote: getExpectationNote(expectation, footprint.confidence)
+      };
+    })
+    .sort(compareOutlooks);
+}
+
+function getSizeConfidence(
+  modelCount: number,
+  unknownSizeCount: number
+): PresetSizeConfidence {
+  if (modelCount === 0) {
+    return "checkpoint-dependent";
+  }
+
+  return unknownSizeCount > 0 ? "partial" : "complete";
+}
+
+function formatFootprintBytes(bytes: number, confidence: PresetSizeConfidence): string {
+  if (confidence === "checkpoint-dependent") {
+    return "Depends on the checkpoint you pick";
+  }
+
+  const formattedBytes = bytes > 0 ? formatBytes(bytes) : "0 MB";
+  return confidence === "partial" ? `At least ${formattedBytes}` : formattedBytes;
+}
+
+function getVramExpectation(
+  footprint: PresetFootprint,
+  vramTotalBytes?: number | null
+): VramExpectation {
+  if (
+    footprint.confidence === "checkpoint-dependent" ||
+    vramTotalBytes == null ||
+    vramTotalBytes <= 0 ||
+    !Number.isFinite(vramTotalBytes)
+  ) {
+    return "unknown";
+  }
+
+  if (footprint.largestModelBytes <= vramTotalBytes * 0.7) {
+    return "comfortable";
+  }
+
+  if (footprint.largestModelBytes <= vramTotalBytes) {
+    return "tight";
+  }
+
+  return "offloads";
+}
+
+function getExpectationNote(
+  expectation: VramExpectation,
+  confidence: PresetSizeConfidence
+): string {
+  switch (expectation) {
+    case "comfortable":
+      return "The largest file fits in VRAM with room to spare, so this should run at full speed.";
+    case "tight":
+      return "The largest file nearly fills VRAM, so expect slower generations and less room for large canvases.";
+    case "offloads":
+      return "The largest file is bigger than the VRAM, so ComfyUI will keep part of it in system RAM. This means generations will be slower, not broken.";
+    case "unknown":
+      return confidence === "checkpoint-dependent"
+        ? "The size depends on the checkpoint chosen."
+        : "ComfyUI has not reported VRAM, so only the sizes are shown.";
+  }
+}
+
+function compareOutlooks(left: PresetVramOutlook, right: PresetVramOutlook): number {
+  return (
+    EXPECTATION_RANK[left.expectation] - EXPECTATION_RANK[right.expectation] ||
+    left.largestModelBytes - right.largestModelBytes ||
+    left.totalBytes - right.totalBytes ||
+    left.presetId.localeCompare(right.presetId)
+  );
+}

--- a/src/comfy/presetFootprint.ts
+++ b/src/comfy/presetFootprint.ts
@@ -3,6 +3,7 @@ import { listRunnableWorkflowPresets } from "./presetRegistry";
 import { buildSetupManifest, formatBytes } from "./setupManifest";
 import { WorkflowPresetDefinition } from "./types";
 import { getWorkflowCapability } from "./workflowCapabilities";
+import { createOpenLayerError } from "../utils/errors";
 
 export type PresetSizeConfidence = "complete" | "partial" | "checkpoint-dependent";
 export type VramExpectation = "comfortable" | "tight" | "offloads" | "unknown";
@@ -66,7 +67,11 @@ export function createPresetFootprints(options: {
       const manifestModel = manifestModelsByKey.get(key);
 
       if (!manifestModel) {
-        throw new Error(`The setup manifest is missing the required model ${key}.`);
+        throw createOpenLayerError(
+          "WORKFLOW_INVALID",
+          `No setup manifest entry matches the required model ${key}.`,
+          "The setup manifest and the preset registry disagree about a required model key."
+        );
       }
 
       if (manifestModel.sizeBytes === undefined) {
@@ -113,12 +118,16 @@ export function rankPresetsByVramOutlook(options: {
       // dominant resident chunk than the sum. The sum instead describes the
       // total download and the amount of model data that may need streaming.
       const expectation = getVramExpectation(footprint, options.vramTotalBytes);
+      const hasVramFigure =
+        options.vramTotalBytes != null &&
+        options.vramTotalBytes > 0 &&
+        Number.isFinite(options.vramTotalBytes);
 
       return {
         ...footprint,
         expectation,
         expectationLabel: EXPECTATION_LABELS[expectation],
-        expectationNote: getExpectationNote(expectation, footprint.confidence)
+        expectationNote: getExpectationNote(expectation, footprint.confidence, hasVramFigure)
       };
     })
     .sort(compareOutlooks);
@@ -140,8 +149,14 @@ function formatFootprintBytes(bytes: number, confidence: PresetSizeConfidence): 
     return "Depends on the checkpoint you pick";
   }
 
-  const formattedBytes = bytes > 0 ? formatBytes(bytes) : "0 MB";
-  return confidence === "partial" ? `At least ${formattedBytes}` : formattedBytes;
+  // A partial stack whose every size is unpublished has nothing to be "at least".
+  // Florence-2 is the live case: it is one repo-folder model with no published
+  // size, so the naive form of this read "At least 0 MB".
+  if (bytes <= 0) {
+    return "Size not published";
+  }
+
+  return confidence === "partial" ? `At least ${formatBytes(bytes)}` : formatBytes(bytes);
 }
 
 function getVramExpectation(
@@ -157,8 +172,13 @@ function getVramExpectation(
     return "unknown";
   }
 
+  // An unpublished size is not a small size. With any size missing, "tight" and
+  // "offloads" stay safe -- the known part alone already reaches that much -- but
+  // "comfortable" does not, because the model nobody published a size for could
+  // be the largest in the stack. Left unguarded, Florence-2 measured zero bytes
+  // and was reported as the single most comfortable preset on the list.
   if (footprint.largestModelBytes <= vramTotalBytes * 0.7) {
-    return "comfortable";
+    return footprint.unknownSizeCount > 0 ? "unknown" : "comfortable";
   }
 
   if (footprint.largestModelBytes <= vramTotalBytes) {
@@ -170,7 +190,8 @@ function getVramExpectation(
 
 function getExpectationNote(
   expectation: VramExpectation,
-  confidence: PresetSizeConfidence
+  confidence: PresetSizeConfidence,
+  hasVramFigure: boolean
 ): string {
   switch (expectation) {
     case "comfortable":
@@ -180,9 +201,15 @@ function getExpectationNote(
     case "offloads":
       return "The largest file is bigger than the VRAM, so ComfyUI will keep part of it in system RAM. This means generations will be slower, not broken.";
     case "unknown":
-      return confidence === "checkpoint-dependent"
-        ? "The size depends on the checkpoint chosen."
-        : "ComfyUI has not reported VRAM, so only the sizes are shown.";
+      if (confidence === "checkpoint-dependent") {
+        return "The size depends on the checkpoint chosen.";
+      }
+
+      if (!hasVramFigure) {
+        return "ComfyUI has not reported VRAM, so only the sizes are shown.";
+      }
+
+      return "This stack includes a model with no published size, so there is nothing reliable to say about speed.";
   }
 }
 

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -1,6 +1,7 @@
 import { ComfyClient } from "../comfy/comfyClient";
 import {
   createHardwareRecommendationReport,
+  getPrimaryDeviceVramTotalBytes,
   formatHardwareReport,
   HardwareRecommendationReport
 } from "../comfy/hardwareAdvisor";
@@ -93,6 +94,11 @@ import {
   evaluateSetupRequirements,
   SetupRequirementsReport
 } from "../comfy/setupRequirements";
+import {
+  PresetVramOutlook,
+  rankPresetsByVramOutlook,
+  VramExpectation
+} from "../comfy/presetFootprint";
 import {
   createSetupTabView,
   SetupFilterView,
@@ -363,6 +369,11 @@ export function renderApp(rootElement: HTMLElement) {
   let setupActiveToolLabel: string | null = null;
   let setupCheckedAtLabel: string | null = null;
   let hasCheckedSetup = false;
+  // Null until ComfyUI reports a device. The outlook is deliberately still drawn
+  // without it: the sizes are worth showing on their own, and a preset ranking
+  // that vanished when the server was down would be the offline failure the rest
+  // of this screen was built to avoid.
+  let setupVramTotalBytes: number | null = null;
   const historyEntries: HistoryEntry[] = [];
   const objectUrls = createObjectUrlRegistry();
 
@@ -1135,6 +1146,15 @@ export function renderApp(rootElement: HTMLElement) {
       const inventory = await client.getModelInventory();
       const nodeAvailability = await client.getWorkflowNodeAvailability(presets);
 
+      // The device report is a bonus, not a requirement. A ComfyUI that answers
+      // for models but not for hardware should still produce a checked screen,
+      // so this failure only costs the ranking its VRAM column.
+      try {
+        setupVramTotalBytes = getPrimaryDeviceVramTotalBytes(await client.getSystemStats());
+      } catch {
+        setupVramTotalBytes = null;
+      }
+
       setupReport = evaluateSetupRequirements({
         pluginVersion: APP_VERSION,
         inventory,
@@ -1189,6 +1209,22 @@ export function renderApp(rootElement: HTMLElement) {
       renderSetupTab();
     });
     renderSetupSections(elements.setupSections, view.sections, handleSetupCopy);
+
+    const outlooks = rankPresetsByVramOutlook({
+      pluginVersion: APP_VERSION,
+      vramTotalBytes: setupVramTotalBytes
+    });
+
+    elements.setupVramLabel.textContent = setupVramTotalBytes
+      ? `${formatGigabytes(setupVramTotalBytes)} VRAM`
+      : "VRAM not detected";
+    renderSetupOutlook(
+      elements.setupOutlookList,
+      setupActiveToolLabel && setupActiveToolLabel !== "Everything"
+        ? outlooks.filter((outlook) => outlook.toolLabel === setupActiveToolLabel)
+        : outlooks,
+      setupVramTotalBytes
+    );
   }
 
   async function handleSetupCopy(action: SetupRowAction) {
@@ -4799,6 +4835,126 @@ function renderWorkflowHealthSummary(elements: AppElements, report: WorkflowHeal
  */
 function createUncheckedSetupReport(): SetupRequirementsReport {
   return evaluateSetupRequirements({ pluginVersion: APP_VERSION });
+}
+
+function formatGigabytes(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
+}
+
+const SETUP_EXPECTATION_TONES: Record<VramExpectation, string> = {
+  comfortable: "is-setup-ready",
+  tight: "is-setup-warning",
+  offloads: "is-setup-warning",
+  unknown: ""
+};
+
+/**
+ * Only the numbers that differ. A preset with one model has a largest file and
+ * a full stack of the same size, and a preset with nothing measurable would
+ * print its one apology twice, so both collapse. The note always carries the
+ * explanation, which is why dropping the fields entirely loses nothing.
+ */
+function createOutlookFields(
+  outlook: PresetVramOutlook,
+  vramTotalBytes: number | null
+): { label: string; value: string }[] {
+  if (outlook.totalBytes <= 0) {
+    return [];
+  }
+
+  const largest = vramTotalBytes
+    ? `${outlook.formattedLargest} of your ${formatGigabytes(vramTotalBytes)}`
+    : outlook.formattedLargest;
+
+  if (outlook.largestModelBytes === outlook.totalBytes) {
+    return [{ label: "Model size", value: largest }];
+  }
+
+  return [
+    { label: "Largest file", value: largest },
+    { label: "Full stack", value: outlook.formattedTotal }
+  ];
+}
+
+/**
+ * The preset ranking. "Will offload" shares the amber of "tight" rather than
+ * taking the red of a missing requirement, because it is not a fault: the
+ * preset runs, it runs slower. Red here would say the same wrong thing the
+ * module refuses to say in words.
+ */
+function renderSetupOutlook(
+  container: HTMLElement,
+  outlooks: readonly PresetVramOutlook[],
+  vramTotalBytes: number | null
+) {
+  container.innerHTML = "";
+
+  if (outlooks.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "diagnostics-line setup-paragraph";
+    empty.textContent = "No presets match this filter.";
+    container.append(empty);
+    return;
+  }
+
+  for (const outlook of outlooks) {
+    const row = document.createElement("div");
+    row.className = "workflow-health-item setup-row";
+
+    const heading = document.createElement("div");
+    heading.className = "workflow-health-heading";
+
+    const titleBlock = document.createElement("div");
+    titleBlock.className = "workflow-health-title-block";
+
+    const title = document.createElement("div");
+    title.className = "workflow-health-title";
+    title.textContent = outlook.displayName;
+    titleBlock.append(title);
+
+    const tool = document.createElement("div");
+    tool.className = "workflow-health-tool";
+    tool.textContent = outlook.toolLabel;
+    titleBlock.append(tool);
+
+    heading.append(titleBlock);
+
+    const badge = document.createElement("div");
+    badge.className = `workflow-health-state ${SETUP_EXPECTATION_TONES[outlook.expectation]}`.trim();
+    badge.textContent = outlook.expectationLabel;
+    heading.append(badge);
+
+    row.append(heading);
+
+    const fields = document.createElement("div");
+    fields.className = "setup-row-fields";
+
+    for (const field of createOutlookFields(outlook, vramTotalBytes)) {
+      const fieldRow = document.createElement("div");
+      fieldRow.className = "setup-row-field";
+
+      const label = document.createElement("span");
+      label.className = "setup-row-field-label";
+      label.textContent = field.label;
+      fieldRow.append(label);
+
+      const value = document.createElement("span");
+      value.className = "setup-row-field-value";
+      value.textContent = field.value;
+      fieldRow.append(value);
+
+      fields.append(fieldRow);
+    }
+
+    row.append(fields);
+
+    const note = document.createElement("div");
+    note.className = "setup-row-note";
+    note.textContent = outlook.expectationNote;
+    row.append(note);
+
+    container.append(row);
+  }
 }
 
 function formatClockTime(when: Date): string {

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -53,6 +53,8 @@ export type AppElements = {
   setupStatusPill: HTMLElement;
   setupFilters: HTMLElement;
   setupSections: HTMLElement;
+  setupVramLabel: HTMLElement;
+  setupOutlookList: HTMLElement;
   historyView: HTMLElement;
   layerToolsView: HTMLElement;
   exportLayerFileButton: HTMLElement;
@@ -1233,6 +1235,17 @@ export function createAppMarkup() {
         <div class="setup-filter-row" id="setup-filters" aria-label="Filter requirements by tool"></div>
 
         <div id="setup-sections"></div>
+
+        <section class="panel-section settings-panel diagnostic-section diagnostic-scroll-safe" aria-label="What will run well">
+          <div class="section-heading">
+            <span class="label">What will run well</span>
+            <span class="muted-label" id="setup-vram-label">VRAM not detected</span>
+          </div>
+          <div class="diagnostics-line setup-paragraph" id="setup-outlook-note">
+            Sizes are model weights, not measured VRAM use. ComfyUI moves what does not fit into system RAM, so a large stack runs slower rather than failing.
+          </div>
+          <div id="setup-outlook-list"></div>
+        </section>
       </section>
 
       <section class="history-view" id="history-view" aria-label="History" hidden>
@@ -1400,6 +1413,8 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     setupStatusPill: getElement<HTMLElement>(rootElement, "setup-status-pill"),
     setupFilters: getElement<HTMLElement>(rootElement, "setup-filters"),
     setupSections: getElement<HTMLElement>(rootElement, "setup-sections"),
+    setupVramLabel: getElement<HTMLElement>(rootElement, "setup-vram-label"),
+    setupOutlookList: getElement<HTMLElement>(rootElement, "setup-outlook-list"),
     historyView: getElement<HTMLElement>(rootElement, "history-view"),
     layerToolsView: getElement<HTMLElement>(rootElement, "layer-tools-view"),
     exportLayerFileButton: getElement<HTMLElement>(rootElement, "export-layer-file"),

--- a/tests/comfy/presetFootprint.test.ts
+++ b/tests/comfy/presetFootprint.test.ts
@@ -41,8 +41,44 @@ describe("preset footprint", () => {
 
     expect(footprint.confidence).toBe("partial");
     expect(footprint.unknownSizeCount).toBeGreaterThan(0);
-    expect(footprint.formattedTotal).toMatch(/^At least /);
     expect(footprint.formattedTotal.toLowerCase()).not.toContain("unknown");
+    // Every size in this stack is unpublished, so there is no floor to be "at
+    // least". The naive form of this read "At least 0 MB".
+    expect(footprint.formattedTotal).toBe("Size not published");
+    expect(footprint.formattedLargest).toBe("Size not published");
+    expect(footprint.formattedTotal).not.toMatch(/\b0\b/);
+  });
+
+  it("never calls a stack comfortable when a size in it is unpublished", () => {
+    // An unpublished size is not a small size. Florence-2 measures zero bytes,
+    // and unguarded that made it the single most comfortable preset on the list
+    // -- the panel telling the artist a model it cannot size will run at full
+    // speed. "Tight" and "offloads" stay safe, because the known part alone
+    // already reaches that much.
+    const florence = getRunnablePreset("prompt-from-layer-florence2");
+    const outlook = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      presets: [florence],
+      vramTotalBytes: 24 * 1024 ** 3
+    })[0];
+
+    expect(outlook.unknownSizeCount).toBeGreaterThan(0);
+    expect(outlook.expectation).toBe("unknown");
+    expect(outlook.expectation).not.toBe("comfortable");
+    expect(outlook.expectationNote).toContain("no published size");
+    expect(outlook.expectationNote).not.toMatch(/full speed/);
+  });
+
+  it("separates a missing VRAM figure from a missing model size in the note", () => {
+    const florence = getRunnablePreset("prompt-from-layer-florence2");
+    const noVram = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      presets: [florence],
+      vramTotalBytes: null
+    })[0];
+
+    expect(noVram.expectation).toBe("unknown");
+    expect(noVram.expectationNote).toContain("has not reported VRAM");
   });
 
   it("describes both comfortable residency and recoverable offloading", () => {

--- a/tests/comfy/presetFootprint.test.ts
+++ b/tests/comfy/presetFootprint.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import { getPrimaryDeviceVramTotalBytes } from "../../src/comfy/hardwareAdvisor";
+import {
+  PresetVramOutlook,
+  VramExpectation,
+  createPresetFootprints,
+  rankPresetsByVramOutlook
+} from "../../src/comfy/presetFootprint";
+import { listRunnableWorkflowPresets } from "../../src/comfy/presetRegistry";
+import { WorkflowPresetDefinition } from "../../src/comfy/types";
+
+const PLUGIN_VERSION = "9.9.9";
+const FIXED_TIMESTAMP = "2026-07-31T00:00:00.000Z";
+const CHECKPOINT_DEPENDENT_PRESET_IDS = [
+  "txt2img-basic",
+  "img2img-basic",
+  "inpaint-basic"
+];
+
+describe("preset footprint", () => {
+  it("keeps checkpoint-selected preset sizes and outlooks unknown", () => {
+    const outlooks = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      vramTotalBytes: Number.MAX_SAFE_INTEGER,
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    for (const presetId of CHECKPOINT_DEPENDENT_PRESET_IDS) {
+      const outlook = getOutlook(outlooks, presetId);
+
+      expect(outlook.confidence).toBe("checkpoint-dependent");
+      expect(outlook.expectation).toBe("unknown");
+      expect(outlook.formattedTotal.toLowerCase()).toContain("checkpoint");
+      expect(outlook.formattedTotal.toLowerCase()).not.toContain("unknown");
+      expect(outlook.formattedTotal).not.toMatch(/\d/);
+    }
+  });
+
+  it("marks the Florence-2 repo-folder size as partial", () => {
+    const footprint = getFootprint("prompt-from-layer-florence2");
+
+    expect(footprint.confidence).toBe("partial");
+    expect(footprint.unknownSizeCount).toBeGreaterThan(0);
+    expect(footprint.formattedTotal).toMatch(/^At least /);
+    expect(footprint.formattedTotal.toLowerCase()).not.toContain("unknown");
+  });
+
+  it("describes both comfortable residency and recoverable offloading", () => {
+    const preset = getRunnablePreset("upscale-basic");
+    const footprint = createPresetFootprints({
+      pluginVersion: PLUGIN_VERSION,
+      presets: [preset],
+      generatedAt: FIXED_TIMESTAMP
+    })[0];
+    expect(footprint.largestModelBytes).toBeGreaterThan(1);
+
+    const comfortable = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      presets: [preset],
+      vramTotalBytes: footprint.largestModelBytes * 2,
+      generatedAt: FIXED_TIMESTAMP
+    })[0];
+    const offloads = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      presets: [preset],
+      vramTotalBytes: footprint.largestModelBytes - 1,
+      generatedAt: FIXED_TIMESTAMP
+    })[0];
+
+    expect(comfortable.expectation).toBe("comfortable");
+    expect(offloads.expectation).toBe("offloads");
+    expect(offloads.expectationNote.toLowerCase()).toContain("slower");
+    expect(offloads.expectationNote.toLowerCase()).toContain("not broken");
+    expect(offloads.expectationNote).not.toMatch(/\b(?:cannot|can not|unable|too large|not supported)\b/i);
+  });
+
+  it("makes no speed claim when ComfyUI has not reported VRAM", () => {
+    const outlooks = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      vramTotalBytes: null,
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    expect(outlooks.every((outlook) => outlook.expectation === "unknown")).toBe(true);
+    expect(outlooks.every((outlook) => !/speed|slow|fast/i.test(outlook.expectationNote))).toBe(true);
+  });
+
+  it("never reports a largest known model bigger than the known total", () => {
+    const footprints = createPresetFootprints({
+      pluginVersion: PLUGIN_VERSION,
+      generatedAt: FIXED_TIMESTAMP
+    });
+
+    for (const footprint of footprints) {
+      expect(footprint.largestModelBytes).toBeLessThanOrEqual(footprint.totalBytes);
+    }
+  });
+
+  it("ranks expectation groups and every within-group tiebreak deterministically", () => {
+    const outlooks = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      vramTotalBytes: 16 * 1024 ** 3,
+      generatedAt: FIXED_TIMESTAMP
+    });
+    const expected = [...outlooks].sort(compareOutlooksBySpecification);
+
+    expect([...new Set(outlooks.map((outlook) => outlook.expectation))]).toEqual([
+      "comfortable",
+      "tight",
+      "offloads",
+      "unknown"
+    ]);
+    expect(outlooks.map((outlook) => outlook.presetId)).toEqual(
+      expected.map((outlook) => outlook.presetId)
+    );
+
+    const tiedGroups = groupExactTies(outlooks).filter((group) => group.length > 1);
+    expect(tiedGroups.length).toBeGreaterThan(0);
+
+    for (const group of tiedGroups) {
+      expect(group.map((outlook) => outlook.presetId)).toEqual(
+        group.map((outlook) => outlook.presetId).sort((left, right) => left.localeCompare(right))
+      );
+    }
+  });
+
+  it("reads VRAM from the selected CUDA device and preserves the torch fallback", () => {
+    expect(
+      getPrimaryDeviceVramTotalBytes({
+        devices: [
+          { name: "CPU", type: "cpu", vramTotalBytes: 111 },
+          { name: "CUDA GPU", type: "cuda:0", vramTotalBytes: 222 },
+          { name: "Other GPU", type: "directml", vramTotalBytes: 333 }
+        ]
+      })
+    ).toBe(222);
+
+    expect(
+      getPrimaryDeviceVramTotalBytes({
+        devices: [{ name: "CUDA GPU", type: "cuda:0", torchVramTotalBytes: 444 }]
+      })
+    ).toBe(444);
+
+    expect(
+      getPrimaryDeviceVramTotalBytes({
+        devices: [{ name: "CPU", type: "cpu" }]
+      })
+    ).toBeNull();
+  });
+
+  it("keeps every outlook string plain", () => {
+    const outlooks = [
+      ...rankPresetsByVramOutlook({
+        pluginVersion: PLUGIN_VERSION,
+        vramTotalBytes: 16 * 1024 ** 3,
+        generatedAt: FIXED_TIMESTAMP
+      }),
+      ...rankPresetsByVramOutlook({
+        pluginVersion: PLUGIN_VERSION,
+        vramTotalBytes: null,
+        generatedAt: FIXED_TIMESTAMP
+      })
+    ];
+
+    for (const value of collectStrings(outlooks)) {
+      expect(value).not.toMatch(/[`—…]/u);
+      expect(value).not.toMatch(/\p{Extended_Pictographic}/u);
+    }
+  });
+});
+
+function getRunnablePreset(id: string): WorkflowPresetDefinition {
+  const preset = listRunnableWorkflowPresets().find((candidate) => candidate.id === id);
+
+  if (!preset) {
+    throw new Error(`Expected runnable preset ${id}.`);
+  }
+
+  return preset;
+}
+
+function getFootprint(presetId: string) {
+  const footprint = createPresetFootprints({
+    pluginVersion: PLUGIN_VERSION,
+    generatedAt: FIXED_TIMESTAMP
+  }).find((candidate) => candidate.presetId === presetId);
+
+  if (!footprint) {
+    throw new Error(`Expected preset footprint ${presetId}.`);
+  }
+
+  return footprint;
+}
+
+function getOutlook(outlooks: readonly PresetVramOutlook[], presetId: string) {
+  const outlook = outlooks.find((candidate) => candidate.presetId === presetId);
+
+  if (!outlook) {
+    throw new Error(`Expected preset outlook ${presetId}.`);
+  }
+
+  return outlook;
+}
+
+function compareOutlooksBySpecification(
+  left: PresetVramOutlook,
+  right: PresetVramOutlook
+): number {
+  const expectationRank: Record<VramExpectation, number> = {
+    comfortable: 0,
+    tight: 1,
+    offloads: 2,
+    unknown: 3
+  };
+
+  return (
+    expectationRank[left.expectation] - expectationRank[right.expectation] ||
+    left.largestModelBytes - right.largestModelBytes ||
+    left.totalBytes - right.totalBytes ||
+    left.presetId.localeCompare(right.presetId)
+  );
+}
+
+function groupExactTies(outlooks: readonly PresetVramOutlook[]): PresetVramOutlook[][] {
+  const groups = new Map<string, PresetVramOutlook[]>();
+
+  for (const outlook of outlooks) {
+    const key = `${outlook.expectation}:${outlook.largestModelBytes}:${outlook.totalBytes}`;
+    const group = groups.get(key) ?? [];
+    group.push(outlook);
+    groups.set(key, group);
+  }
+
+  return [...groups.values()];
+}
+
+function collectStrings(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(collectStrings);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).flatMap(collectStrings);
+  }
+
+  return [];
+}


### PR DESCRIPTION
Roadmap item 3, built to the two calls you made: report footprint and speed expectations rather than can/cannot, and surface it on the Setup screen.

Codex wrote the pure module (commit 1), I reviewed and fixed it (commit 2) and built the screen section (commit 3).

## What it claims, and what it refuses to

Model file size is not a VRAM requirement — ComfyUI offloads what does not fit to system RAM. Your own box runs a 22.2 GB Flux Fill on 12 GB every day, so any logic concluding "you cannot run this" would be confidently wrong about four presets you use daily. **Nothing here decides that.** It reports sizes and sets expectations: Comfortable, Tight, Will offload, Not known. There is a test asserting the offload copy contains none of "cannot", "unable", "too large" or "not supported".

No VRAM number is hardcoded anywhere — per model, per family or per preset. Everything derives from `sizeBytes` already in the setup manifest and from what ComfyUI reports about the device.

**The expectation comes from the largest single file, not the sum**, because ComfyUI loads a text encoder, encodes, frees it, then loads the diffusion model — so the biggest component is the better proxy for peak residency. The sum is still shown as download and streaming cost.

## The bug the review caught

Florence-2 is one repo-folder model with no published size, so it measured **zero bytes** — and zero comfortably fits any card. The panel ranked Prompt from Layer as the single most comfortable preset and told you it would run at full speed, about the one model whose size it does not know. Same confident wrongness the module exists to prevent, arriving from the opposite direction. Its size strings also read "At least 0 MB".

An unpublished size is not a small size. "Tight" and "will offload" stay safe with a size missing, because the known part alone already reaches that much; "comfortable" does not. The existing test only asserted the string began with "At least", which "At least 0 MB" satisfied.

## A decision reversed on purpose

The Presets section was cut from the Setup screen in #63 because it duplicated Workflow Health. It comes back here, because it now carries something Health has no idea about: what a preset will feel like on this card. Filter chips narrow it along with everything else.

"Will offload" is amber, not red. Red is a missing requirement; this preset runs, just slower — colouring it as a fault would say in CSS what the module refuses to say in words.

## Smoke test

1. **Setup** screen, scroll past Custom nodes to **What will run well**. Header should show your VRAM (about 12.0 GB).
2. Expected order on your machine, top to bottom: Standard upscaler and LineArt ControlNet as **Comfortable**; both Z_image_Turbo presets **Tight**; both Krea-2, Flux1-dev fp8 and both Flux Fill presets **Will offload**; the three Standard checkpoint presets and Florence-2 as **Not known**.
3. **Florence-2 PromptGen must read "Not known", not "Comfortable"**, and must not appear at the top. Its sizes read "Size not published" — never "At least 0 MB", never "unknown".
4. The three Standard checkpoint presets read "Depends on the checkpoint you pick", once per row rather than twice.
5. Flux Fill reads "Largest file 22.2 GB of your 12.0 GB" and a note saying generations will be **slower, not broken**. It must not say you cannot run it.
6. Tap the **Inpaint** chip — this section narrows too. **Everything** restores it.
7. **Stop ComfyUI** and press Check Again. The section keeps every preset and its sizes; the header reads "VRAM not detected" and rows drop the "of your 12.0 GB" comparison. It must not vanish or error.

## Gates

`npm run typecheck`, `npm test`, `npm run build`, `npx eslint .` all pass. 491 tests, up from 481.

Badge widths and panel overflow were measured against the compiled stylesheet at a real 380px frame: widest badge 87px, nothing overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)