### PR TITLE
Assisted install: the planning layer and Manager client

### DIFF
--- a/src/comfy/assistedInstall.ts
+++ b/src/comfy/assistedInstall.ts
@@ -157,7 +157,13 @@ export function planAssistedInstall(report: SetupRequirementsReport): AssistedIn
     installable,
     excluded,
     totalBytes,
-    formattedTotal: formatBytes(totalBytes)
+    // formatBytes answers "how big is this model?", where zero means the size
+    // was never published, so it returns "unknown". Zero here means the
+    // opposite -- there is nothing for OpenLayer to install -- and routing it
+    // through formatBytes reads as "unknown to install" on exactly the machines
+    // that are fully set up. `evaluateSetupRequirements` hit this same trap on
+    // its remaining-download total; the wording matches it deliberately.
+    formattedTotal: totalBytes > 0 ? formatBytes(totalBytes) : "Nothing"
   };
 }
 
@@ -289,13 +295,14 @@ function hasDownloadUrl(model: SetupModelRequirement): model is AssistedInstallI
   return typeof model.downloadUrl === "string" && model.downloadUrl.length > 0;
 }
 
+// `evaluateSetupRequirements` only ever gives a node package one of three
+// statuses -- a node is present in `/object_info` or it is not, so there is no
+// "wrong folder" for it the way there is for a model file. Handling that case
+// here would mean answering a custom node with the model-worded reason, so the
+// branch is left out rather than written to be unreachable.
 function getNodeExclusionReason(node: SetupNodeRequirement): AssistedInstallExclusionReason {
   if (node.status === "installed") {
     return ALREADY_INSTALLED_REASON;
-  }
-
-  if (node.status === "wrong-folder") {
-    return WRONG_FOLDER_REASON;
   }
 
   if (node.status === "not-checked") {

--- a/src/comfy/assistedInstall.ts
+++ b/src/comfy/assistedInstall.ts
@@ -1,0 +1,310 @@
+import { formatBytes } from "./setupManifest";
+import type {
+  SetupModelRequirement,
+  SetupNodeRequirement,
+  SetupRequirementsReport
+} from "./setupRequirements";
+
+export const OPENLAYER_UI_ID_PREFIX = "openlayer:";
+
+export type AssistedInstallExclusionReasonId =
+  | "already-installed"
+  | "wrong-folder"
+  | "licence-gated"
+  | "no-download-url"
+  | "not-checked"
+  | "custom-node";
+
+export type AssistedInstallExclusionReason = {
+  id: AssistedInstallExclusionReasonId;
+  message: string;
+};
+
+export type AssistedInstallItem = SetupModelRequirement & {
+  downloadUrl: string;
+};
+
+export type AssistedInstallExclusion =
+  | {
+      kind: "model";
+      requirement: SetupModelRequirement;
+      reason: AssistedInstallExclusionReason;
+    }
+  | {
+      kind: "custom-node";
+      requirement: SetupNodeRequirement;
+      reason: AssistedInstallExclusionReason;
+    };
+
+export type AssistedInstallPlan = {
+  installable: AssistedInstallItem[];
+  excluded: AssistedInstallExclusion[];
+  totalBytes: number;
+  formattedTotal: string;
+};
+
+export type ManagerInstallModelRequest = {
+  save_path: string;
+  base: string;
+  filename: string;
+  url: string;
+  ui_id: string;
+};
+
+export type ManagerQueueStatus = {
+  total_count: number;
+  done_count: number;
+  in_progress_count: number;
+  is_processing: boolean;
+};
+
+export type QueuePreconditionVerdict =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: "already-processing" | "foreign-items-queued";
+      message: string;
+    };
+
+export type ManagerQueueStatusPayload = {
+  status: string;
+  target?: string | null;
+  [key: string]: unknown;
+};
+
+export type InstallProgressSummary = {
+  pending: number;
+  inProgress: number;
+  done: number;
+  foreign: number;
+  currentUiId: string | null;
+};
+
+const ALREADY_INSTALLED_REASON: AssistedInstallExclusionReason = {
+  id: "already-installed",
+  message: "This requirement is already installed."
+};
+
+const WRONG_FOLDER_REASON: AssistedInstallExclusionReason = {
+  id: "wrong-folder",
+  message:
+    "This model is already on disk in a different folder. OpenLayer will not download a second copy; move the existing file to the required folder instead."
+};
+
+const LICENCE_GATED_REASON: AssistedInstallExclusionReason = {
+  id: "licence-gated",
+  message:
+    "OpenLayer cannot download this model because its licence must be accepted in an authenticated browser session. An unauthenticated download can save an HTML error page instead of a working model."
+};
+
+const NO_DOWNLOAD_URL_REASON: AssistedInstallExclusionReason = {
+  id: "no-download-url",
+  message: "OpenLayer cannot install this model because no direct download URL is available."
+};
+
+const NOT_CHECKED_REASON: AssistedInstallExclusionReason = {
+  id: "not-checked",
+  message:
+    "OpenLayer has not checked this requirement against ComfyUI, so it will not offer an install that may be unnecessary."
+};
+
+const CUSTOM_NODE_REASON: AssistedInstallExclusionReason = {
+  id: "custom-node",
+  message:
+    "OpenLayer cannot install custom nodes in this version. Use Copy Link and install the package through ComfyUI-Manager."
+};
+
+/**
+ * Produces the subset that OpenLayer can safely offer through Manager without
+ * changing the report's broader "remaining download" figure. These totals are
+ * intentionally allowed to disagree: the setup report includes missing models
+ * that assisted install must refuse.
+ */
+export function planAssistedInstall(report: SetupRequirementsReport): AssistedInstallPlan {
+  const installable: AssistedInstallItem[] = [];
+  const excluded: AssistedInstallExclusion[] = [];
+
+  for (const model of report.models) {
+    const reason = getModelExclusionReason(model);
+
+    if (reason) {
+      excluded.push({ kind: "model", requirement: model, reason });
+    } else if (hasDownloadUrl(model)) {
+      installable.push(model);
+    }
+  }
+
+  // Custom-node installation is deliberately excluded. The git URL route
+  // requires the non-default allow_git_url_install flag, while the queue route
+  // needs registry id/channel/mode fields OpenLayer does not carry. Node rows
+  // therefore retain their existing Copy Link path instead of being guessed at.
+  for (const customNode of report.customNodes) {
+    excluded.push({
+      kind: "custom-node",
+      requirement: customNode,
+      reason: getNodeExclusionReason(customNode)
+    });
+  }
+
+  installable.sort(
+    (left, right) =>
+      (right.sizeBytes ?? 0) - (left.sizeBytes ?? 0) || left.key.localeCompare(right.key)
+  );
+
+  const totalBytes = installable.reduce((total, item) => total + (item.sizeBytes ?? 0), 0);
+
+  return {
+    installable,
+    excluded,
+    totalBytes,
+    formattedTotal: formatBytes(totalBytes)
+  };
+}
+
+export function createInstallModelRequest(item: AssistedInstallItem): ManagerInstallModelRequest {
+  return {
+    save_path: item.targetFolder,
+    base: item.label,
+    filename: item.modelName,
+    url: item.downloadUrl,
+    ui_id: `${OPENLAYER_UI_ID_PREFIX}${item.key}`
+  };
+}
+
+export function evaluateQueuePrecondition(status: ManagerQueueStatus): QueuePreconditionVerdict {
+  if (status.is_processing) {
+    return {
+      allowed: false,
+      reason: "already-processing",
+      message:
+        "OpenLayer will not add installs while ComfyUI-Manager is downloading something. Wait for the current download to finish, then try again."
+    };
+  }
+
+  if (status.total_count > status.done_count) {
+    return {
+      allowed: false,
+      reason: "foreign-items-queued",
+      message:
+        "OpenLayer will not start the ComfyUI-Manager queue because it already contains items that OpenLayer did not put there. Finish those items in ComfyUI-Manager, then try again."
+    };
+  }
+
+  return { allowed: true };
+}
+
+export function summarizeInstallProgress(
+  openLayerUiIds: Iterable<string>,
+  payloads: readonly ManagerQueueStatusPayload[]
+): InstallProgressSummary {
+  const states = new Map<string, "pending" | "in-progress" | "done">();
+  const foreignTargets = new Set<string>();
+  const runningOrder: string[] = [];
+
+  for (const uiId of openLayerUiIds) {
+    states.set(uiId, "pending");
+  }
+
+  for (const payload of payloads) {
+    const target = typeof payload.target === "string" ? payload.target : null;
+
+    if (!target) {
+      continue;
+    }
+
+    if (!states.has(target)) {
+      foreignTargets.add(target);
+      continue;
+    }
+
+    if (payload.status === "pending") {
+      states.set(target, "pending");
+    } else if (payload.status === "in_progress") {
+      states.set(target, "in-progress");
+      runningOrder.push(target);
+    } else if (payload.status === "done") {
+      states.set(target, "done");
+    }
+  }
+
+  let pending = 0;
+  let inProgress = 0;
+  let done = 0;
+
+  for (const state of states.values()) {
+    if (state === "pending") {
+      pending += 1;
+    } else if (state === "in-progress") {
+      inProgress += 1;
+    } else {
+      done += 1;
+    }
+  }
+
+  const currentUiId = [...runningOrder]
+    .reverse()
+    .find((uiId) => states.get(uiId) === "in-progress") ?? null;
+
+  return {
+    pending,
+    inProgress,
+    done,
+    foreign: foreignTargets.size,
+    currentUiId
+  };
+}
+
+function getModelExclusionReason(
+  model: SetupModelRequirement
+): AssistedInstallExclusionReason | null {
+  if (model.status === "installed") {
+    return ALREADY_INSTALLED_REASON;
+  }
+
+  // A wrong-folder file is already on disk. Downloading it again would create
+  // a duplicate; the required operation is a move, which OpenLayer cannot do.
+  if (model.status === "wrong-folder") {
+    return WRONG_FOLDER_REASON;
+  }
+
+  // This check must precede every remaining model exclusion. A gated URL can
+  // quietly save an authentication HTML page under the model filename, making
+  // it indistinguishable from a corrupt model until ComfyUI tries to load it.
+  if (model.licenseGated) {
+    return LICENCE_GATED_REASON;
+  }
+
+  if (!model.downloadUrl) {
+    return NO_DOWNLOAD_URL_REASON;
+  }
+
+  if (model.status === "not-checked") {
+    return NOT_CHECKED_REASON;
+  }
+
+  return null;
+}
+
+function hasDownloadUrl(model: SetupModelRequirement): model is AssistedInstallItem {
+  return typeof model.downloadUrl === "string" && model.downloadUrl.length > 0;
+}
+
+function getNodeExclusionReason(node: SetupNodeRequirement): AssistedInstallExclusionReason {
+  if (node.status === "installed") {
+    return ALREADY_INSTALLED_REASON;
+  }
+
+  if (node.status === "wrong-folder") {
+    return WRONG_FOLDER_REASON;
+  }
+
+  if (node.status === "not-checked") {
+    return NOT_CHECKED_REASON;
+  }
+
+  return CUSTOM_NODE_REASON;
+}
+
+// There is intentionally no queue reset or server reboot operation in this
+// layer. Reset could discard another client's queue, and reboot would restart
+// the user's server without their control; their absence is a safety property.

--- a/src/comfy/managerClient.ts
+++ b/src/comfy/managerClient.ts
@@ -1,0 +1,208 @@
+import type { ManagerInstallModelRequest, ManagerQueueStatus } from "./assistedInstall";
+import {
+  createOpenLayerError,
+  getNestedErrorMessage,
+  OpenLayerError
+} from "../utils/errors";
+
+export const MANAGER_SECURITY_LEVEL_ERROR_NAME = "ManagerSecurityLevelError";
+
+const MANAGER_SECURITY_LEVEL_MESSAGE =
+  "ComfyUI-Manager blocked this model install because of its security_level setting. In ComfyUI-Manager's config.ini, set security_level to normal (or normal- for non-safetensors models), restart ComfyUI, and try again.";
+
+export class ManagerClient {
+  private readonly serverUrl: string;
+
+  constructor(serverUrl: string) {
+    this.serverUrl = normalizeServerUrl(serverUrl);
+  }
+
+  async getManagerVersion(): Promise<string | null> {
+    const response = await fetchManager(
+      `${this.serverUrl}/manager/version`,
+      undefined,
+      this.serverUrl,
+      "check the ComfyUI-Manager version"
+    );
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    await assertOk(response, "ComfyUI-Manager version check");
+
+    try {
+      return (await response.text()).trim();
+    } catch (caughtError) {
+      throw createOpenLayerError(
+        "COMFY_HTTP",
+        "ComfyUI-Manager returned an unreadable version response.",
+        getNestedErrorMessage(caughtError)
+      );
+    }
+  }
+
+  async getQueueStatus(): Promise<ManagerQueueStatus> {
+    const response = await fetchManager(
+      `${this.serverUrl}/manager/queue/status`,
+      undefined,
+      this.serverUrl,
+      "read the ComfyUI-Manager queue"
+    );
+    await assertOk(response, "ComfyUI-Manager queue status request");
+
+    let data: unknown;
+
+    try {
+      data = await response.json();
+    } catch (caughtError) {
+      throw createOpenLayerError(
+        "COMFY_HTTP",
+        "ComfyUI-Manager returned an invalid queue status.",
+        getNestedErrorMessage(caughtError)
+      );
+    }
+
+    return readManagerQueueStatus(data);
+  }
+
+  async enqueueModelInstall(request: ManagerInstallModelRequest): Promise<void> {
+    const response = await fetchManager(
+      `${this.serverUrl}/manager/queue/install_model`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(request)
+      },
+      this.serverUrl,
+      "queue a model install"
+    );
+
+    if (response.status === 403) {
+      const technicalDetails = await readResponseText(response);
+      const error = createOpenLayerError(
+        "COMFY_HTTP",
+        MANAGER_SECURITY_LEVEL_MESSAGE,
+        technicalDetails
+      );
+      error.name = MANAGER_SECURITY_LEVEL_ERROR_NAME;
+      throw error;
+    }
+
+    await assertOk(response, "ComfyUI-Manager model install request");
+  }
+
+  async startQueue(): Promise<void> {
+    const response = await fetchManager(
+      `${this.serverUrl}/manager/queue/start`,
+      { method: "POST" },
+      this.serverUrl,
+      "start the ComfyUI-Manager queue"
+    );
+    await assertOk(response, "ComfyUI-Manager queue start request");
+  }
+}
+
+export function isManagerSecurityLevelError(error: unknown): error is OpenLayerError {
+  return error instanceof OpenLayerError && error.name === MANAGER_SECURITY_LEVEL_ERROR_NAME;
+}
+
+function normalizeServerUrl(serverUrl: string) {
+  const trimmed = serverUrl.trim();
+
+  if (!trimmed) {
+    throw new Error("ComfyUI server URL is empty.");
+  }
+
+  return trimmed.replace(/\/+$/, "");
+}
+
+async function fetchManager(
+  url: string,
+  init: RequestInit | undefined,
+  serverUrl: string,
+  action: string
+): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (caughtError) {
+    throw createOpenLayerError(
+      "COMFY_OFFLINE",
+      `Could not ${action} because ComfyUI is offline or unreachable at ${serverUrl}.`,
+      getNestedErrorMessage(caughtError)
+    );
+  }
+}
+
+async function assertOk(response: Response, action: string): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+
+  throw createOpenLayerError(
+    "COMFY_HTTP",
+    `${action} failed with HTTP ${response.status}.`,
+    await readResponseText(response)
+  );
+}
+
+function readManagerQueueStatus(data: unknown): ManagerQueueStatus {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw invalidQueueStatusError(data);
+  }
+
+  const record = data as Record<string, unknown>;
+  const totalCount = readCount(record.total_count);
+  const doneCount = readCount(record.done_count);
+  const inProgressCount = readCount(record.in_progress_count);
+
+  if (
+    totalCount === null ||
+    doneCount === null ||
+    inProgressCount === null ||
+    typeof record.is_processing !== "boolean"
+  ) {
+    throw invalidQueueStatusError(data);
+  }
+
+  return {
+    total_count: totalCount,
+    done_count: doneCount,
+    in_progress_count: inProgressCount,
+    is_processing: record.is_processing
+  };
+}
+
+function readCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function invalidQueueStatusError(data: unknown) {
+  return createOpenLayerError(
+    "COMFY_HTTP",
+    "ComfyUI-Manager returned an invalid queue status.",
+    stringifyForDetails(data)
+  );
+}
+
+function stringifyForDetails(value: unknown) {
+  try {
+    return JSON.stringify(value) ?? "No queue status details were returned.";
+  } catch {
+    return "The queue status could not be serialized.";
+  }
+}
+
+async function readResponseText(response: Response) {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}
+
+// This client intentionally exposes no reset, reboot, or custom-node install.
+// Reset and reboot can disrupt server-global work owned by another client, and
+// OpenLayer does not carry the registry metadata needed for safe node installs.

--- a/tests/comfy/assistedInstall.test.ts
+++ b/tests/comfy/assistedInstall.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+import {
+  createInstallModelRequest,
+  evaluateQueuePrecondition,
+  OPENLAYER_UI_ID_PREFIX,
+  planAssistedInstall,
+  summarizeInstallProgress
+} from "../../src/comfy/assistedInstall";
+import { listRequiredModelsForPresets } from "../../src/comfy/modelFolders";
+import { listRunnableWorkflowPresets } from "../../src/comfy/presetRegistry";
+import {
+  evaluateSetupRequirements,
+  SetupRequirementsReport
+} from "../../src/comfy/setupRequirements";
+import type {
+  ComfyModelInventory,
+  WorkflowPresetDefinition,
+  WorkflowRequiredModel
+} from "../../src/comfy/types";
+
+const PLUGIN_VERSION = "9.9.9";
+const FIXED_TIMESTAMP = "2026-08-01T00:00:00.000Z";
+
+describe("assisted install planning", () => {
+  it("excludes a missing licence-gated model with the licence reason", () => {
+    const report = evaluateMissingRequirements([getRunnablePreset("txt2img-flux1-dev-fp8")]);
+    const plan = planAssistedInstall(report);
+    const gatedModel = report.models.find((model) => model.licenseGated);
+
+    expect(gatedModel?.status).toBe("missing");
+    expect(
+      plan.excluded.find(
+        (entry) => entry.kind === "model" && entry.requirement.key === gatedModel?.key
+      )?.reason
+    ).toMatchObject({ id: "licence-gated" });
+    expect(plan.installable.map((item) => item.key)).not.toContain(gatedModel?.key);
+  });
+
+  it("excludes a wrong-folder model from both the items and installable total", () => {
+    const presets = [getRunnablePreset("txt2img-krea2-turbo")];
+    const inventory = createCompleteInventory(presets);
+    const modelName = "krea2_turbo_fp8_scaled.safetensors";
+    inventory.diffusionModels = inventory.diffusionModels.filter((name) => name !== modelName);
+    inventory.checkpoints.push(modelName);
+
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      inventory,
+      generatedAt: FIXED_TIMESTAMP
+    });
+    const plan = planAssistedInstall(report);
+    const misplaced = report.models.find((model) => model.modelName === modelName);
+
+    expect(misplaced?.status).toBe("wrong-folder");
+    expect(plan.installable).toHaveLength(0);
+    expect(plan.totalBytes).toBe(0);
+    expect(
+      plan.excluded.find(
+        (entry) => entry.kind === "model" && entry.requirement.key === misplaced?.key
+      )?.reason.id
+    ).toBe("wrong-folder");
+  });
+
+  it("offers nothing from a report that has not been checked", () => {
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      generatedAt: FIXED_TIMESTAMP
+    });
+    const plan = planAssistedInstall(report);
+
+    expect(report.models.every((model) => model.status === "not-checked")).toBe(true);
+    expect(plan.installable).toHaveLength(0);
+    expect(plan.totalBytes).toBe(0);
+  });
+
+  it("never offers custom nodes as installable", () => {
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets: [getRunnablePreset("prompt-from-layer-florence2")],
+      inventory: createEmptyInventory(),
+      nodeAvailability: {},
+      generatedAt: FIXED_TIMESTAMP
+    });
+    const plan = planAssistedInstall(report);
+    const nodeExclusions = plan.excluded.filter((entry) => entry.kind === "custom-node");
+
+    expect(report.customNodes).not.toHaveLength(0);
+    expect(nodeExclusions).toHaveLength(report.customNodes.length);
+    expect(nodeExclusions.every((entry) => entry.reason.id === "custom-node")).toBe(true);
+  });
+
+  it("sorts installable models largest-first and totals only that subset", () => {
+    const report = evaluateMissingRequirements([getRunnablePreset("txt2img-krea2-turbo")]);
+    const plan = planAssistedInstall(report);
+    const sizes = plan.installable.map((item) => item.sizeBytes ?? 0);
+
+    expect(sizes).toEqual([...sizes].sort((left, right) => right - left));
+    expect(plan.totalBytes).toBe(sizes.reduce((total, size) => total + size, 0));
+    expect(plan.formattedTotal).toMatch(/(GB|MB)$/);
+  });
+
+  it("creates the exact Manager body with an attributable OpenLayer ui_id", () => {
+    const report = evaluateMissingRequirements([getRunnablePreset("txt2img-krea2-turbo")]);
+    const item = planAssistedInstall(report).installable[0];
+    const request = createInstallModelRequest(item);
+
+    expect(OPENLAYER_UI_ID_PREFIX).toBe("openlayer:");
+    expect(request).toEqual({
+      save_path: item.targetFolder,
+      base: item.label,
+      filename: item.modelName,
+      url: item.downloadUrl,
+      ui_id: `${OPENLAYER_UI_ID_PREFIX}${item.key}`
+    });
+  });
+});
+
+describe("assisted install queue ownership", () => {
+  it("refuses while Manager is processing", () => {
+    const verdict = evaluateQueuePrecondition({
+      total_count: 1,
+      done_count: 0,
+      in_progress_count: 1,
+      is_processing: true
+    });
+
+    expect(verdict).toMatchObject({ allowed: false, reason: "already-processing" });
+    expect(verdict.allowed ? "" : verdict.message).toContain("will not add installs");
+  });
+
+  it("refuses queued work that OpenLayer does not own", () => {
+    const verdict = evaluateQueuePrecondition({
+      total_count: 2,
+      done_count: 1,
+      in_progress_count: 0,
+      is_processing: false
+    });
+
+    expect(verdict).toMatchObject({ allowed: false, reason: "foreign-items-queued" });
+    expect(verdict.allowed ? "" : verdict.message).toContain("OpenLayer did not put there");
+  });
+
+  it("allows an idle queue with no unfinished items", () => {
+    expect(
+      evaluateQueuePrecondition({
+        total_count: 3,
+        done_count: 3,
+        in_progress_count: 0,
+        is_processing: false
+      })
+    ).toEqual({ allowed: true });
+  });
+
+  it("keeps foreign targets separate from OpenLayer progress", () => {
+    const first = `${OPENLAYER_UI_ID_PREFIX}checkpoints/first.safetensors`;
+    const second = `${OPENLAYER_UI_ID_PREFIX}vae/second.safetensors`;
+    const summary = summarizeInstallProgress(
+      new Set([first, second]),
+      [
+        { status: "in_progress", target: first },
+        { status: "in_progress", target: "manager-browser-item" },
+        { status: "done", target: "manager-browser-item" },
+        { status: "done", target: first },
+        { status: "in_progress", target: second }
+      ]
+    );
+
+    expect(summary).toEqual({
+      pending: 0,
+      inProgress: 1,
+      done: 1,
+      foreign: 1,
+      currentUiId: second
+    });
+  });
+});
+
+function evaluateMissingRequirements(
+  presets: readonly WorkflowPresetDefinition[]
+): SetupRequirementsReport {
+  return evaluateSetupRequirements({
+    pluginVersion: PLUGIN_VERSION,
+    presets,
+    inventory: createEmptyInventory(),
+    nodeAvailability: {},
+    generatedAt: FIXED_TIMESTAMP
+  });
+}
+
+function getRunnablePreset(id: string): WorkflowPresetDefinition {
+  const preset = listRunnableWorkflowPresets().find((candidate) => candidate.id === id);
+
+  if (!preset) {
+    throw new Error(`Expected runnable preset ${id}.`);
+  }
+
+  return preset;
+}
+
+function createEmptyInventory(): ComfyModelInventory {
+  return {
+    checkpoints: [],
+    diffusionModels: [],
+    clipModels: [],
+    vaeModels: [],
+    controlNetModels: [],
+    visionLanguageModels: [],
+    upscaleModels: [],
+    missingSources: []
+  };
+}
+
+function createCompleteInventory(
+  presets: readonly WorkflowPresetDefinition[]
+): ComfyModelInventory {
+  const inventory = createEmptyInventory();
+
+  for (const model of listRequiredModelsForPresets(presets)) {
+    getInventoryBucket(inventory, model).push(model.modelName);
+  }
+
+  return inventory;
+}
+
+function getInventoryBucket(
+  inventory: ComfyModelInventory,
+  model: WorkflowRequiredModel
+): string[] {
+  switch (model.kind) {
+    case "checkpoint":
+      return inventory.checkpoints;
+    case "diffusion-model-stack":
+      return inventory.diffusionModels;
+    case "clip":
+      return inventory.clipModels;
+    case "vae":
+      return inventory.vaeModels;
+    case "controlnet":
+      return inventory.controlNetModels;
+    case "vision-language":
+      return inventory.visionLanguageModels;
+    case "upscale":
+      return inventory.upscaleModels;
+  }
+}

--- a/tests/comfy/assistedInstall.test.ts
+++ b/tests/comfy/assistedInstall.test.ts
@@ -74,6 +74,25 @@ describe("assisted install planning", () => {
     expect(plan.totalBytes).toBe(0);
   });
 
+  it("says nothing is left to install rather than 'unknown' on a set up machine", () => {
+    const presets = [getRunnablePreset("txt2img-krea2-turbo")];
+    const report = evaluateSetupRequirements({
+      pluginVersion: PLUGIN_VERSION,
+      presets,
+      inventory: createCompleteInventory(presets),
+      generatedAt: FIXED_TIMESTAMP
+    });
+    const plan = planAssistedInstall(report);
+
+    expect(plan.installable).toHaveLength(0);
+    expect(plan.totalBytes).toBe(0);
+    // formatBytes returns "unknown" for zero, which is right for an unpublished
+    // model size and exactly backwards for a total that reaches zero because
+    // everything is already installed.
+    expect(plan.formattedTotal).toBe("Nothing");
+    expect(plan.formattedTotal).not.toBe("unknown");
+  });
+
   it("never offers custom nodes as installable", () => {
     const report = evaluateSetupRequirements({
       pluginVersion: PLUGIN_VERSION,

--- a/tests/comfy/managerClient.test.ts
+++ b/tests/comfy/managerClient.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ManagerInstallModelRequest } from "../../src/comfy/assistedInstall";
+import {
+  isManagerSecurityLevelError,
+  ManagerClient,
+  MANAGER_SECURITY_LEVEL_ERROR_NAME
+} from "../../src/comfy/managerClient";
+
+describe("ManagerClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("treats a missing Manager version route as a normal unavailable state", async () => {
+    const fetchMock = vi.fn(async () => new Response("Not Found", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ManagerClient("  http://127.0.0.1:8190///  ");
+
+    await expect(client.getManagerVersion()).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8190/manager/version",
+      undefined
+    );
+  });
+
+  it("reads the bare Manager version string", async () => {
+    vi.stubGlobal("fetch", async () => new Response("V3.41\n", { status: 200 }));
+
+    await expect(
+      new ManagerClient("http://127.0.0.1:8190").getManagerVersion()
+    ).resolves.toBe("V3.41");
+  });
+
+  it("validates and returns Manager queue status", async () => {
+    const status = {
+      total_count: 4,
+      done_count: 2,
+      in_progress_count: 1,
+      is_processing: true
+    };
+    vi.stubGlobal(
+      "fetch",
+      async () =>
+        new Response(JSON.stringify(status), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        })
+    );
+
+    await expect(
+      new ManagerClient("http://127.0.0.1:8190").getQueueStatus()
+    ).resolves.toEqual(status);
+  });
+
+  it("rejects a malformed Manager queue status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      async () =>
+        new Response(JSON.stringify({ total_count: "4", is_processing: false }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        })
+    );
+
+    await expect(
+      new ManagerClient("http://127.0.0.1:8190").getQueueStatus()
+    ).rejects.toMatchObject({
+      code: "COMFY_HTTP",
+      message: "ComfyUI-Manager returned an invalid queue status."
+    });
+  });
+
+  it("posts the exact model request body", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const request: ManagerInstallModelRequest = {
+      save_path: "diffusion_models",
+      base: "Krea-2 Turbo diffusion model",
+      filename: "krea2_turbo_fp8_scaled.safetensors",
+      url: "https://example.test/krea2_turbo_fp8_scaled.safetensors",
+      ui_id: "openlayer:diffusion_models/krea2_turbo_fp8_scaled.safetensors"
+    };
+
+    await new ManagerClient("http://127.0.0.1:8190").enqueueModelInstall(request);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8190/manager/queue/install_model",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request)
+      }
+    );
+  });
+
+  it("maps a 403 to the identifiable security-level error without retrying", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response("A security error has occurred", { status: 403 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const request: ManagerInstallModelRequest = {
+      save_path: "checkpoints",
+      base: "Flux checkpoint",
+      filename: "flux.safetensors",
+      url: "https://example.test/flux.safetensors",
+      ui_id: "openlayer:checkpoints/flux.safetensors"
+    };
+
+    let caughtError: unknown;
+
+    try {
+      await new ManagerClient("http://127.0.0.1:8190").enqueueModelInstall(request);
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(isManagerSecurityLevelError(caughtError)).toBe(true);
+    expect(caughtError).toMatchObject({
+      name: MANAGER_SECURITY_LEVEL_ERROR_NAME,
+      code: "COMFY_HTTP",
+      technicalDetails: "A security error has occurred"
+    });
+    expect((caughtError as Error).message).toContain("security_level");
+    expect((caughtError as Error).message).toContain("config.ini");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the Manager queue with a bodyless POST", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await new ManagerClient("http://127.0.0.1:8190").startQueue();
+
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:8190/manager/queue/start", {
+      method: "POST"
+    });
+  });
+});


### PR DESCRIPTION
Roadmap item 4, first half. **No UI, and nothing in this PR can download anything** — it decides what OpenLayer would be *willing* to install, and exposes four Manager calls. The Setup screen wiring and the per-item confirmation come next, separately.

Two commits, deliberately separable per ORCHESTRATION §5a:

1. **`76cd207` — Codex's implementation**, verbatim against a written brief.
2. **`784a321` — my review fixes** on top.

## What it does

`planAssistedInstall` partitions the existing setup report into an installable set plus exclusions that each carry a user-facing reason. The exclusions are the substance:

- **Licence-gated models are refused.** A gated URL fetched without an authenticated session doesn't fail loudly — it saves an HTML error page under `flux1-dev.safetensors`, which then looks exactly like a corrupt model. This is the most important line in the module.
- **Wrong-folder models are refused.** The file is already on disk; the fix is a move, which we can't do.
- **A not-checked report yields nothing.** Never offer to install against a report we haven't verified.
- **All custom nodes are refused in this version** — a finding, not a shortcut. See below.

`createInstallModelRequest` builds the exact Manager body. `evaluateQueuePrecondition` refuses to start the queue when it already holds work. `summarizeInstallProgress` attributes `cm-queue-status` messages by `ui_id` and counts foreign items separately.

## API facts, verified rather than assumed

ComfyUI-Manager V3.41 was probed read-only on `127.0.0.1:8190` and its routes read from upstream `glob/manager_server.py`:

| route | method | body |
|---|---|---|
| `/manager/version` | GET | — |
| `/manager/queue/status` | GET | — |
| `/manager/queue/install_model` | POST | `save_path, base, filename, url, ui_id` |
| `/manager/queue/start` | POST | — |

`install_model` accepts an arbitrary `url` + `save_path`, so it is not limited to the Manager's own catalog — that is what makes this feasible without new registry data.

**Why no custom nodes:** `/customnode/install/git_url` requires the non-default `allow_git_url_install` flag *and* loopback binding; `/manager/queue/install` needs registry `id`/`channel`/`mode` that our registry does not carry. Node rows keep Copy Link.

**Why no reset and no reboot, at any layer:** the Manager queue is server-global. `/manager/queue/reset` would discard a queue that may belong to a ComfyUI browser tab, and `/manager/reboot` restarts the user's server under them. Their absence is a safety property and is commented as such.

**Expect a 403 in the wild.** `install_model` requires Manager's `security_level` at `middle` or below; `normal` is the default, so most users are fine. The client maps 403 to a distinct identifiable error naming the setting — information for the user, never a retry.

## Review findings (commit 2)

- **`formatBytes(0)` returns `"unknown"`**, so an empty plan reported its size as "unknown" — the best possible outcome, showing only on fully set up machines. This is the same trap `evaluateSetupRequirements` fell into during v0.11.0, recurring in a new module because the brief said "reuse `formatBytes`" and didn't mention it. Now matches the existing `"Nothing"` wording. **The new test was confirmed to fail before the fix** (`expected 'unknown' to be 'Nothing'`).
- Dropped an unreachable `wrong-folder` branch from the custom-node path, which could only ever have answered a node with a model-worded reason.

## Checks

`npm run typecheck`, `npm test` (**509 passed, 59 files**, up from 491/57), `npm run build`, `npx eslint .` — all clean.

## Smoke checklist

Honestly: **there is nothing to click.** This PR adds no UI and changes no existing screen, so the Photoshop-side check is a regression check, not a feature check.

1. Load the panel and confirm it still opens, Home renders, and the footer reads `v0.11.0`.
2. Open **Setup**, click **Check Again**, and confirm the screen behaves exactly as it did in v0.11.0 — same rows, same tallies, same download line. Nothing here should have changed it.
3. Run one `txt2img-basic` generate → import to confirm the main path is untouched.

If you'd rather not spend a Photoshop pass on a PR with no user-visible surface, merging on CI plus the review above is defensible — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
