### PR TITLE
Fix: a GGUF model you already have is reported as missing

### DIFF
--- a/src/comfy/comfyClient.ts
+++ b/src/comfy/comfyClient.ts
@@ -28,13 +28,26 @@ import {
 import { createOpenLayerError, getNestedErrorMessage } from "../utils/errors";
 import { createMultipartBoundary, createMultipartRequestBody } from "../utils/multipart";
 
-const MODEL_INVENTORY_SOURCES = {
+/**
+ * Which `object_info` node each inventory bucket is built from.
+ *
+ * Exported so a test can assert the invariant that broke once already: every
+ * loader a preset requires a model through must also be asked for its list
+ * here, or that model is invisible and the panel reports a file you have as
+ * one you still need to download.
+ */
+export const MODEL_INVENTORY_SOURCES = {
   checkpoints: [
     { objectInfoNode: "CheckpointLoaderSimple", inputName: "ckpt_name", label: "checkpoint loader" }
   ],
   diffusionModels: [
     { objectInfoNode: "UNETLoader", inputName: "unet_name", label: "diffusion model loader" },
-    { objectInfoNode: "DiffusionModelLoader", inputName: "model_name", label: "diffusion model loader" }
+    { objectInfoNode: "DiffusionModelLoader", inputName: "model_name", label: "diffusion model loader" },
+    // Core UNETLoader does not enumerate .gguf files AT ALL -- verified live, it
+    // listed only the safetensors sitting in the same folder. So a quantised
+    // model is invisible to this inventory unless its own loader is asked, and
+    // a preset requiring one reports "missing" for a file that is right there.
+    { objectInfoNode: "UnetLoaderGGUF", inputName: "unet_name", label: "GGUF diffusion model loader" }
   ],
   clipModels: [
     { objectInfoNode: "CLIPLoader", inputName: "clip_name", label: "CLIP loader" },
@@ -42,7 +55,13 @@ const MODEL_INVENTORY_SOURCES = {
     { objectInfoNode: "DualCLIPLoader", inputName: "clip_name2", label: "dual CLIP loader" },
     { objectInfoNode: "TripleCLIPLoader", inputName: "clip_name1", label: "triple CLIP loader" },
     { objectInfoNode: "TripleCLIPLoader", inputName: "clip_name2", label: "triple CLIP loader" },
-    { objectInfoNode: "TripleCLIPLoader", inputName: "clip_name3", label: "triple CLIP loader" }
+    { objectInfoNode: "TripleCLIPLoader", inputName: "clip_name3", label: "triple CLIP loader" },
+    // Same reasoning for quantised text encoders. No shipped preset requires
+    // one yet, but a GGUF encoder sitting in text_encoders/ should not be
+    // reported as absent just because nothing thought to ask its loader.
+    { objectInfoNode: "CLIPLoaderGGUF", inputName: "clip_name", label: "GGUF CLIP loader" },
+    { objectInfoNode: "DualCLIPLoaderGGUF", inputName: "clip_name1", label: "GGUF dual CLIP loader" },
+    { objectInfoNode: "DualCLIPLoaderGGUF", inputName: "clip_name2", label: "GGUF dual CLIP loader" }
   ],
   vaeModels: [
     { objectInfoNode: "VAELoader", inputName: "vae_name", label: "VAE loader" }

--- a/tests/comfy/modelInventorySources.test.ts
+++ b/tests/comfy/modelInventorySources.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { MODEL_INVENTORY_SOURCES } from "../../src/comfy/comfyClient";
+import { listRequiredModelsForPresets } from "../../src/comfy/modelFolders";
+import { listRunnableWorkflowPresets } from "../../src/comfy/presetRegistry";
+
+const askedLoaders = new Set(
+  Object.values(MODEL_INVENTORY_SOURCES).flatMap((sources) =>
+    sources.map((source) => source.objectInfoNode)
+  )
+);
+
+describe("model inventory sources", () => {
+  /**
+   * The regression this exists for: the Flux.2 preset shipped with its GGUF
+   * loader mapped to a folder but never added here, so the inventory only ever
+   * asked core UNETLoader — which does not enumerate .gguf files at all. The
+   * model sat on disk while Setup reported it missing and asked for an 18.7 GB
+   * download the user had already made.
+   */
+  it("asks every loader that a preset requires a model through", () => {
+    const unasked = new Set<string>();
+
+    for (const model of listRequiredModelsForPresets(listRunnableWorkflowPresets())) {
+      if (!askedLoaders.has(model.objectInfoNode)) {
+        unasked.add(model.objectInfoNode);
+      }
+    }
+
+    expect(
+      [...unasked].sort(),
+      "these loaders supply a required model but are never asked for their model list, so those models will always read as missing"
+    ).toEqual([]);
+  });
+
+  it("asks the GGUF loaders, which core loaders cannot stand in for", () => {
+    // Verified against a live ComfyUI: with flux2-dev-Q4_K_M.gguf present in
+    // models/diffusion_models, UNETLoader listed only the three safetensors
+    // beside it, while UnetLoaderGGUF listed the .gguf. They are not
+    // interchangeable sources for the same folder.
+    expect(askedLoaders.has("UnetLoaderGGUF")).toBe(true);
+    expect(askedLoaders.has("CLIPLoaderGGUF")).toBe(true);
+    expect(askedLoaders.has("DualCLIPLoaderGGUF")).toBe(true);
+  });
+
+  it("keeps every asked loader pointed at a real input name", () => {
+    for (const [bucket, sources] of Object.entries(MODEL_INVENTORY_SOURCES)) {
+      expect(sources.length, `${bucket} has no inventory source`).toBeGreaterThan(0);
+
+      for (const source of sources) {
+        expect(source.objectInfoNode).toMatch(/^[A-Za-z0-9_|]+$/);
+        expect(source.inputName.length).toBeGreaterThan(0);
+        expect(source.label.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
**Bug I introduced in #70, visible in Mehran's screenshot.** Setup showed `flux2-dev-Q4_K_M.gguf` as **Missing** and asked for an **18.7 GB download of a file already on disk** — exactly the mistake the Setup screen exists to prevent.

## Cause

There are **two** tables and #70 only updated one. `modelFolders.ts` maps a loader to its folder; `MODEL_INVENTORY_SOURCES` in `comfyClient.ts` decides which loaders get asked for their model list. The inventory only ever asked core `UNETLoader`, and **that loader does not enumerate `.gguf` files at all** — confirmed live:

```
UNETLoader only    : ["flux1-fill-dev.safetensors","krea2_turbo_fp8_scaled.safetensors","z_image_turbo_bf16.safetensors"]
UnetLoaderGGUF only: ["flux2-dev-Q4_K_M.gguf"]
merged             : all four  ✓
```

So the file was invisible to the inventory, and every consumer downstream — Setup, Workflow Health, the remaining-download total — correctly reported what it was told.

## The fix

`UnetLoaderGGUF` added to `diffusionModels`; `CLIPLoaderGGUF` and `DualCLIPLoaderGGUF` added to `clipModels`. The CLIP ones aren't needed by any shipped preset yet, but a quantised encoder in `text_encoders/` would be invisible for the identical reason.

**Servers without ComfyUI-GGUF are unaffected.** An absent class answers `200` with an empty body, which reads as an empty list rather than an error — nothing is added to `missingSources`, no new noise.

## The test is the point

It encodes the **invariant**, not this instance: *every loader that any runnable preset requires a model through must also be asked for its model list.* Confirmed to fail without the fix, naming the culprit:

```
AssertionError: these loaders supply a required model but are never asked
for their model list, so those models will always read as missing:
expected [ 'UnetLoaderGGUF' ] to deeply equal []
```

It will catch the next loader someone maps to a folder and forgets to ask.

## Checks

`typecheck`, `test` (**514 passed**, +3), `build`, `eslint` — all clean.

## Smoke checklist

1. **Setup → Check Again.** `flux2-dev-Q4_K_M.gguf` must now read **Installed**. Missing should drop from 2 to **1** (only the Mistral-3 encoder), and the remaining download from 35.5 GB to **16.8 GB**.
2. **Check Workflow Health.** "Flux.2 dev (GGUF)" should still say Missing model, but naming *only* the text encoder.
3. Confirm no other model's status changed — this touches the inventory every preset is checked against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
