### PR TITLE
Release v0.11.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## v0.11.0-alpha - 2026-08-01
+
+Everything here is about the distance between installing OpenLayer and being able to generate anything with it. The panel has always known exactly which model files and custom nodes its presets need, and where each one goes, but it only said so one preset at a time, in the middle of a health report, using names like `txt2img-krea2-turbo`. This release turns that knowledge into a screen you can work from: what you still need, where it goes, how big it is, what it unlocks — and, once ComfyUI reports its VRAM, which of the presets your card will actually run well.
+
+### Added
+
+- **A Setup screen**, on Home under Preferences. It lists every model file and custom node package the presets need, each with the folder it belongs in, its download size, which tools it unlocks, and its live status: Installed, Wrong folder, Missing, or Not checked. Rows for things you already have collapse into a one-line summary, so what is left on screen is what you still have to do.
+- **Models are the list, not presets.** The 13 runnable presets share 13 model files with heavy overlap — a preset-first list prints `ae.safetensors` four times and reads as roughly 18 GB of downloads that do not exist. The remaining-download figure is therefore the sum of what is actually missing, counted once each, and it says "Nothing" when you are done rather than a number.
+- **The screen is useful with ComfyUI stopped.** The requirement list is static and the status is an overlay on top of it, so every name, folder, size and link is still there when nothing can be checked — which is the state most people are in when they go looking for what to download. The tallies show a dash rather than 0 in that case, because "0 missing" against a server that never answered reads as good news.
+- **A file in the wrong folder is not a download.** `CheckpointLoaderSimple` reads `models/checkpoints/` and `UNETLoader` reads `models/diffusion_models/`; a file in the wrong one of those is invisible to the workflow and looks exactly like a file you never downloaded. Those rows say you already have the file, name the folder it is sitting in, and contribute zero to the remaining download.
+- **Copy Link, Copy Folder Path and Copy Page on each row**, plus notes for the cases that trip people up: licence-gated files that need the licence accepted first, Florence-2's repo-folder layout where the loader opens a directory rather than a file, alternative filenames that also work, and the fact that a newly installed custom node needs a ComfyUI restart rather than a refresh.
+- **Filter chips** narrow the list to one tool — the models Inpaint needs, say — while the tallies and the download total keep describing the whole report.
+- **"What will run well" ranks the presets against your card**, at the bottom of the Setup screen next to the requirements it describes. Each preset is rated Comfortable, Tight, Will offload, or Not known, best first, using the VRAM ComfyUI reports for the primary device. The rating is based on the **largest single file** in a preset's stack rather than the sum, because ComfyUI loads and offloads components at different stages of a run, so the biggest resident chunk predicts speed better than the total does. The screen says plainly that these are weight sizes and not measured VRAM use, and that a stack too big for the card runs slower rather than failing.
+
+### Changed
+
+- **Presets have artist-facing names now.** Every preset gained a display name, so Workflow Health shows "Krea-2 Turbo" and "Flux Fill" with the tool named alongside, instead of the internal ids `txt2img-krea2-turbo` and `inpaint-flux-fill-basic` that had been on those cards for several releases.
+- **The status badge is a squared label in small caps** rather than a rounded pill in sentence case, on both the Setup screen and Workflow Health. It was changed on the shared badge itself so the two screens keep one badge language rather than rendering the same idea two ways.
+- Workflow Health's "Missing workflow JSON" is now "Needs workflow JSON" — it describes the two presets whose workflows have not been authored yet, not a file that went missing from your install.
+
+### Fixed
+
+- **A preset with an unpublished model size was ranked as the most comfortable thing on the list.** Florence-2 is one repo-folder model that publishes no size, so its stack measured zero bytes and sorted to the top. An unknown size is not a small size: it now blocks a "Comfortable" rating, while "Tight" and "Will offload" still stand, because the part that *is* known already reaches that much on its own. A stack whose sizes are all unpublished says "Size not published" instead of "At least 0 MB".
+- **A fully set up machine was told the remaining download was "unknown".** The formatter that renders model sizes treats zero as "nobody published this size", which is right for a model and exactly backwards for a total that hits zero when everything is installed — the best possible outcome, showing only on machines where setup is complete, which is the one state least likely to be caught by hand.
+- Fixed the Setup filter chips rendering as gold rectangles. They are buttons carrying `aria-pressed`, which is correct for them and also opted them into the compact theme's toggle-switch styling, so a chip saying which slice of a list you were looking at was drawn like a switch that was turned on.
+- Fixed the same chips then rendering as tall ovals: a 999px radius is only a pill if you control the height, and theirs came out around 28px. Their height is now stated and the radius is half of it.
+
+### Known limitations
+
+- Setup and Workflow Health overlap on purpose for now. Setup answers "what do I need and where does it go"; Health answers "can I run this preset right now". If that turns out to be one screen too many, Health folds into Setup rather than the reverse.
+- Nothing on the Setup screen downloads anything. It copies links and folder paths for you to use elsewhere; assisted install through ComfyUI-Manager is the next item on the roadmap. The panel cannot open a browser either — `uxp.shell.openExternal` has never been called in this project — which is why every row offers Copy Link rather than a button that opens the page.
+- "What will run well" reads the VRAM ComfyUI reports for its primary device. With ComfyUI stopped, or on a setup it reports oddly, every preset falls back to "Not known" and only the sizes are shown.
+- **Live Painting is experimental.** The live tier needs an SD 1.5 LCM LoRA in `models/loras/`, and Start Live Session reports an error naming it if none is found. The Refine tier additionally needs the three Krea-2 Turbo files; without them the live tier still works and Refine reports what is missing. Auto-import fires when you stop the session, by design.
+- Installation still requires the UXP Developer Tool. Whether a `.ccx` double-click install works on a machine that has never had developer mode enabled is documented as an open question in `docs/DISTRIBUTION_SPIKE.md` and needs a clean second machine to answer.
+- The Layer Tools card on Home does not dim when ComfyUI is unreachable, unlike the generation tools. Saving to a file works with ComfyUI stopped; Send to ComfyUI will fail and report the connection error on the Layer Tools status line.
+- Layer, canvas, selection, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
+- The Preview panel offers each tool's primary import only.
+- The setup pack contains no model weights. They are roughly 85 GB and two are licence-restricted, so it ships the list and the downloader instead — an internet connection is required.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+- CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
+
 ## v0.10.0-alpha - 2026-07-31
 
 The first OpenLayer release whose plugin zip is built to the ZIP specification, which matters more than a packaging note usually would: every release from v0.1.0 to v0.9.0-alpha wrote its entry paths with backslashes, and macOS refuses to unpack those into folders. Everything else here follows from the same question — what happens to somebody setting this up without anyone to ask. Workflow health now tells you which folder your "missing" model is actually sitting in, missing nodes name the package that provides them, and Live Painting stops looking half-finished.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.10.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
+`v0.11.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
 
-New in `v0.10.0-alpha`:
+New in `v0.11.0-alpha`:
+
+- **A Setup screen**, on Home under Preferences. It lists every model file and custom node package the presets need, with the folder each one goes in, its size, what it unlocks, and whether it is installed, missing, or sitting in the wrong folder. It works with ComfyUI stopped — the list is static and the status is an overlay — because that is the state most people are in when they go looking for what to download.
+- **"What will run well"** ranks the presets against the VRAM ComfyUI reports for your card: Comfortable, Tight, Will offload, or Not known. It rates on the largest single file in a preset's stack rather than the total, and says plainly that a stack too big for the card runs slower rather than failing.
+- **Presets are named for artists.** Workflow Health shows "Krea-2 Turbo" and "Flux Fill" instead of the internal ids `txt2img-krea2-turbo` and `inpaint-flux-fill-basic`, and the status badge is now one squared label used on both screens.
+
+Also new in `v0.10.0-alpha`:
 
 - **The plugin zip is built to the ZIP specification for the first time.** Every release from v0.1.0 to v0.9.0-alpha stored entry paths with backslashes, which macOS `unzip` unpacks as a flat directory with no `assets/` folder, so the panel could not render. **If an earlier release gave you a blank panel on macOS, this was why — use this one.**
 - **Check Workflow Health finds models that are in the wrong folder.** When a preset's model is missing from the folder its loader reads, the report searches the other model folders and names where it found it, so "missing" and "downloaded, but one directory over" stop looking identical. It also names the repository that provides a missing custom node.
@@ -99,7 +105,19 @@ The earlier card-based dashboard established OpenLayer's honest available/experi
 
 </details>
 
-v0.10.0-alpha tester focus:
+v0.11.0-alpha tester focus:
+
+- Open **Setup** from Home *before* starting ComfyUI. Confirm every model and node package is still listed with its folder, size and links, that the three tallies show a dash rather than 0, and that nothing claims you are set up.
+- Start ComfyUI, click **Check Again**, and confirm the list splits into what you have and what you are missing, with the installed rows collapsed. The remaining download figure should count each file once even though several presets share it — and should say "Nothing" if you have everything.
+- Move one model into the wrong folder — a checkpoint into `models/diffusion_models/`, say — check again, and confirm its row says you already have the file, names the folder it is in, and does not add its size to the remaining download.
+- Use the filter chips to narrow the list to one tool, and confirm the tallies and the download total keep describing everything rather than only the filtered slice.
+- Read **"What will run well"** at the bottom of Setup. Confirm the VRAM figure matches your card, that the order runs best-first, and that the Florence-2 preset is *not* claimed to be the most comfortable one on the list.
+- Look at the status badges on both Setup and **Check Workflow Health**: they should be the same squared uppercase label on both screens, with no text cut off by an ellipsis. The longest ones are NEEDS WORKFLOW JSON and MISSING COMFYUI NODE.
+- Confirm the filter chips read as flat outlined pills of uniform height — not gold switches, not stretched ovals.
+- Confirm Workflow Health names presets the way an artist would ("Krea-2 Turbo", "Standard checkpoint") rather than by their internal ids.
+- Confirm the panel footer reads `v0.11.0`.
+
+Also worth rechecking from v0.10.0-alpha:
 
 - Unzip the release package and confirm it expands into folders, with an `assets/` directory beside `index.html` — not a flat pile of files with backslashes in their names. **On macOS this is the single most useful thing to report.**
 - Put a model in the wrong folder on purpose — move a checkpoint into `models/diffusion_models/`, say — then run **Check Workflow Health** and confirm the report names the folder it actually found it in and the folder the workflow wants.
@@ -122,8 +140,11 @@ Also worth rechecking from v0.9.0-alpha:
 - Run `npm run setup-pack` and confirm it reports no source/API mismatches at all.
 - Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
-Known v0.10.0-alpha boundaries:
+Known v0.11.0-alpha boundaries:
 
+- The Setup screen reports and copies. It does not download or install anything; assisted install through ComfyUI-Manager is the next roadmap item.
+- "What will run well" rates on published model weight sizes against reported VRAM. It is not a measurement of VRAM use during a run, and a preset with an unpublished model size is reported as unknown rather than guessed at.
+- Setup and Check Workflow Health overlap on purpose. Setup answers what you need and where it goes; Health answers whether a given preset can run right now.
 - Image to Image is an early foundation path, not a full production workflow yet.
 - Sketch to Image is limited to the first SD 1.x LINECN starter workflow.
 - Sketch to Image is currently tested with `epicrealism_naturalSinRC1VAE.safetensors` and `control_v11p_sd15_lineart_fp16.safetensors`.
@@ -283,7 +304,7 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.10.0-alpha.zip
+packages/openlayer-v0.11.0-alpha.zip
 ```
 
 ## Loading In UXP Developer Tool
@@ -410,7 +431,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.10.0-alpha test result:
+Use this quick pass before reporting a v0.11.0-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.
@@ -419,7 +440,7 @@ Use this quick pass before reporting a v0.10.0-alpha test result:
 5. Open two tool screens; confirm the Back to Tools control, icon, title, and progress track have clear spacing and remain visible while scrolling.
 6. Paste a long prompt, confirm it remains editable and scrollable, and confirm the Prompt from Layer generated-text field is substantially taller than other fields.
 7. Open Settings and click `Check ComfyUI`; confirm checkpoints load.
-8. Click `Check Workflow Health`; confirm each registered preset shows Ready, Experimental, Missing model, Missing ComfyUI node, Missing workflow JSON, or Setup required.
+8. Click `Check Workflow Health`; confirm each registered preset shows Ready, Experimental, Missing model, Missing ComfyUI node, Needs workflow JSON, or Setup required, under its artist-facing name.
 9. Confirm Settings shows readable summary counts and collapsed technical details without overlapping cards.
 10. Click `Copy Diagnostics`; confirm the report is copied or appears in the read-only diagnostics box.
 11. Generate one `txt2img-basic` image and import it as a new layer; confirm the determinate progress bar advances cleanly.

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -153,7 +153,11 @@ snapshot `.git/HEAD` and `refs/heads/` before launching; never edit while a Code
 `HEAD`, branch and last commit survived before touching anything afterwards; and require a reported
 diff rather than a commit, a push, or any contact with `.git`.
 
-## 6. Roadmap (state as of 2026-08-01, post-v0.10.0-alpha)
+## 6. Roadmap (state as of 2026-08-01, during the v0.11.0-alpha release)
+
+**v0.11.0-alpha is the release in flight**: the Setup screen (PRs #62, #63), the roadmap-item-3 preset
+ranking (#65) and this doc's own update (#64) are all merged to main and were unreleased for three
+sessions. Nothing a tester can install contains any of it until the tag is pushed.
 
 **v0.10.0-alpha is published** (tag on `31e21d7`, prerelease, plugin zip + setup pack + `checksums.txt`).
 Its headline fix was the release zip: every release from v0.1.0 to v0.9.0-alpha stored entry paths with
@@ -169,7 +173,7 @@ anything depends on Creative Cloud accepting an unsigned non-Marketplace package
 that has never had UDT — nobody on the project has one. It was deliberately left out of v0.10.0 because
 release assets can be added to a published release at any time, so deferring costs nothing.
 
-**Roadmap items 1 and 2 are done** (PRs #58, #62, #63). See the entries below.
+**Roadmap items 1, 2 and 3 are done** (PRs #58, #62, #63, #65). See the entries below.
 
 **v0.8 so far (merged):** version bump to 0.8.0; ESLint in CI (with `TextEncoder`/`TextDecoder`
 banned in `src/`, the one rule that catches a UXP failure neither `tsc` nor Vitest can see); preview
@@ -191,8 +195,10 @@ LoRA browser are explicitly **out of v0.8 scope**.
    - **Static manifest, live status as an overlay.** Status is four-valued — `not-checked` keeps every name, folder, size and link when ComfyUI is unreachable, because someone asking what to download usually has not started it yet. Tallies show a dash, not 0, when nothing was checked: "0 missing" against a dead server reads as good news.
    - **A wrong-folder model contributes zero to the remaining download**, and its row says the file is already there. `evaluateSetupRequirements` (pure) and `setupTabModel.ts` (pure view model) hold all of this; the DOM layer only draws it.
    Presets also gained a required `displayName`, because `label` was the preset id and the health cards had been showing `txt2img-krea2-turbo` to artists for several releases.
-3. **GPU-aware recommendations (Phase 3)** — extend `hardwareAdvisor` to rank runnable workflows by VRAM. **Next up.** The Setup screen is the natural place to surface it, and `SetupModelRequirement` already carries `sizeBytes` and `usedByPresets`.
-4. **Assisted install (Phase 4)** — ComfyUI-Manager API behind explicit user approval. Biggest surface; last.
+3. ~~**GPU-aware recommendations (Phase 3)**~~ — **DONE** (PR #65). `presetFootprint.ts` ranks every runnable preset against the VRAM `hardwareAdvisor` reports for the primary device, and the "What will run well" block sits at the bottom of the Setup screen next to the requirements it describes. Two decisions worth carrying forward:
+   - **Rank on the largest single file, not the sum.** ComfyUI loads and offloads components at different stages, so the biggest resident chunk predicts speed; the sum describes the download instead. Both are computed, and they answer different questions.
+   - **An unpublished size is not a small size.** Florence-2 publishes no size, measured as zero bytes, and sorted to the top as the single most comfortable preset on the list. Missing sizes now block a "Comfortable" claim but not "Tight"/"Will offload", because the known part alone already justifies those. Any new size-derived claim needs the same asymmetry.
+4. **Assisted install (Phase 4)** — ComfyUI-Manager API behind explicit user approval. **Next up.** The Setup screen already computes the inputs: `SetupModelRequirement` carries the target folder, the download URL, the size and the licence-gated flag, and `evaluateSetupRequirements` already knows exactly which files are missing versus merely misplaced. Biggest surface on the list; nothing may download without per-item confirmation.
 5. **Outpaint canvas expansion + aligned import** — currently outpaint imports centered without resizing the canvas. Proper fix = batchPlay canvas resize + coordinate-shift for alignment. **Hardest host work on the list**; touches the same adapter machinery as A2/A3. Needs the strongest available model + careful Mehran verification.
 6. **Live Painting v2 (two-tier: SD1.5-LCM fast tier / Krea2-turbo quality tier)** — design exists in the assistant's memory notes; the current spike (event-candidate listeners, serial pump loop in `livePaintingSession.ts`) works but is primitive. Flagship feature. Architecture first, then incremental delegation.
 7. **Layer tools & new-tool pattern** — new tools go in their own `src/ui/tools/<name>.ts` modules (the forward-looking half of skipped step 5); wire through `generationController` + a new busy-table group + `generationToolUi` row + preset registry entry.

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,10 +33,10 @@
       "operatingSystem": "Windows, macOS",
       "applicationCategory": "DesignApplication",
       "applicationSubCategory": "Adobe Photoshop plugin",
-      "softwareVersion": "0.10.0-alpha",
+      "softwareVersion": "0.11.0-alpha",
       "description": "Open-source Photoshop UXP plugin that connects to a local ComfyUI server for AI image generation: text to image, image to image, sketch to image, inpaint, outpaint, and upscale with Stable Diffusion, SDXL, and Flux models.",
       "url": "https://mehran-ahmadi.com/OpenLayer/",
-      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.10.0-alpha",
+      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.11.0-alpha",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Mehran Ahmadi", "url": "https://github.com/MehranMarxian" }
     }
@@ -65,7 +65,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.10.0 · free &amp; open source</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.11.0 · free &amp; open source</p>
           <h1 id="hero-title">Local AI layers,<br><span class="grad">inside Photoshop.</span></h1>
           <p class="hero-lede">
             OpenLayer connects Photoshop to <strong>your own ComfyUI server</strong>.
@@ -74,7 +74,7 @@
             <strong>No cloud. No credits. No subscription.</strong>
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.10.0-alpha">Download alpha</a>
+            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.11.0-alpha">Download alpha</a>
             <a class="button button-secondary" href="https://github.com/MehranMarxian/OpenLayer">Star on GitHub</a>
           </div>
           <ul class="signal-list" aria-label="Project signals">
@@ -323,11 +323,11 @@ npm run build</code></pre>
             </article>
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.10.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.11.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
-              <p>v0.10.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
+              <p>v0.11.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
             </article>
             <article class="status-card">
               <h3>Flux Fill is experimental</h3>
@@ -350,7 +350,7 @@ npm run build</code></pre>
               <li>Inpaint and Outpaint should be tested on duplicate layers first.</li>
               <li>Prompt from Layer requires the local Florence-2 PromptGen model and the comfyui-florence2 nodes. The custom-scripts pack is no longer needed.</li>
               <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.10.0 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.11.0 keeps the shared metadata foundation and session-history wiring.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
               <li>Progress is shown in the generation status panel rather than pinned to the screen header, so it scrolls with the form.</li>
@@ -396,6 +396,10 @@ npm run build</code></pre>
               <p>Workflow Health finds models sitting in the wrong folder and names the repository behind a missing node — and the plugin zip is finally built to spec, so it unpacks correctly on macOS.</p>
             </article>
             <article>
+              <h3>v0.11 · Know what you need</h3>
+              <p>A Setup screen listing every model and node package with its folder, size and status — usable before ComfyUI is even running — plus a ranking of which presets your card will actually run well.</p>
+            </article>
+            <article>
               <h3>Next · Reliability and artist control</h3>
               <p>Finish Inpaint and Outpaint alignment, strengthen workflow validation, and turn the metadata foundation into repeatable layer-level iteration.</p>
             </article>
@@ -424,7 +428,7 @@ npm run build</code></pre>
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.10.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.11.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a>
       </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlayer",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlayer",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.openlayer.photoshop",
   "name": "OpenLayer",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "index.html",
   "host": [
     {

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -1,7 +1,7 @@
 import { OpenLayerTheme } from "../utils/preferences";
 
 export const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-export const APP_VERSION = "0.10.0";
+export const APP_VERSION = "0.11.0";
 export const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 export const HISTORY_LIMIT = 5;
 export const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];


### PR DESCRIPTION
Ships the fourteen commits that have been sitting on `main` since v0.10.0-alpha — the Setup screen (#62, #63), the "What will run well" preset ranking (#65), and the roadmap update (#64). All of it was smoke-tested in real Photoshop when it merged; none of it is installable by a tester until this ships.

**Two commits, separable:**

1. **The version bump**, first rather than last, in all four locations — `package.json`, both `package-lock.json` entries, `src/manifest.json`, and `APP_VERSION`. The panel footer reads `APP_VERSION`, so the build you smoke-test identifies itself as 0.11.0 rather than as the release before it.
2. **The paperwork** — CHANGELOG, README, `docs/index.html`, and the two stale spots in `docs/ORCHESTRATION.md` §6: item 3 still said "Next up" when #65 finished it, and the "state as of" line described the previous release.

The notes were written from `git log v0.10.0-alpha..main` and the diffs, not from the task list.

## Smoke checklist

Setup screen, the new surface:

1. **Start Photoshop with ComfyUI stopped.** Open **Plugins > OpenLayer**, then **Setup** on Home under Preferences. Every model and node package should still be listed with its folder, size and links; the three tallies should read `-`, not `0`; nothing should claim you are set up.
2. Start ComfyUI on 8190, click **Check Again**. Installed rows collapse into a one-line summary; what is left on screen is what you still need. With your machine fully set up, the download line should say **Nothing** — not "unknown".
3. Move one checkpoint into `models/diffusion_models/`, click **Check Again**. That row should say you already have the file, name the folder it is actually in, and add **zero** to the remaining download. Move it back afterwards.
4. Click a **Copy Link**, a **Copy Folder Path**, and a **Copy Page**, and paste each somewhere to confirm the right value landed and the status line names the model.
5. Tap a filter chip. The list narrows to that tool; the tallies and the download total must keep describing the whole report.
6. **"What will run well"**, at the bottom of Setup: the VRAM label should match your 4070 Ti, the order should run best-first, and **Florence-2 must not be at the top as the most comfortable preset** — that was the bug in d6d2d17.

Regressions the badge and chip work could have caused:

7. Open **Settings > Check Workflow Health**. Badges should be squared uppercase labels identical to Setup's, with **no text cut off by an ellipsis** — the two longest are `NEEDS WORKFLOW JSON` and `MISSING COMFYUI NODE`.
8. Preset names on those cards should read "Krea-2 Turbo", "Flux Fill", "Standard checkpoint" — not `txt2img-krea2-turbo`.
9. The Setup filter chips should be flat outlined pills of uniform height. Not gold (that would be the compact theme's toggle styling leaking back in), not stretched ovals.
10. Confirm the footer reads **v0.11.0**.
11. One `txt2img-basic` generate → import, to confirm the version bump broke nothing on the main path.

## Checks

`npm run typecheck`, `npm test` (491 tests, 57 files), `npm run build`, `npx eslint .` all clean locally.

Tag, zips and the GitHub release follow after merge; the packaged zip will be verified against the artifact GitHub serves, not the local `packages/` copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
