### PR TITLE
Flux.2 dev (GGUF) Text to Image preset

### DIFF
--- a/src/comfy/hardwareAdvisor.ts
+++ b/src/comfy/hardwareAdvisor.ts
@@ -40,6 +40,7 @@ const FAMILY_LABELS: Record<ModelFamily, string> = {
   sdxl: "SDXL",
   sd3: "SD3 / SD3.5",
   flux: "Flux",
+  flux2: "Flux.2",
   zImage: "Z_image_Turbo",
   unknown: "Unknown"
 };

--- a/src/comfy/modelCompatibility.ts
+++ b/src/comfy/modelCompatibility.ts
@@ -14,6 +14,7 @@ const FAMILY_LABELS: Record<ModelFamily, string> = {
   sdxl: "SDXL",
   sd3: "SD3",
   flux: "Flux",
+  flux2: "Flux.2",
   zImage: "Z_image_Turbo",
   unknown: "Unknown"
 };
@@ -27,6 +28,20 @@ export function detectCheckpointFamily(checkpointName: string): ModelFamily {
     normalized.includes("zimage")
   ) {
     return "zImage";
+  }
+
+  // Must precede the plain "flux" test, which would otherwise swallow every
+  // Flux.2 filename by substring. The two are not interchangeable: Flux.1 runs
+  // through a plain KSampler, while Flux.2 needs the advanced sampler chain and
+  // a 128-channel latent, so calling a Flux.2 file "Flux" would tell an artist
+  // a preset is compatible when the graph cannot run it at all.
+  if (
+    normalized.includes("flux2") ||
+    normalized.includes("flux-2") ||
+    normalized.includes("flux_2") ||
+    normalized.includes("flux.2")
+  ) {
+    return "flux2";
   }
 
   if (normalized.includes("flux")) {

--- a/src/comfy/modelFolders.ts
+++ b/src/comfy/modelFolders.ts
@@ -32,7 +32,16 @@ export const MODEL_FOLDER_BY_OBJECT_INFO_NODE = {
   VAELoader: "vae",
   ControlNetLoader: "controlnet",
   UpscaleModelLoader: "upscale_models",
-  Florence2ModelLoader: "LLM"
+  Florence2ModelLoader: "LLM",
+  // ComfyUI-GGUF's loaders read the same two folders as the core loaders they
+  // stand in for -- the pack registers itself against ComfyUI's existing folder
+  // names rather than inventing its own. They are listed here because this map
+  // is what OpenLayer's own setup and health screens read; ComfyUI finding the
+  // file is a separate question, and getModelTargetFolder throws for any loader
+  // that is missing from this table.
+  UnetLoaderGGUF: "diffusion_models",
+  CLIPLoaderGGUF: "text_encoders",
+  DualCLIPLoaderGGUF: "text_encoders"
 } as const satisfies Record<string, WorkflowModelFolder>;
 
 export type ComfyModelInventoryBucket = Exclude<keyof ComfyModelInventory, "missingSources">;

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -34,7 +34,16 @@ const FLUX1_DEV_LICENSE: WorkflowModelLicenseGate = {
     "Black Forest Labs restricts these weights to non-commercial use. Read the licence before downloading them or publishing work made with them."
 };
 
+const FLUX2_DEV_LICENSE: WorkflowModelLicenseGate = {
+  name: "FLUX.2 [dev] Non-Commercial License",
+  url: "https://huggingface.co/black-forest-labs/FLUX.2-dev/blob/main/LICENSE.md",
+  summary:
+    "Black Forest Labs restricts these weights to non-commercial use. Read the licence before downloading them or publishing work made with them."
+};
+
 const COMFY_ORG_FLUX1_DEV_REPO = "https://huggingface.co/Comfy-Org/flux1-dev";
+const COMFY_ORG_FLUX2_DEV_REPO = "https://huggingface.co/Comfy-Org/flux2-dev";
+const CITY96_FLUX2_DEV_GGUF_REPO = "https://huggingface.co/city96/FLUX.2-dev-gguf";
 const COMFY_ORG_Z_IMAGE_TURBO_REPO = "https://huggingface.co/Comfy-Org/z_image_turbo";
 const COMFY_ORG_KREA2_REPO = "https://huggingface.co/Comfy-Org/Krea-2";
 const FLUX_TEXT_ENCODERS_REPO = "https://huggingface.co/comfyanonymous/flux_text_encoders";
@@ -139,6 +148,57 @@ const KREA2_TURBO_STACK = [
     downloadUrl: `${COMFY_ORG_KREA2_REPO}/resolve/main/vae/qwen_image_vae.safetensors`,
     sourcePageUrl: COMFY_ORG_KREA2_REPO,
     downloadSizeBytes: 253806246
+  }
+] as const;
+
+const FLUX2_DEV_GGUF_STACK = [
+  {
+    // A Q4_K_M quantisation, so the loader is ComfyUI-GGUF's rather than the
+    // core UNETLoader -- core does not enumerate .gguf at all, which makes an
+    // unquantised-looking setup report the file as simply absent.
+    kind: "diffusion-model-stack",
+    objectInfoNode: "UnetLoaderGGUF",
+    inputName: "unet_name",
+    label: "Flux.2 dev diffusion model (GGUF)",
+    modelName: "flux2-dev-Q4_K_M.gguf",
+    setupHint:
+      "Install flux2-dev-Q4_K_M.gguf in ComfyUI models/diffusion_models. It needs the ComfyUI-GGUF custom nodes, which also require the gguf Python package.",
+    downloadUrl: `${CITY96_FLUX2_DEV_GGUF_REPO}/resolve/main/flux2-dev-Q4_K_M.gguf`,
+    sourcePageUrl: CITY96_FLUX2_DEV_GGUF_REPO,
+    downloadSizeBytes: 20082414560,
+    licenseGate: FLUX2_DEV_LICENSE
+  },
+  {
+    // Flux.2 dev uses a Mistral-3 encoder, NOT the Qwen encoders the Klein
+    // variant reuses and not Flux.1's T5/CLIP pair. Pointing this at a Qwen
+    // file loads and then fails, so the name is pinned.
+    kind: "clip",
+    objectInfoNode: "CLIPLoader",
+    inputName: "clip_name",
+    label: "Flux.2 text encoder (Mistral-3)",
+    modelName: "mistral_3_small_flux2_fp8.safetensors",
+    setupHint:
+      "Install mistral_3_small_flux2_fp8.safetensors in ComfyUI models/text_encoders. Flux.2 dev will not run on the Qwen encoders used by Z_image_Turbo or Krea-2.",
+    downloadUrl: `${COMFY_ORG_FLUX2_DEV_REPO}/resolve/main/split_files/text_encoders/mistral_3_small_flux2_fp8.safetensors`,
+    sourcePageUrl: COMFY_ORG_FLUX2_DEV_REPO,
+    downloadSizeBytes: 18034640095,
+    licenseGate: FLUX2_DEV_LICENSE
+  },
+  {
+    // Not interchangeable with Flux.1's ae.safetensors: Flux.2 latents are 128
+    // channels at a 16x downscale against Flux.1's 16 channels at 8x. The
+    // generic filename hides which family it belongs to.
+    kind: "vae",
+    objectInfoNode: "VAELoader",
+    inputName: "vae_name",
+    label: "Flux.2 VAE",
+    modelName: "full_encoder_small_decoder.safetensors",
+    setupHint:
+      "Install full_encoder_small_decoder.safetensors in ComfyUI models/vae. Flux.1's ae.safetensors will not decode Flux.2 latents.",
+    downloadUrl:
+      "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder/resolve/main/full_encoder_small_decoder.safetensors",
+    sourcePageUrl: "https://huggingface.co/black-forest-labs/FLUX.2-small-decoder",
+    downloadSizeBytes: 249519092
   }
 ] as const;
 
@@ -267,6 +327,22 @@ const OUTPAINT_FLUX_FILL_BASIC_NODES = {
   negativeConditioning: "46",
   outpaintConditioning: "38",
   sampler: "3",
+  decode: "8",
+  saveImage: "9"
+} as const;
+
+const FLUX2_DEV_GGUF_TXT2IMG_NODES = {
+  diffusionModelLoader: "12",
+  clipLoader: "38",
+  vaeLoader: "10",
+  positivePrompt: "6",
+  fluxGuidance: "26",
+  guider: "22",
+  noise: "25",
+  samplerSelect: "16",
+  scheduler: "48",
+  latentImage: "47",
+  sampler: "13",
   decode: "8",
   saveImage: "9"
 } as const;
@@ -423,6 +499,29 @@ const OUTPAINT_FLUX_FILL_BASIC_INJECTIONS = {
   outpaintRight: target(OUTPAINT_FLUX_FILL_BASIC_NODES.imagePad, "right"),
   outpaintBottom: target(OUTPAINT_FLUX_FILL_BASIC_NODES.imagePad, "bottom"),
   outpaintFeathering: target(OUTPAINT_FLUX_FILL_BASIC_NODES.imagePad, "feathering")
+} as const;
+
+const FLUX2_DEV_GGUF_TXT2IMG_INJECTIONS = {
+  checkpoint: target(FLUX2_DEV_GGUF_TXT2IMG_NODES.diffusionModelLoader, "unet_name"),
+  positivePrompt: target(FLUX2_DEV_GGUF_TXT2IMG_NODES.positivePrompt, "text"),
+  // Width and height go to TWO nodes. The latent node allocates the tensor and
+  // the scheduler derives its shift from the same dimensions, so a size set on
+  // only one of them silently produces a schedule for a different image than
+  // the one being generated. This is the first preset to use the array form of
+  // an injection target; normalizeTargets has always supported it.
+  width: [
+    target(FLUX2_DEV_GGUF_TXT2IMG_NODES.latentImage, "width"),
+    target(FLUX2_DEV_GGUF_TXT2IMG_NODES.scheduler, "width")
+  ],
+  height: [
+    target(FLUX2_DEV_GGUF_TXT2IMG_NODES.latentImage, "height"),
+    target(FLUX2_DEV_GGUF_TXT2IMG_NODES.scheduler, "height")
+  ],
+  seed: target(FLUX2_DEV_GGUF_TXT2IMG_NODES.noise, "noise_seed"),
+  steps: target(FLUX2_DEV_GGUF_TXT2IMG_NODES.scheduler, "steps"),
+  // Same remap as txt2img-flux1-dev-fp8: there is no KSampler and therefore no
+  // cfg widget, so the panel's CFG control drives FluxGuidance instead.
+  cfg: target(FLUX2_DEV_GGUF_TXT2IMG_NODES.fluxGuidance, "guidance")
 } as const;
 
 const Z_IMAGE_TURBO_TXT2IMG_INJECTIONS = {
@@ -680,6 +779,31 @@ const OUTPAINT_FLUX_FILL_BASIC_CAPABILITY: WorkflowCapability = {
     showModelSelector: true,
     modelSelectorLabel: "Flux Fill model",
     primaryActionLabel: "Generate Outpaint"
+  }
+};
+
+const FLUX2_DEV_GGUF_TXT2IMG_CAPABILITY: WorkflowCapability = {
+  toolType: "txt2img",
+  loaderType: "diffusion-model-stack",
+  artistLabel: "Text to Image",
+  technicalLabel: "txt2img-flux2-dev-gguf",
+  requiredPhotoshopInputs: [],
+  // No negativePrompt: Flux.2 is guidance-distilled and the reference graph has
+  // no negative conditioning node at all, so the control is hidden rather than
+  // wired to something that would quietly do nothing.
+  controls: ["prompt", "width", "height", "steps", "guidance", "seed"],
+  output: {
+    kind: "full-image",
+    size: "preset",
+    importBehavior: "new-layer"
+  },
+  uiHints: {
+    showModelSelector: true,
+    modelSelectorLabel: "Flux.2 model",
+    primaryActionLabel: "Generate",
+    hiddenControls: ["negativePrompt"],
+    experimentalNote:
+      "Flux.2 dev is a very large stack: an 18.7 GB quantised model plus a 16.8 GB text encoder. On a 12 GB card ComfyUI streams most of it from system RAM, so expect minutes per image rather than seconds."
   }
 };
 
@@ -1585,6 +1709,95 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     ],
     compatibilityNote:
       "txt2img-krea2-turbo follows the official ComfyUI Krea-2 Turbo template: UNETLoader with krea2_turbo_fp8_scaled, CLIPLoader with the qwen3vl text encoder in krea2 mode, the Qwen image VAE, and an 8-step CFG 1 euler/simple sampler."
+  },
+  {
+    id: "txt2img-flux2-dev-gguf",
+    label: "txt2img-flux2-dev-gguf",
+    displayName: "Flux.2 dev (GGUF)",
+    mode: "txt2img",
+    description:
+      "Experimental Flux.2 dev text-to-image preset using a GGUF-quantised diffusion model and the Mistral-3 text encoder.",
+    workflowFile: "workflows/api/txt2img-flux2-dev-gguf.json",
+    status: "experimental",
+    recommendedSettings: { steps: 20, cfg: 4 },
+    supportedModelFamilies: ["flux2"],
+    experimentalModelFamilies: ["unknown"],
+    modelSource: DIFFUSION_MODEL_SOURCE,
+    capability: FLUX2_DEV_GGUF_TXT2IMG_CAPABILITY,
+    modelStack: [...FLUX2_DEV_GGUF_STACK],
+    requiredModels: [...FLUX2_DEV_GGUF_STACK],
+    injections: FLUX2_DEV_GGUF_TXT2IMG_INJECTIONS,
+    requiredNodes: [
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.diffusionModelLoader,
+        classType: "UnetLoaderGGUF",
+        // Only unet_name. The core UNETLoader's weight_dtype does not exist
+        // here, because a GGUF file carries its own quantisation.
+        requiredInputs: ["unet_name"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.clipLoader,
+        classType: "CLIPLoader",
+        requiredInputs: ["clip_name", "type"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.vaeLoader,
+        classType: "VAELoader",
+        requiredInputs: ["vae_name"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.positivePrompt,
+        classType: "CLIPTextEncode",
+        requiredInputs: ["text", "clip"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.fluxGuidance,
+        classType: "FluxGuidance",
+        requiredInputs: ["conditioning", "guidance"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.guider,
+        classType: "BasicGuider",
+        requiredInputs: ["model", "conditioning"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.noise,
+        classType: "RandomNoise",
+        requiredInputs: ["noise_seed"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.samplerSelect,
+        classType: "KSamplerSelect",
+        requiredInputs: ["sampler_name"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.scheduler,
+        classType: "Flux2Scheduler",
+        requiredInputs: ["steps", "width", "height"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.latentImage,
+        classType: "EmptyFlux2LatentImage",
+        requiredInputs: ["width", "height", "batch_size"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.sampler,
+        classType: "SamplerCustomAdvanced",
+        requiredInputs: ["noise", "guider", "sampler", "sigmas", "latent_image"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.decode,
+        classType: "VAEDecode",
+        requiredInputs: ["samples", "vae"]
+      },
+      {
+        id: FLUX2_DEV_GGUF_TXT2IMG_NODES.saveImage,
+        classType: "SaveImage",
+        requiredInputs: ["images"]
+      }
+    ],
+    compatibilityNote:
+      "txt2img-flux2-dev-gguf follows the Flux.2 dev template that ships with ComfyUI, and is the first OpenLayer preset built on the advanced sampler chain rather than KSampler: RandomNoise, KSamplerSelect, Flux2Scheduler and BasicGuider feed SamplerCustomAdvanced. There is no negative prompt, because the reference graph has none. Width and height are written to both EmptyFlux2LatentImage and Flux2Scheduler, which derives its shift from the same dimensions. The diffusion model loads through ComfyUI-GGUF, which needs the gguf Python package installed in ComfyUI's environment or it registers no nodes at all."
   },
   {
     id: "img2img-krea2-turbo",

--- a/src/comfy/setupManifest.ts
+++ b/src/comfy/setupManifest.ts
@@ -42,6 +42,24 @@ export const CUSTOM_NODE_PACKAGES: Record<string, { name: string; repoUrl: strin
   "ShowText|pysssss": {
     name: "ComfyUI-Custom-Scripts",
     repoUrl: "https://github.com/pythongosssss/ComfyUI-Custom-Scripts"
+  },
+  // Listing these matters more than usual. ComfyUI-GGUF fails in a way that
+  // looks like nothing at all: it needs a `gguf` Python package that its own
+  // install does not always pull in, and without it the pack imports silently,
+  // registers no classes, and every .gguf model becomes invisible to every
+  // loader. Naming the package here means Setup and Workflow Health can say
+  // which install is missing instead of reporting an unexplained absent node.
+  UnetLoaderGGUF: {
+    name: "ComfyUI-GGUF",
+    repoUrl: "https://github.com/city96/ComfyUI-GGUF"
+  },
+  CLIPLoaderGGUF: {
+    name: "ComfyUI-GGUF",
+    repoUrl: "https://github.com/city96/ComfyUI-GGUF"
+  },
+  DualCLIPLoaderGGUF: {
+    name: "ComfyUI-GGUF",
+    repoUrl: "https://github.com/city96/ComfyUI-GGUF"
   }
 };
 

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -2,6 +2,7 @@ export type WorkflowPreset =
   | "txt2img-basic"
   | "img2img-basic"
   | "txt2img-flux1-dev-fp8"
+  | "txt2img-flux2-dev-gguf"
   | "txt2img-z-image-turbo"
   | "img2img-z-image-turbo"
   | "txt2img-krea2-turbo"

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -20,7 +20,7 @@ export type WorkflowMode =
   | "outpaint"
   | "prompt"
   | "upscale";
-export type ModelFamily = "sd1" | "sdxl" | "sd3" | "flux" | "zImage" | "unknown";
+export type ModelFamily = "sd1" | "sdxl" | "sd3" | "flux" | "flux2" | "zImage" | "unknown";
 export type WorkflowToolType = WorkflowMode | "realtime";
 export type WorkflowLoaderType = "checkpoint" | "diffusion-model-stack" | "vision-language" | "upscale";
 export type WorkflowControlId =

--- a/src/workflows/api/txt2img-flux2-dev-gguf.json
+++ b/src/workflows/api/txt2img-flux2-dev-gguf.json
@@ -1,0 +1,169 @@
+{
+  "12": {
+    "class_type": "UnetLoaderGGUF",
+    "inputs": {
+      "unet_name": "flux2-dev-Q4_K_M.gguf"
+    },
+    "_meta": {
+      "title": "Load Flux.2 dev Diffusion Model (GGUF)"
+    }
+  },
+  "38": {
+    "class_type": "CLIPLoader",
+    "inputs": {
+      "clip_name": "mistral_3_small_flux2_fp8.safetensors",
+      "type": "flux2"
+    },
+    "_meta": {
+      "title": "Load Mistral-3 Text Encoder"
+    }
+  },
+  "10": {
+    "class_type": "VAELoader",
+    "inputs": {
+      "vae_name": "full_encoder_small_decoder.safetensors"
+    },
+    "_meta": {
+      "title": "Load Flux.2 VAE"
+    }
+  },
+  "6": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "_meta": {
+      "title": "Positive Prompt"
+    }
+  },
+  "26": {
+    "class_type": "FluxGuidance",
+    "inputs": {
+      "conditioning": [
+        "6",
+        0
+      ],
+      "guidance": 4
+    },
+    "_meta": {
+      "title": "Flux Guidance"
+    }
+  },
+  "22": {
+    "class_type": "BasicGuider",
+    "inputs": {
+      "model": [
+        "12",
+        0
+      ],
+      "conditioning": [
+        "26",
+        0
+      ]
+    },
+    "_meta": {
+      "title": "Guider"
+    }
+  },
+  "25": {
+    "class_type": "RandomNoise",
+    "inputs": {
+      "noise_seed": 1
+    },
+    "_meta": {
+      "title": "Noise"
+    }
+  },
+  "16": {
+    "class_type": "KSamplerSelect",
+    "inputs": {
+      "sampler_name": "euler"
+    },
+    "_meta": {
+      "title": "Sampler"
+    }
+  },
+  "48": {
+    "class_type": "Flux2Scheduler",
+    "inputs": {
+      "steps": 20,
+      "width": 1024,
+      "height": 1024
+    },
+    "_meta": {
+      "title": "Flux.2 Scheduler"
+    }
+  },
+  "47": {
+    "class_type": "EmptyFlux2LatentImage",
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "_meta": {
+      "title": "Image Size"
+    }
+  },
+  "13": {
+    "class_type": "SamplerCustomAdvanced",
+    "inputs": {
+      "noise": [
+        "25",
+        0
+      ],
+      "guider": [
+        "22",
+        0
+      ],
+      "sampler": [
+        "16",
+        0
+      ],
+      "sigmas": [
+        "48",
+        0
+      ],
+      "latent_image": [
+        "47",
+        0
+      ]
+    },
+    "_meta": {
+      "title": "Custom Sampler"
+    }
+  },
+  "8": {
+    "class_type": "VAEDecode",
+    "inputs": {
+      "samples": [
+        "13",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ]
+    },
+    "_meta": {
+      "title": "Decode"
+    }
+  },
+  "9": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "filename_prefix": "OpenLayer_Flux2",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/tests/comfy/modelCompatibility.test.ts
+++ b/tests/comfy/modelCompatibility.test.ts
@@ -11,6 +11,22 @@ describe("model compatibility", () => {
     expect(detectCheckpointFamily("z_image_turbo_bf16.safetensors")).toBe("zImage");
   });
 
+  it("keeps Flux.2 apart from Flux.1, whatever the filename spells it", () => {
+    // Every one of these contains "flux", so the plain Flux test would claim
+    // all of them without the more specific check running first. The families
+    // are not interchangeable: Flux.1 runs on a plain KSampler and Flux.2 needs
+    // the advanced sampler chain and a 128-channel latent, so a mis-detection
+    // tells an artist a preset is compatible when its graph cannot run at all.
+    expect(detectCheckpointFamily("flux2-dev-Q4_K_M.gguf")).toBe("flux2");
+    expect(detectCheckpointFamily("flux2_dev_fp8mixed.safetensors")).toBe("flux2");
+    expect(detectCheckpointFamily("FLUX.2-dev.safetensors")).toBe("flux2");
+    expect(detectCheckpointFamily("flux-2-klein-4b-fp8.safetensors")).toBe("flux2");
+
+    // And the Flux.1 names must not drift into the new family.
+    expect(detectCheckpointFamily("flux1-dev.safetensors")).toBe("flux");
+    expect(detectCheckpointFamily("flux1-fill-dev.safetensors")).toBe("flux");
+  });
+
   it("warns when a Flux-style model is used with img2img-basic", () => {
     const preset = getWorkflowPreset("img2img-basic");
     const compatibility = getCheckpointCompatibility("flux1-dev-fp8.safetensors", preset);

--- a/tests/comfy/modelFolders.test.ts
+++ b/tests/comfy/modelFolders.test.ts
@@ -37,7 +37,13 @@ describe("model folder mapping", () => {
       VAELoader: "vae",
       ControlNetLoader: "controlnet",
       UpscaleModelLoader: "upscale_models",
-      Florence2ModelLoader: "LLM"
+      Florence2ModelLoader: "LLM",
+      // ComfyUI-GGUF stands in for the core loaders and reads their folders,
+      // confirmed against the live server: UnetLoaderGGUF's own combo list
+      // offered flux2-dev-Q4_K_M.gguf straight out of models/diffusion_models/.
+      UnetLoaderGGUF: "diffusion_models",
+      CLIPLoaderGGUF: "text_encoders",
+      DualCLIPLoaderGGUF: "text_encoders"
     });
   });
 

--- a/tests/comfy/modelFolders.test.ts
+++ b/tests/comfy/modelFolders.test.ts
@@ -121,14 +121,17 @@ describe("required model inventory", () => {
         "checkpoints/flux1-dev-fp8.safetensors",
         "controlnet/control_v11p_sd15_lineart_fp16.safetensors",
         "diffusion_models/flux1-fill-dev.safetensors",
+        "diffusion_models/flux2-dev-Q4_K_M.gguf",
         "diffusion_models/krea2_turbo_fp8_scaled.safetensors",
         "diffusion_models/z_image_turbo_bf16.safetensors",
         "text_encoders/clip_l.safetensors",
+        "text_encoders/mistral_3_small_flux2_fp8.safetensors",
         "text_encoders/qwen3vl_4b_fp8_scaled.safetensors",
         "text_encoders/qwen_3_4b.safetensors",
         "text_encoders/t5xxl_fp16.safetensors",
         "upscale_models/4x-UltraSharp.pth",
         "vae/ae.safetensors",
+        "vae/full_encoder_small_decoder.safetensors",
         "vae/qwen_image_vae.safetensors"
       ].sort()
     );
@@ -166,7 +169,15 @@ describe("required model inventory", () => {
   it("gates the licence-restricted Flux weights and nothing else", () => {
     const gated = runnableModels.filter((entry) => entry.licenseGate).map((entry) => entry.modelName);
 
-    expect(gated.sort()).toEqual(["flux1-dev-fp8.safetensors", "flux1-fill-dev.safetensors"]);
+    // Flux.2's diffusion model and its Mistral-3 encoder carry the FLUX.2 [dev]
+    // licence. The Flux.2 VAE does not -- it is published separately and
+    // ungated -- and that asymmetry is deliberate, not an omission.
+    expect(gated.sort()).toEqual([
+      "flux1-dev-fp8.safetensors",
+      "flux1-fill-dev.safetensors",
+      "flux2-dev-Q4_K_M.gguf",
+      "mistral_3_small_flux2_fp8.safetensors"
+    ]);
 
     for (const entry of runnableModels) {
       if (!entry.licenseGate) {

--- a/tests/comfy/presetRegistry.test.ts
+++ b/tests/comfy/presetRegistry.test.ts
@@ -33,7 +33,8 @@ describe("presetRegistry", () => {
       "txt2img-basic",
       "txt2img-flux1-dev-fp8",
       "txt2img-z-image-turbo",
-      "txt2img-krea2-turbo"
+      "txt2img-krea2-turbo",
+      "txt2img-flux2-dev-gguf"
     ]);
     expect(allImg2ImgIds).toContain("img2img-z-image-turbo");
     expect(runnableImg2ImgIds).toEqual(["img2img-basic", "img2img-z-image-turbo", "img2img-krea2-turbo"]);

--- a/tests/comfy/setupManifest.test.ts
+++ b/tests/comfy/setupManifest.test.ts
@@ -77,12 +77,16 @@ describe("setup manifest", () => {
     expect(sharedVae?.usedByPresets).toContain("txt2img-z-image-turbo");
   });
 
-  it("requires only the two custom node packages that are left", () => {
+  it("requires only the three custom node packages that are left", () => {
     const manifest = build();
 
+    // ComfyUI-GGUF joined when the Flux.2 preset landed. It is worth naming
+    // here because it is the one pack that can be installed and still register
+    // nothing, when its gguf Python dependency is missing from the environment.
     expect(manifest.customNodes.map((node) => node.name)).toEqual([
       "comfyui_controlnet_aux",
-      "ComfyUI-Florence2"
+      "ComfyUI-Florence2",
+      "ComfyUI-GGUF"
     ]);
 
     for (const node of manifest.customNodes) {
@@ -121,7 +125,9 @@ describe("setup manifest", () => {
     const manifest = build();
 
     expect(manifest.totals.models).toBe(manifest.models.length);
-    expect(manifest.totals.licenseGatedModels).toBe(2);
+    // Four: both Flux.1 weights, plus Flux.2's diffusion model and its
+    // Mistral-3 encoder. The Flux.2 VAE is published ungated and is not one.
+    expect(manifest.totals.licenseGatedModels).toBe(4);
     expect(manifest.totals.knownDownloadBytes).toBe(
       manifest.models.reduce((total, model) => total + (model.sizeBytes ?? 0), 0)
     );

--- a/tests/comfy/workflowFiles.test.ts
+++ b/tests/comfy/workflowFiles.test.ts
@@ -26,7 +26,15 @@ function loadApiWorkflow(preset: WorkflowPresetDefinition): ComfyWorkflow {
  * this test also guards that assumption — a new custom node that nobody
  * registered there would be silently reported as core, and this fails first.
  */
-const EXPECTED_CUSTOM_NODE_CLASSES = ["Florence2ModelLoader", "Florence2Run", "LineArtPreprocessor"];
+const EXPECTED_CUSTOM_NODE_CLASSES = [
+  "Florence2ModelLoader",
+  "Florence2Run",
+  "LineArtPreprocessor",
+  // Flux.2's quantised model. Note only the UNET loader appears: its text
+  // encoder is a safetensors file read by core CLIPLoader, so CLIPLoaderGGUF is
+  // mapped in the registry but not required by any shipped preset.
+  "UnetLoaderGGUF"
+];
 
 describe("shipped API workflow files", () => {
   const runnablePresets = listRunnableWorkflowPresets();


### PR DESCRIPTION
Adds a Text to Image preset for `flux2-dev-Q4_K_M.gguf`, which is already on your disk. Two commits: the groundwork, then the preset.

## `9eb5852` — groundwork

Three changes, none visible alone, none of which the preset can be written without:

1. **GGUF loaders mapped to folders.** `getModelTargetFolder` throws `WORKFLOW_INVALID` for any loader missing from that table. Note this is not about ComfyUI finding the file — it already can — it's what OpenLayer's own Setup and Health screens read.
2. **`ComfyUI-GGUF` added to the custom node packages.** This one earns its place: the pack can be fully installed and still register *nothing* when its `gguf` Python dependency is absent, which is exactly what happened on your machine. Now the panel can name the package instead of reporting an unexplained missing node.
3. **`ModelFamily` gains `"flux2"`**, tested *before* the plain `"flux"` substring that would otherwise swallow every Flux.2 filename. The families aren't interchangeable — Flux.1 runs on a plain KSampler, Flux.2 needs the advanced sampler chain and a 128-channel latent — so the old behaviour told an artist a preset was compatible when its graph couldn't run the file at all.

## `e1d3246` — the preset

Graph taken from the Flux.2 template **ComfyUI itself ships**, read directly rather than reconstructed from docs, minus its optional Turbo-LoRA switch.

First OpenLayer preset on the advanced sampler chain: `RandomNoise` + `KSamplerSelect` + `Flux2Scheduler` + `BasicGuider` → `SamplerCustomAdvanced`. Two consequences:

- **Width and height go to two nodes.** `Flux2Scheduler` derives its shift from the same dimensions that size the latent; setting one without the other silently schedules for a different image than the one being generated. First use of the array injection-target form — `normalizeTargets` always supported it, nothing had exercised it.
- **No negative prompt.** The reference graph has no negative conditioning node, so the control is hidden rather than wired to something that would quietly do nothing. CFG drives `FluxGuidance`, same remap as `txt2img-flux1-dev-fp8`.

## Verified against live ComfyUI 0.29.2, not assumed

Every class exists; every required input supplied and no unknown input present; every pinned model name offered by its loader — **except** `mistral_3_small_flux2_fp8.safetensors`, which isn't downloaded yet and which the preset therefore correctly reports as a missing model.

Two method notes worth recording: `/object_info/<Class>` returns **HTTP 200 with `{}`** for a class that doesn't exist, so status codes prove nothing. And ComfyUI 0.29 has **two** combo schemas — legacy `[[...]]` and `["COMBO", {options}]`. Our `readComfyModelNameList` already handles both; I checked after my own ad-hoc probe got it wrong.

## Honest expectation

Marked **experimental**, and the note says why: 18.7 GB quantised model + 16.8 GB encoder on a 12 GB card means most of it streams from system RAM. **Minutes per image, not seconds.** Krea-2 Turbo remains the preset for iterating.

## Checks

`typecheck`, `test` (**511 passed**), `build`, `eslint` all clean. Five frozen-inventory tests caught the addition. Setup pack now reports **14 presets, 16 models, 120.7 GB**.

## Smoke checklist

**Before the encoder is downloaded** — this is the interesting half, and it's testable right now:

1. **Settings → Check Workflow Health.** "Flux.2 dev (GGUF)" should appear as **Missing model**, naming `mistral_3_small_flux2_fp8.safetensors` — *not* the diffusion model and *not* the VAE, both of which you already have.
2. **Setup → Check Again.** Two new rows: the Mistral-3 encoder as **Missing** (`models/text_encoders/`, 16.8 GB, licence note), and `flux2-dev-Q4_K_M.gguf` as **Installed**. `full_encoder_small_decoder.safetensors` should also read Installed — it's the Flux.2 VAE you already had under a name that hides it.
3. **A custom node row for `ComfyUI-GGUF`** should appear, Installed. If you ever hit the empty-pack problem again, this row is what will say so.
4. **"What will run well"** should rank Flux.2 dev as **Will offload** — near the bottom, which is correct.
5. **Text to Image → workflow dropdown** should offer "Flux.2 dev (GGUF)". Select it and confirm the **negative prompt field disappears**, and that CFG still shows (it drives guidance).
6. Confirm no other preset changed name, badge or availability. The family split touches how every Flux file is classified, so this is the regression that matters.

**After the encoder is downloaded:** generate once at 1024×1024, 20 steps, guidance 4. Expect it to be slow. Confirm the image imports as a layer and the seed is recorded in History.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
