### PR TITLE
Measure Live Painting in phases instead of three compound numbers

### DIFF
--- a/src/photoshop/livePaintingCapture.ts
+++ b/src/photoshop/livePaintingCapture.ts
@@ -22,6 +22,11 @@ export type LiveCaptureResult = {
   height: number;
   mode: LiveCaptureMode;
   captureMs: number;
+  phases: {
+    getPixelsMs: number;
+    toRgbaMs: number;
+    pngEncodeMs: number;
+  };
   originatingDocument: PhotoshopDocumentIdentity;
 };
 
@@ -130,11 +135,18 @@ export async function captureCanvasForLivePainting(maxDimension = 512): Promise<
 async function capturePixelsAsPng(
   imaging: NonNullable<LivePhotoshopModule["imaging"]>,
   options: Record<string, unknown>
-): Promise<{ blob: Blob; width: number; height: number }> {
+): Promise<{
+  blob: Blob;
+  width: number;
+  height: number;
+  phases: LiveCaptureResult["phases"];
+}> {
   let imageData: Awaited<ReturnType<NonNullable<LivePhotoshopModule["imaging"]>["getPixels"]>>["imageData"];
 
   try {
+    const getPixelsStartedAt = Date.now();
     const pixelResult = await imaging.getPixels(options);
+    const getPixelsMs = Date.now() - getPixelsStartedAt;
     imageData = pixelResult.imageData;
 
     if (!imageData || typeof imageData.getData !== "function") {
@@ -155,13 +167,22 @@ async function capturePixelsAsPng(
     }
 
     const raw = toUint8Array(await imageData.getData());
+    const toRgbaStartedAt = Date.now();
     const rgba = convertPixelsToRgba(raw, width, height, components);
+    const toRgbaMs = Date.now() - toRgbaStartedAt;
+    const pngEncodeStartedAt = Date.now();
     const png = encodeRgbaPng({ width, height, rgba });
+    const pngEncodeMs = Date.now() - pngEncodeStartedAt;
 
     return {
       blob: new Blob([toArrayBuffer(png)], { type: "image/png" }),
       width,
-      height
+      height,
+      phases: {
+        getPixelsMs,
+        toRgbaMs,
+        pngEncodeMs
+      }
     };
   } finally {
     imageData?.dispose?.();

--- a/src/ui/livePaintingTimings.ts
+++ b/src/ui/livePaintingTimings.ts
@@ -159,6 +159,65 @@ export function formatCycleLine(sample: LiveCycleSample): string {
   return `Cycle ${sample.cycleIndex} (${sample.kind}): ${fields.join(" | ")}`;
 }
 
+/**
+ * The per-cycle status line, showing only what was actually measured, most
+ * expensive first.
+ *
+ * Every phase is deliberately NOT printed. The panel is 356px wide and eleven
+ * phases plus their labels do not fit, but the stronger reason is that a line
+ * listing eight "not reported" entries buries the three numbers that matter.
+ * Unmeasured phases are still counted, in `unaccounted`, so nothing disappears
+ * silently.
+ */
+export function formatMeasuredCycleLine(sample: LiveCycleSample): string {
+  const summary = summariseCycle(sample);
+  const measured = LIVE_PHASE_IDS
+    .map((phaseId) => ({ phaseId, duration: sample.phases[phaseId] }))
+    .filter((entry): entry is { phaseId: LivePhaseId; duration: number } =>
+      entry.duration !== null && entry.duration !== undefined)
+    .sort((left, right) => right.duration - left.duration)
+    .map((entry) => `${entry.phaseId} ${entry.duration}ms`);
+
+  const fields = [
+    ...measured,
+    `unaccounted ${summary.unaccountedMs}ms`,
+    `total ${summary.totalMs}ms`
+  ];
+
+  if (summary.overAccounted) {
+    fields.push("OVER-ACCOUNTED");
+  }
+
+  return `Cycle ${sample.cycleIndex} (${sample.kind}): ${fields.join(" | ")}`;
+}
+
+/**
+ * The end-of-session line: median per phase across every cycle, worst first.
+ *
+ * This is the number the optimisation decision gets made from. A single cycle
+ * is noise -- the first one pays for a cold model load and any one of them can
+ * land badly against the poll interval -- so the panel shows this when the
+ * session stops rather than asking anyone to read medians off a moving line.
+ */
+export function formatAggregateLine(samples: readonly LiveCycleSample[]): string {
+  if (samples.length === 0) {
+    return "No Live Painting cycles were measured.";
+  }
+
+  const aggregate = aggregateCycles(samples);
+  const measured = LIVE_PHASE_IDS
+    .map((phaseId) => ({ phaseId, aggregated: aggregate.phases[phaseId] }))
+    .filter((entry) => entry.aggregated.median !== null)
+    .sort((left, right) => (right.aggregated.median ?? 0) - (left.aggregated.median ?? 0))
+    .map((entry) => `${entry.phaseId} ${entry.aggregated.median}ms`);
+
+  return [
+    `${samples.length} cycle${samples.length === 1 ? "" : "s"} measured`,
+    `median total ${aggregate.totalMs.median}ms`,
+    ...measured
+  ].join(" | ");
+}
+
 export function formatCyclesTable(samples: readonly LiveCycleSample[]): string {
   const headers = [
     "cycleIndex",

--- a/src/ui/livePaintingTimings.ts
+++ b/src/ui/livePaintingTimings.ts
@@ -1,0 +1,246 @@
+export const LIVE_PHASE_IDS = [
+  "capture.getPixels",
+  "capture.toRgba",
+  "capture.pngEncode",
+  "upload.encodeBody",
+  "upload.http",
+  "submit.http",
+  "server.queueWait",
+  "server.execute",
+  "poll.overshoot",
+  "download.http",
+  "paint"
+] as const;
+
+export type LivePhaseId = (typeof LIVE_PHASE_IDS)[number];
+
+export type LiveCyclePhaseDurations = Partial<Record<LivePhaseId, number | null>>;
+
+export type LiveCycleSample = {
+  cycleIndex: number;
+  kind: "live" | "refine";
+  totalMs: number;
+  phases: LiveCyclePhaseDurations;
+  captureMode?: string;
+  width?: number;
+  height?: number;
+};
+
+export type LiveCycleSummary = LiveCycleSample & {
+  accountedMs: number;
+  unaccountedMs: number;
+  overAccounted: boolean;
+};
+
+export type LiveDurationAggregate = {
+  median: number | null;
+  p90: number | null;
+  count: number;
+};
+
+export type LiveCycleAggregate = {
+  phases: Record<LivePhaseId, LiveDurationAggregate>;
+  totalMs: LiveDurationAggregate;
+};
+
+export type ServerPhaseDurations = {
+  queueWaitMs: number | null;
+  executeMs: number | null;
+  pollOvershootMs: number | null;
+};
+
+export function summariseCycle(sample: LiveCycleSample): LiveCycleSummary {
+  const accountedMs = LIVE_PHASE_IDS.reduce((total, phaseId) => {
+    const duration = sample.phases[phaseId];
+    return duration === null || duration === undefined ? total : total + duration;
+  }, 0);
+  const overAccounted = accountedMs > sample.totalMs;
+
+  return {
+    ...sample,
+    phases: { ...sample.phases },
+    accountedMs,
+    unaccountedMs: overAccounted ? 0 : sample.totalMs - accountedMs,
+    overAccounted
+  };
+}
+
+export function deriveServerPhases(
+  submittedAtMs: number,
+  observedCompleteAtMs: number,
+  messages: unknown
+): ServerPhaseDurations {
+  if (!Array.isArray(messages)) {
+    return emptyServerPhases();
+  }
+
+  let executionStartMs: number | null = null;
+  let executionSuccessMs: number | null = null;
+
+  for (const message of messages) {
+    if (!Array.isArray(message) || message.length < 2) {
+      continue;
+    }
+
+    const [eventName, data] = message;
+    if (eventName !== "execution_start" && eventName !== "execution_success") {
+      continue;
+    }
+
+    const timestamp = readTimestamp(data);
+    if (timestamp === null) {
+      continue;
+    }
+
+    if (eventName === "execution_start" && executionStartMs === null) {
+      executionStartMs = timestamp;
+    } else if (eventName === "execution_success" && executionSuccessMs === null) {
+      executionSuccessMs = timestamp;
+    }
+  }
+
+  if (executionStartMs === null || executionSuccessMs === null) {
+    return emptyServerPhases();
+  }
+
+  return {
+    queueWaitMs: nonNegativeDifference(executionStartMs, submittedAtMs),
+    executeMs: nonNegativeDifference(executionSuccessMs, executionStartMs),
+    pollOvershootMs: nonNegativeDifference(observedCompleteAtMs, executionSuccessMs)
+  };
+}
+
+export function aggregateCycles(samples: readonly LiveCycleSample[]): LiveCycleAggregate {
+  const phases = {} as Record<LivePhaseId, LiveDurationAggregate>;
+
+  for (const phaseId of LIVE_PHASE_IDS) {
+    const durations: number[] = [];
+
+    for (const sample of samples) {
+      const duration = sample.phases[phaseId];
+      if (duration !== null && duration !== undefined) {
+        durations.push(duration);
+      }
+    }
+
+    phases[phaseId] = aggregateDurations(durations);
+  }
+
+  return {
+    phases,
+    totalMs: aggregateDurations(samples.map((sample) => sample.totalMs))
+  };
+}
+
+export function formatCycleLine(sample: LiveCycleSample): string {
+  const summary = summariseCycle(sample);
+  const fields = [
+    ...LIVE_PHASE_IDS.map(
+      (phaseId) => `${phaseId} ${formatDuration(sample.phases[phaseId])}`
+    ),
+    `total ${formatDuration(sample.totalMs)}`,
+    `accounted ${formatDuration(summary.accountedMs)}`,
+    `unaccounted ${formatDuration(summary.unaccountedMs)}`,
+    `overAccounted ${summary.overAccounted ? "yes" : "no"}`
+  ];
+
+  if (sample.captureMode !== undefined) {
+    fields.push(`captureMode ${sample.captureMode}`);
+  }
+
+  if (sample.width !== undefined) {
+    fields.push(`width ${sample.width}`);
+  }
+
+  if (sample.height !== undefined) {
+    fields.push(`height ${sample.height}`);
+  }
+
+  return `Cycle ${sample.cycleIndex} (${sample.kind}): ${fields.join(" | ")}`;
+}
+
+export function formatCyclesTable(samples: readonly LiveCycleSample[]): string {
+  const headers = [
+    "cycleIndex",
+    "kind",
+    "captureMode",
+    "width",
+    "height",
+    ...LIVE_PHASE_IDS,
+    "totalMs",
+    "accountedMs",
+    "unaccountedMs",
+    "overAccounted"
+  ];
+  const rows = samples.map((sample) => {
+    const summary = summariseCycle(sample);
+
+    return [
+      String(sample.cycleIndex),
+      sample.kind,
+      sample.captureMode ?? "not reported",
+      formatOptionalNumber(sample.width),
+      formatOptionalNumber(sample.height),
+      ...LIVE_PHASE_IDS.map((phaseId) => formatDuration(sample.phases[phaseId])),
+      formatDuration(sample.totalMs),
+      formatDuration(summary.accountedMs),
+      formatDuration(summary.unaccountedMs),
+      summary.overAccounted ? "yes" : "no"
+    ].join("\t");
+  });
+
+  return [headers.join("\t"), ...rows].join("\n");
+}
+
+function emptyServerPhases(): ServerPhaseDurations {
+  return {
+    queueWaitMs: null,
+    executeMs: null,
+    pollOvershootMs: null
+  };
+}
+
+function readTimestamp(value: unknown): number | null {
+  if (typeof value !== "object" || value === null || !("timestamp" in value)) {
+    return null;
+  }
+
+  const timestamp = value.timestamp;
+  return typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function nonNegativeDifference(laterMs: number, earlierMs: number): number | null {
+  if (!Number.isFinite(laterMs) || !Number.isFinite(earlierMs)) {
+    return null;
+  }
+
+  const difference = laterMs - earlierMs;
+  return difference >= 0 ? difference : null;
+}
+
+function aggregateDurations(durations: readonly number[]): LiveDurationAggregate {
+  if (durations.length === 0) {
+    return { median: null, p90: null, count: 0 };
+  }
+
+  const sorted = [...durations].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+  const p90Index = Math.ceil(sorted.length * 0.9) - 1;
+
+  return {
+    median,
+    p90: sorted[p90Index],
+    count: sorted.length
+  };
+}
+
+function formatDuration(duration: number | null | undefined): string {
+  return duration === null || duration === undefined ? "not reported" : `${duration}ms`;
+}
+
+function formatOptionalNumber(value: number | undefined): string {
+  return value === undefined ? "not reported" : String(value);
+}

--- a/src/ui/tools/livePainting.ts
+++ b/src/ui/tools/livePainting.ts
@@ -11,6 +11,12 @@ import {
 import type { ComfyHistoryItem, ComfyModelInventory, ComfyWorkflow } from "../../comfy/types";
 import type { PhotoshopDocumentIdentity } from "../../photoshop/documentContext";
 import type { LiveCaptureResult } from "../../photoshop/livePaintingCapture";
+import {
+  deriveServerPhases,
+  formatAggregateLine,
+  formatMeasuredCycleLine,
+  type LiveCycleSample
+} from "../livePaintingTimings";
 import { createOpenLayerError, getErrorMessage } from "../../utils/errors";
 
 export type LivePaintingState =
@@ -115,6 +121,13 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 
 type JobKind = "live" | "refine";
 
+type SubmitOutcome = {
+  blob: Blob;
+  submitMs: number;
+  downloadMs: number;
+  serverPhases: ReturnType<typeof deriveServerPhases>;
+};
+
 export class LivePaintingSessionV2 {
   private readonly options: LivePaintingV2Options;
   private readonly callbacks: LivePaintingV2Callbacks;
@@ -129,6 +142,7 @@ export class LivePaintingSessionV2 {
   };
 
   private state: LivePaintingState = "idle";
+  private readonly cycleSamples: LiveCycleSample[] = [];
   private loraName = "";
   private refineGap: string | null = null;
   private registeredEvents: string[] = [];
@@ -237,6 +251,14 @@ export class LivePaintingSessionV2 {
     this.cancelCurrentPrompt();
     this.removeStrokeListeners();
     this.setState("stopped");
+
+    // The medians are the number the optimisation decision gets made from --
+    // a single cycle is noise (the first pays a cold model load) -- so they
+    // are reported once, when the session ends and the sample set is final.
+    if (this.cycleSamples.length > 0) {
+      this.callbacks.onTimings(formatAggregateLine(this.cycleSamples));
+    }
+
     this.callbacks.onStopped(reason);
   }
 
@@ -417,15 +439,16 @@ export class LivePaintingSessionV2 {
     this.liveCycles += 1;
     this.callbacks.onPreviewBlob(result.blob, capture.originatingDocument);
     this.callbacks.onStatus(`Live preview updated (cycle ${this.liveCycles}).`);
-    this.callbacks.onTimings(
-      [
-        `Cycle ${this.liveCycles}:`,
-        `capture ${capturedAt - cycleStart}ms (${capture.mode}, ${capture.width}x${capture.height})`,
-        `upload ${uploadedAt - capturedAt}ms`,
-        `generate ${finishedAt - uploadedAt}ms`,
-        `total ${((finishedAt - cycleStart) / 1000).toFixed(2)}s`
-      ].join(" | ")
-    );
+    this.recordCycleSample({
+      cycleIndex: this.liveCycles,
+      kind: "live",
+      cycleStart,
+      capturedAt,
+      uploadedAt,
+      finishedAt,
+      capture,
+      outcome: result
+    });
     this.setState("listening");
     return true;
   }
@@ -460,7 +483,7 @@ export class LivePaintingSessionV2 {
       height: capture.height
     });
 
-    let result: { blob: Blob } | null;
+    let result: SubmitOutcome | null;
 
     try {
       result = await this.submitAndRetrieve(
@@ -487,17 +510,73 @@ export class LivePaintingSessionV2 {
     this.refineCycles += 1;
     this.callbacks.onRefineResult(result.blob, capture.originatingDocument);
     this.callbacks.onStatus(`Refine result updated (cycle ${this.refineCycles}).`);
-    this.callbacks.onTimings(
-      [
-        `Refine ${this.refineCycles}:`,
-        `capture ${capturedAt - cycleStart}ms (${capture.mode}, ${capture.width}x${capture.height})`,
-        `upload ${uploadedAt - capturedAt}ms`,
-        `generate ${finishedAt - uploadedAt}ms`,
-        `total ${((finishedAt - cycleStart) / 1000).toFixed(2)}s`
-      ].join(" | ")
-    );
+    this.recordCycleSample({
+      cycleIndex: this.refineCycles,
+      kind: "refine",
+      cycleStart,
+      capturedAt,
+      uploadedAt,
+      finishedAt,
+      capture,
+      outcome: result
+    });
     this.setState("refined");
     return true;
+  }
+
+  /**
+   * Turn one cycle's marks into a phase sample.
+   *
+   * `upload.http` currently includes multipart body construction, and
+   * `upload.encodeBody` is therefore left unmeasured rather than guessed at:
+   * splitting them means changing `comfyClient.uploadImage`, which all eight
+   * tools share. If the measurement shows upload is expensive, that split is
+   * the follow-up. `paint` is unmeasured for the same reason -- the blob
+   * becomes visible inside the panel, past this callback.
+   *
+   * Capture phases are read defensively because a capture implementation that
+   * predates the phase field returns undefined here, and a missing measurement
+   * must degrade to "not reported" rather than throw inside the paint loop.
+   */
+  private recordCycleSample(input: {
+    cycleIndex: number;
+    kind: JobKind;
+    cycleStart: number;
+    capturedAt: number;
+    uploadedAt: number;
+    finishedAt: number;
+    capture: LiveCaptureResult;
+    outcome: SubmitOutcome;
+  }) {
+    const capturePhases = input.capture.phases as LiveCaptureResult["phases"] | undefined;
+    const sample: LiveCycleSample = {
+      cycleIndex: input.cycleIndex,
+      kind: input.kind,
+      totalMs: input.finishedAt - input.cycleStart,
+      captureMode: input.capture.mode,
+      width: input.capture.width,
+      height: input.capture.height,
+      phases: {
+        "capture.getPixels": capturePhases?.getPixelsMs ?? null,
+        "capture.toRgba": capturePhases?.toRgbaMs ?? null,
+        "capture.pngEncode": capturePhases?.pngEncodeMs ?? null,
+        "upload.encodeBody": null,
+        "upload.http": input.uploadedAt - input.capturedAt,
+        "submit.http": input.outcome.submitMs,
+        "server.queueWait": input.outcome.serverPhases.queueWaitMs,
+        "server.execute": input.outcome.serverPhases.executeMs,
+        "poll.overshoot": input.outcome.serverPhases.pollOvershootMs,
+        "download.http": input.outcome.downloadMs,
+        paint: null
+      }
+    };
+
+    this.cycleSamples.push(sample);
+    this.callbacks.onTimings(formatMeasuredCycleLine(sample));
+  }
+
+  getCycleSamples(): readonly LiveCycleSample[] {
+    return this.cycleSamples;
   }
 
   private async submitAndRetrieve(
@@ -506,8 +585,10 @@ export class LivePaintingSessionV2 {
     intervalMs: number,
     timeoutMs: number,
     isCancelled: () => boolean
-  ): Promise<{ blob: Blob } | null> {
+  ): Promise<SubmitOutcome | null> {
+    const submitStartedAt = Date.now();
     const promptId = await this.client.submitPrompt(workflow);
+    const submittedAt = Date.now();
 
     if (isCancelled()) {
       this.cancelPrompt(promptId);
@@ -522,6 +603,7 @@ export class LivePaintingSessionV2 {
         timeoutMs,
         isCancelled
       });
+      const observedCompleteAt = Date.now();
 
       if (isCancelled()) {
         this.cancelPrompt(promptId);
@@ -531,13 +613,26 @@ export class LivePaintingSessionV2 {
       const result = await this.client.retrieveFirstOutputImage(promptId, history, {
         preferredNodeId
       });
+      const downloadedAt = Date.now();
 
       if (isCancelled()) {
         this.cancelPrompt(promptId);
         return null;
       }
 
-      return result;
+      return {
+        blob: result.blob,
+        submitMs: submittedAt - submitStartedAt,
+        downloadMs: downloadedAt - observedCompleteAt,
+        // Submission returns once ComfyUI has accepted the prompt, which is the
+        // instant the queue wait starts. Measuring it from before the POST
+        // would count our own request in the server's waiting time.
+        serverPhases: deriveServerPhases(
+          submittedAt,
+          observedCompleteAt,
+          history.status?.messages
+        )
+      };
     } catch (caughtError) {
       if (isCancelled()) {
         this.cancelPrompt(promptId);

--- a/tests/ui/livePaintingTimings.test.ts
+++ b/tests/ui/livePaintingTimings.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateCycles,
+  deriveServerPhases,
+  formatCycleLine,
+  formatCyclesTable,
+  LIVE_PHASE_IDS,
+  summariseCycle,
+  type LiveCycleSample
+} from "../../src/ui/livePaintingTimings";
+
+function sample(
+  totalMs: number,
+  phases: LiveCycleSample["phases"] = {},
+  cycleIndex = 1
+): LiveCycleSample {
+  return {
+    cycleIndex,
+    kind: "live",
+    totalMs,
+    phases
+  };
+}
+
+describe("live painting timing summaries", () => {
+  it("keeps phase IDs in the order used by cycle output", () => {
+    expect(LIVE_PHASE_IDS).toEqual([
+      "capture.getPixels",
+      "capture.toRgba",
+      "capture.pngEncode",
+      "upload.encodeBody",
+      "upload.http",
+      "submit.http",
+      "server.queueWait",
+      "server.execute",
+      "poll.overshoot",
+      "download.http",
+      "paint"
+    ]);
+  });
+
+  it("accounts only measured phases and preserves the exact total", () => {
+    const summary = summariseCycle(sample(50, {
+      "capture.getPixels": 10,
+      "capture.toRgba": null,
+      "capture.pngEncode": 0
+    }));
+
+    expect(summary.accountedMs).toBe(10);
+    expect(summary.unaccountedMs).toBe(40);
+    expect(summary.accountedMs + summary.unaccountedMs).toBe(summary.totalMs);
+    expect(summary.overAccounted).toBe(false);
+    expect(summary.phases["capture.toRgba"]).toBeNull();
+  });
+
+  it("flags overlapping marks and clamps negative unaccounted time", () => {
+    const summary = summariseCycle(sample(10, {
+      "capture.getPixels": 8,
+      "capture.toRgba": 5
+    }));
+
+    expect(summary.accountedMs).toBe(13);
+    expect(summary.unaccountedMs).toBe(0);
+    expect(summary.overAccounted).toBe(true);
+  });
+});
+
+describe("deriveServerPhases", () => {
+  it("derives queue, execution, and polling durations from a real ComfyUI history fixture", () => {
+    const messages = [
+      ["execution_start", { prompt_id: "prompt-1", timestamp: 1785599882955 }],
+      ["execution_cached", { nodes: [], prompt_id: "prompt-1", timestamp: 1785599882959 }],
+      ["execution_success", { prompt_id: "prompt-1", timestamp: 1785599891059 }]
+    ];
+
+    expect(deriveServerPhases(1785599882823, 1785599891349, messages)).toEqual({
+      queueWaitMs: 132,
+      executeMs: 8104,
+      pollOvershootMs: 290
+    });
+  });
+
+  it("ignores unrelated completion events without crashing", () => {
+    const messages = [
+      ["execution_start", { timestamp: 110 }],
+      ["execution_error", { exception_message: "cancelled" }],
+      ["execution_interrupted", null],
+      ["execution_success", { timestamp: 150 }]
+    ];
+
+    expect(deriveServerPhases(100, 170, messages)).toEqual({
+      queueWaitMs: 10,
+      executeMs: 40,
+      pollOvershootMs: 20
+    });
+  });
+
+  it.each([
+    undefined,
+    null,
+    "not an array",
+    {},
+    [],
+    [["execution_start", { timestamp: 110 }]],
+    [["execution_start", { timestamp: "110" }], ["execution_success", { timestamp: 150 }]],
+    [["execution_start"], ["execution_success", { timestamp: 150 }]],
+    [null, 42, {}]
+  ])("returns no measurements for absent or malformed messages %#", (messages) => {
+    expect(deriveServerPhases(100, 170, messages)).toEqual({
+      queueWaitMs: null,
+      executeMs: null,
+      pollOvershootMs: null
+    });
+  });
+
+  it("turns clock-skewed durations into null without discarding valid durations", () => {
+    const messages = [
+      ["execution_start", { timestamp: 90 }],
+      ["execution_success", { timestamp: 80 }]
+    ];
+
+    expect(deriveServerPhases(100, 70, messages)).toEqual({
+      queueWaitMs: null,
+      executeMs: null,
+      pollOvershootMs: null
+    });
+
+    expect(deriveServerPhases(100, 140, [
+      ["execution_start", { timestamp: 90 }],
+      ["execution_success", { timestamp: 130 }]
+    ])).toEqual({
+      queueWaitMs: null,
+      executeMs: 40,
+      pollOvershootMs: 10
+    });
+  });
+});
+
+describe("aggregateCycles", () => {
+  it("calculates odd medians and counts phases measured in only some cycles", () => {
+    const aggregate = aggregateCycles([
+      sample(10, { "capture.getPixels": 1, "capture.toRgba": 2 }, 1),
+      sample(20, { "capture.getPixels": 3 }, 2),
+      sample(30, { "capture.getPixels": 5, "capture.toRgba": 4 }, 3)
+    ]);
+
+    expect(aggregate.totalMs).toEqual({ median: 20, p90: 30, count: 3 });
+    expect(aggregate.phases["capture.getPixels"]).toEqual({ median: 3, p90: 5, count: 3 });
+    expect(aggregate.phases["capture.toRgba"]).toEqual({ median: 3, p90: 4, count: 2 });
+    expect(aggregate.phases["capture.pngEncode"]).toEqual({ median: null, p90: null, count: 0 });
+  });
+
+  it("averages the middle pair for even medians", () => {
+    const aggregate = aggregateCycles([
+      sample(40),
+      sample(10),
+      sample(30),
+      sample(20)
+    ]);
+
+    expect(aggregate.totalMs).toEqual({ median: 25, p90: 40, count: 4 });
+  });
+});
+
+describe("live painting timing formatters", () => {
+  it("renders measured zero separately from an unmeasured phase in a cycle line", () => {
+    const line = formatCycleLine(sample(5, {
+      "capture.getPixels": 0,
+      "capture.toRgba": null
+    }));
+
+    expect(line).toContain("capture.getPixels 0ms");
+    expect(line).toContain("capture.toRgba not reported");
+    expect(line).not.toContain("capture.getPixels not reported");
+    expect(line).not.toContain("capture.toRgba 0ms");
+    expect(line.split("\n")).toHaveLength(1);
+  });
+
+  it("creates a tab-separated multi-line table without conflating zero and missing data", () => {
+    const table = formatCyclesTable([
+      {
+        ...sample(5, { "capture.getPixels": 0, "capture.toRgba": null }),
+        captureMode: "non-modal-scaled",
+        width: 512,
+        height: 256
+      },
+      sample(8, {}, 2)
+    ]);
+    const [headers, firstRow, secondRow] = table.split("\n").map((line) => line.split("\t"));
+    const getPixelsIndex = headers.indexOf("capture.getPixels");
+    const toRgbaIndex = headers.indexOf("capture.toRgba");
+
+    expect(table.split("\n")).toHaveLength(3);
+    expect(firstRow[getPixelsIndex]).toBe("0ms");
+    expect(firstRow[toRgbaIndex]).toBe("not reported");
+    expect(secondRow[getPixelsIndex]).toBe("not reported");
+    expect(firstRow.slice(getPixelsIndex, getPixelsIndex + LIVE_PHASE_IDS.length)).toHaveLength(
+      LIVE_PHASE_IDS.length
+    );
+  });
+});

--- a/tests/ui/livePaintingV2.test.ts
+++ b/tests/ui/livePaintingV2.test.ts
@@ -96,6 +96,7 @@ function createHarness(
     height: Math.max(64, Math.round(maxDimension / 2)),
     mode: "non-modal-scaled" as const,
     captureMs: 1,
+    phases: { getPixelsMs: 2, toRgbaMs: 3, pngEncodeMs: 4 },
     originatingDocument: origin
   }));
   const session = new LivePaintingSessionV2(
@@ -163,9 +164,24 @@ describe("LivePaintingSessionV2", () => {
     expect(harness.session.getState()).toBe("listening");
     expect(harness.capture).toHaveBeenCalledWith(512);
     expect(harness.callbacks.onPreviewBlob).toHaveBeenCalledWith(expect.any(Blob), origin);
-    expect(harness.callbacks.onTimings).toHaveBeenCalledWith(
-      expect.stringMatching(/^Cycle 1: \| capture \d+ms \(non-modal-scaled, 512x256\) \| upload \d+ms \| generate \d+ms \| total \d+\.\d{2}s$/)
-    );
+    // The capture phases come from the stub above, so they pin that the split
+    // capture measurements survive the trip into the sample rather than being
+    // collapsed back into one "capture" number.
+    const timingLine = harness.callbacks.onTimings.mock.calls[0][0] as string;
+
+    expect(timingLine).toMatch(/^Cycle 1 \(live\): /);
+    expect(timingLine).toContain("capture.getPixels 2ms");
+    expect(timingLine).toContain("capture.toRgba 3ms");
+    expect(timingLine).toContain("capture.pngEncode 4ms");
+    expect(timingLine).toContain("unaccounted ");
+    // No assertion on OVER-ACCOUNTED here: the stub reports 9ms of capture
+    // phases inside a cycle that really elapses ~2ms, because a synchronous
+    // fake returns instantly, so this fixture over-accounts by construction.
+    // The flag's actual behaviour is pinned in the timings unit tests.
+    // Phases the live path cannot measure yet must be absent from the line,
+    // never printed as 0ms, which would read as "this phase is instant".
+    expect(timingLine).not.toContain("upload.encodeBody");
+    expect(timingLine).not.toContain("paint ");
     expect(harness.client.pollUntilComplete.mock.calls[0][1]).toMatchObject({
       intervalMs: 250,
       timeoutMs: 120000
@@ -378,6 +394,38 @@ describe("LivePaintingSessionV2", () => {
     poll.resolve(completeHistory);
     await flushAsyncWork();
     expect(harness.callbacks.onPreviewBlob).not.toHaveBeenCalled();
+  });
+
+  it("reports median phase timings when a session with cycles stops", async () => {
+    const harness = createHarness();
+
+    await startAndWaitForLive(harness);
+    harness.session.stop("Done painting.");
+
+    const lines = harness.callbacks.onTimings.mock.calls.map((call) => call[0] as string);
+    const aggregate = lines[lines.length - 1];
+
+    expect(harness.session.getCycleSamples()).toHaveLength(1);
+    expect(aggregate).toContain("1 cycle measured");
+    expect(aggregate).toContain("capture.pngEncode 4ms");
+    // Ordered worst-first, because the point of the summary is to name the
+    // phase worth optimising rather than to list them in pipeline order.
+    expect(aggregate.indexOf("capture.pngEncode")).toBeLessThan(aggregate.indexOf("capture.toRgba"));
+    expect(aggregate).not.toContain("paint");
+  });
+
+  it("reports nothing extra when a session stops without completing a cycle", async () => {
+    const poll = createDeferred<typeof completeHistory>();
+    const harness = createHarness({}, {
+      pollUntilComplete: vi.fn(() => poll.promise)
+    });
+
+    await harness.session.start();
+    await vi.waitFor(() => expect(harness.client.pollUntilComplete).toHaveBeenCalledTimes(1));
+    harness.session.stop("Stopped early.");
+
+    expect(harness.session.getCycleSamples()).toHaveLength(0);
+    expect(harness.callbacks.onTimings).not.toHaveBeenCalled();
   });
 
   it("cancels a prompt ID that arrives after the session has stopped", async () => {


### PR DESCRIPTION
Task 1 of the Live Painting v2 roadmap: **the measurement, before any optimisation.** No behaviour change to what is submitted, captured, or generated.

Two commits, per the two-model protocol — Codex implemented the pure module and capture instrumentation, my review pass wired it up and fixed what the delegation missed.

## Why this before optimising

The panel reports `capture | upload | generate | total`, and two of those three hide the interesting costs:

- **"capture"** bundles `imaging.getPixels` + RGBA conversion + `encodeRgbaPng` — *a pure-JS deflate over roughly a megabyte*.
- **"generate"** bundles ComfyUI queue wait + real server execution + **up to 250ms of poll quantisation** + the history fetch + the image download.

A step-count change (5→1, Hyper-SD, etc.) moves *one* of those and nothing else. Optimising against the current numbers would be guessing.

## What you get

Per cycle, only the phases actually measured, worst first:

```
Cycle 7 (live): server.execute 612ms | capture.pngEncode 88ms | poll.overshoot 41ms | ...
                | unaccounted 12ms | total 806ms
```

On **Stop**, the medians across the whole session — one cycle is noise, since the first pays a cold model load and any cycle can land badly against the poll interval. Painting for a while then pressing Stop is the entire measurement procedure; no new UI was needed, because the timings callback already writes to its own element (**the `renderApp` closure is untouched**).

`deriveServerPhases` reads ComfyUI's history `status.messages` timestamps to separate **queue wait from real execution from poll overshoot** — otherwise unknowable from the client, and the number that decides whether the WebSocket switch is worth doing.

## The zero-versus-null discipline

An unmeasured phase renders `not reported`, **never `0ms`**. This is the `formatBytes(0)` trap from the other direction: there, zero meant "size never published" and leaked into a total where zero meant "nothing left to download". Here, a phase we failed to measure rendering as `0ms` would read as *"this phase is instant"* and aim the optimisation work at the wrong target. Tests assert the two can never print the same.

Reconciliation makes the output trustworthy: `accountedMs + unaccountedMs` always equals `totalMs` exactly, so time no phase explains is visible rather than silently absorbed. Overlapping marks produce `OVER-ACCOUNTED` rather than a negative gap — a broken instrument must announce itself.

## Deliberately not measured

`upload.encodeBody` needs `comfyClient.uploadImage` split, and that method is shared by all eight tools; `paint` happens past the callback, inside the panel. Both report `not reported` rather than a guess. If the measurement shows upload matters, that split is the follow-up.

## Review findings from the delegated work

- **The existing V2 capture stub returned no `phases`, and typecheck did not catch it.** `vi.fn` infers a Mock type loose enough to satisfy the dependency signature, so the newly-required field was unenforced at the only call site that mattered. Stub fixed; capture phases are also read defensively, since a missing measurement must degrade rather than throw inside a paint loop.
- **The over-accounting guard fires in that test and is right to** — a synchronous fake claims 9ms of capture inside a cycle that really elapses ~2ms. That is a fixture property, not a product one, so the test says so instead of pinning either outcome.

## Validation

`npm run typecheck`, `npm test` (**542 passed**, 62 files), `npm run build`, `npx eslint .` — all green, run independently rather than taken from the delegated report.

## Smoke test

This is the one that produces the data we act on next:

1. Open **Live Painting**, start a session with SD 1.5 + LCM at 512.
2. **Paint 20 or so strokes**, pausing briefly between them so each triggers a cycle. Watch the timings line change per cycle.
3. Press **Stop**. The line should show `N cycles measured | median total …` followed by median per phase, worst first.
4. **Screenshot that line** — that is the measurement, and it decides which optimisation is worth building.
5. Confirm no phase reads `0ms` that should read `not reported`, and that `OVER-ACCOUNTED` does *not* appear in a real session.

Also worth confirming nothing regressed: preview still updates per stroke, **Refine Now** still works, and Stop still ends the session cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)