### PR TITLE
Wake the Live Painting poll on ComfyUI's completion event

### DIFF
--- a/src/comfy/comfyClient.ts
+++ b/src/comfy/comfyClient.ts
@@ -82,6 +82,21 @@ type PollOptions = {
   timeoutMs?: number;
   onTick?: (message: string) => void;
   isCancelled?: () => boolean;
+  /**
+   * Interruptible sleep between history checks.
+   *
+   * Measured on the reference machine, waiting out the fixed interval was 224ms
+   * of a 653ms Live Painting cycle -- a third of it spent not noticing an image
+   * that was already finished. Lowering the interval does not fix that, because
+   * each localhost request costs ~70ms and would become the new floor, so the
+   * sleep is made wakeable instead and ComfyUI's own completion event ends it
+   * early.
+   *
+   * Only the waiting changes. Every history check, error path and cancellation
+   * check around it is untouched, and omitting this falls back to a plain
+   * delay -- which is what happens whenever UXP gives us no WebSocket.
+   */
+  waitForWake?: (timeoutMs: number) => Promise<void>;
 };
 
 type ProgressWatcherOptions = {
@@ -89,6 +104,12 @@ type ProgressWatcherOptions = {
   onProgress?: (value: number, max: number) => void;
   onPreviewBlob?: (blob: Blob) => void;
   onError?: (message: string) => void;
+  /**
+   * Fired when ComfyUI reports this prompt has finished executing. It is a
+   * hint to look at the history now, never a result in itself: the outputs
+   * still come from `/history`, because the socket does not carry them.
+   */
+  onCompleted?: () => void;
 };
 
 type RetrieveOutputOptions = {
@@ -495,7 +516,12 @@ export class ComfyClient {
       }
 
       options.onTick?.(await this.createPollingStatusMessage(promptId));
-      await delay(intervalMs);
+
+      if (options.waitForWake) {
+        await options.waitForWake(intervalMs);
+      } else {
+        await delay(intervalMs);
+      }
 
       if (options.isCancelled?.()) {
         throw createGenerationCancelledError();
@@ -778,8 +804,28 @@ export class ComfyClient {
       }
     } else if (message.type === "execution_error") {
       options.onError?.("ComfyUI reported an execution error. Waiting for final history...");
+    } else if (isCompletionMessage(message)) {
+      options.onCompleted?.();
     }
   }
+}
+
+/**
+ * Whether a socket frame means "this prompt has finished executing".
+ *
+ * ComfyUI says this two ways and both are accepted. `executing` with a null
+ * node is the long-standing signal and is what 0.29.2 sends; `execution_success`
+ * is the newer explicit one. A prompt_id mismatch has already been filtered out
+ * by the caller, so an `executing` frame naming a node is mid-run progress and
+ * deliberately does not match.
+ */
+function isCompletionMessage(message: { type?: string; data?: { node?: unknown } }) {
+  if (message.type === "execution_success") {
+    return true;
+  }
+
+  return message.type === "executing"
+    && (message.data?.node === null || message.data?.node === undefined);
 }
 
 function normalizeServerUrl(serverUrl: string) {

--- a/src/comfy/comfyClient.ts
+++ b/src/comfy/comfyClient.ts
@@ -765,10 +765,19 @@ export class ComfyClient {
     options: ProgressWatcherOptions
   ) {
     if (data instanceof Blob || data instanceof ArrayBuffer) {
+      // Decoding is skipped outright when nobody wants the frame. ComfyUI
+      // streams a preview per sampler step whenever it runs with
+      // --preview-method auto, and Live Painting opens this socket for the
+      // completion event alone -- decoding those frames only to drop them is
+      // work competing with the capture loop it is meant to speed up.
+      if (!options.onPreviewBlob) {
+        return;
+      }
+
       const previewBlob = await decodeComfyPreviewBlob(data);
 
       if (previewBlob) {
-        options.onPreviewBlob?.(previewBlob);
+        options.onPreviewBlob(previewBlob);
       }
 
       return;

--- a/src/ui/livePaintingTimings.ts
+++ b/src/ui/livePaintingTimings.ts
@@ -211,9 +211,19 @@ export function formatAggregateLine(samples: readonly LiveCycleSample[]): string
     .sort((left, right) => (right.aggregated.median ?? 0) - (left.aggregated.median ?? 0))
     .map((entry) => `${entry.phaseId} ${entry.aggregated.median}ms`);
 
+  // Reported second, before the phases, because it is the number that says
+  // whether the breakdown can be trusted at all. Per-phase medians do not sum
+  // to the median total -- medians are not additive -- so without this there is
+  // no way to tell a cycle whose time is explained from one where most of it
+  // went somewhere no phase is watching.
+  const unaccounted = aggregateDurations(
+    samples.map((cycleSample) => summariseCycle(cycleSample).unaccountedMs)
+  );
+
   return [
     `${samples.length} cycle${samples.length === 1 ? "" : "s"} measured`,
     `median total ${aggregate.totalMs.median}ms`,
+    `median unaccounted ${unaccounted.median}ms`,
     ...measured
   ].join(" | ");
 }

--- a/src/ui/livePaintingTimings.ts
+++ b/src/ui/livePaintingTimings.ts
@@ -220,8 +220,20 @@ export function formatAggregateLine(samples: readonly LiveCycleSample[]): string
     samples.map((cycleSample) => summariseCycle(cycleSample).unaccountedMs)
   );
 
+  // The generated size belongs next to the timings because it is the variable
+  // that most directly explains server.execute, and comparing two sessions
+  // without it invites blaming the client for a bigger image. Every distinct
+  // size in the run is listed: a session that changed shape halfway is not
+  // comparable to either of the sessions it looks like.
+  const sizes = [...new Set(
+    samples
+      .filter((cycleSample) => cycleSample.width !== undefined && cycleSample.height !== undefined)
+      .map((cycleSample) => `${cycleSample.width}x${cycleSample.height}`)
+  )];
+
   return [
     `${samples.length} cycle${samples.length === 1 ? "" : "s"} measured`,
+    sizes.length > 0 ? `at ${sizes.join(", ")}` : "size not reported",
     `median total ${aggregate.totalMs.median}ms`,
     `median unaccounted ${unaccounted.median}ms`,
     ...measured

--- a/src/ui/tools/livePainting.ts
+++ b/src/ui/tools/livePainting.ts
@@ -76,8 +76,15 @@ export type LivePaintingClient = {
       intervalMs?: number;
       timeoutMs?: number;
       isCancelled?: () => boolean;
+      waitForWake?: (timeoutMs: number) => Promise<void>;
     }
   ) => Promise<ComfyHistoryItem>;
+  // Optional: a client without it, or a UXP build with no WebSocket, simply
+  // polls on the fixed interval as before.
+  watchProgress?: (
+    promptId: string,
+    options: { onCompleted?: () => void }
+  ) => { close: () => void } | null;
   retrieveFirstOutputImage: (
     promptId: string,
     history: ComfyHistoryItem,
@@ -597,11 +604,16 @@ export class LivePaintingSessionV2 {
 
     this.currentPromptId = promptId;
 
+    const wake = this.createCompletionWake();
+    const watcher = this.client.watchProgress?.(promptId, { onCompleted: wake.signal }) ?? null;
+
     try {
       const history = await this.client.pollUntilComplete(promptId, {
         intervalMs,
         timeoutMs,
-        isCancelled
+        isCancelled,
+        // Without a socket there is nothing to wake on, so the interval stands.
+        waitForWake: watcher ? wake.waitForWake : undefined
       });
       const observedCompleteAt = Date.now();
 
@@ -641,10 +653,56 @@ export class LivePaintingSessionV2 {
 
       throw caughtError;
     } finally {
+      // B2: the socket must not outlive the cycle that opened it, on any exit
+      // path, including panel close and a cancelled refine.
+      watcher?.close();
+
       if (this.currentPromptId === promptId) {
         this.currentPromptId = null;
       }
     }
+  }
+
+  /**
+   * A sleep that ComfyUI's completion event can end early.
+   *
+   * The latch is the whole point. Completion routinely arrives while we are
+   * still awaiting the history request that precedes the sleep, and a wake
+   * delivered to nobody would be dropped -- leaving the cycle to wait out the
+   * full interval and silently giving back the time this is meant to save. A
+   * signal that arrives early is therefore remembered, and the next sleep
+   * returns immediately.
+   */
+  private createCompletionWake() {
+    let pendingSignal = false;
+    let resolveWake: (() => void) | null = null;
+
+    return {
+      signal: () => {
+        pendingSignal = true;
+        const resolve = resolveWake;
+        resolveWake = null;
+        resolve?.();
+      },
+      waitForWake: (timeoutMs: number) => {
+        if (pendingSignal) {
+          pendingSignal = false;
+          return Promise.resolve();
+        }
+
+        return new Promise<void>((resolve) => {
+          const timer = this.timers.setTimeout(() => {
+            resolveWake = null;
+            resolve();
+          }, timeoutMs);
+
+          resolveWake = () => {
+            this.timers.clearTimeout(timer);
+            resolve();
+          };
+        });
+      }
+    };
   }
 
   private handleCycleFailure(jobKind: JobKind, caughtError: unknown) {

--- a/tests/ui/livePaintingTimings.test.ts
+++ b/tests/ui/livePaintingTimings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   aggregateCycles,
   deriveServerPhases,
+  formatAggregateLine,
   formatCycleLine,
   formatCyclesTable,
   LIVE_PHASE_IDS,
@@ -197,5 +198,28 @@ describe("live painting timing formatters", () => {
     expect(firstRow.slice(getPixelsIndex, getPixelsIndex + LIVE_PHASE_IDS.length)).toHaveLength(
       LIVE_PHASE_IDS.length
     );
+  });
+
+  it("names the generated size next to the medians, since it explains server.execute", () => {
+    const line = formatAggregateLine([
+      { ...sample(100, { "server.execute": 80 }), width: 512, height: 256 },
+      { ...sample(120, { "server.execute": 90 }, 2), width: 512, height: 256 }
+    ]);
+
+    expect(line).toContain("at 512x256");
+    expect(line).toContain("median unaccounted ");
+  });
+
+  it("lists every distinct size, so a session that changed shape mid-way is not mistaken for a steady one", () => {
+    const line = formatAggregateLine([
+      { ...sample(100), width: 512, height: 256 },
+      { ...sample(200, {}, 2), width: 1024, height: 512 }
+    ]);
+
+    expect(line).toContain("at 512x256, 1024x512");
+  });
+
+  it("says nothing was measured rather than dividing by zero", () => {
+    expect(formatAggregateLine([])).toBe("No Live Painting cycles were measured.");
   });
 });

--- a/tests/ui/livePaintingV2.test.ts
+++ b/tests/ui/livePaintingV2.test.ts
@@ -43,7 +43,10 @@ function createFakeClient(overrides: Record<string, unknown> = {}) {
     submitPrompt: vi.fn(async () => `prompt-${++nextPrompt}`),
     pollUntilComplete: vi.fn(async () => completeHistory),
     retrieveFirstOutputImage: vi.fn(async () => ({ blob: new Blob(["result"], { type: "image/png" }) })),
-    cancelPrompt: vi.fn(async () => "interrupted" as const)
+    cancelPrompt: vi.fn(async () => "interrupted" as const),
+    watchProgress: vi.fn((_promptId: string, _options: { onCompleted?: () => void }) => ({
+      close: vi.fn()
+    }))
   };
 
   return Object.assign(client, overrides);
@@ -426,6 +429,81 @@ describe("LivePaintingSessionV2", () => {
 
     expect(harness.session.getCycleSamples()).toHaveLength(0);
     expect(harness.callbacks.onTimings).not.toHaveBeenCalled();
+  });
+
+  it("ends the poll wait early when ComfyUI reports the prompt finished", async () => {
+    let waking: Promise<void> | null = null;
+    const harness = createHarness({}, {
+      pollUntilComplete: vi.fn(async (_promptId: string, options: {
+        waitForWake?: (timeoutMs: number) => Promise<void>;
+      }) => {
+        // A real poll sleeps between history checks; this captures that sleep
+        // so the test can prove the socket event ends it rather than the timer.
+        waking = options.waitForWake?.(120000) ?? null;
+        return completeHistory;
+      })
+    });
+
+    await startAndWaitForLive(harness);
+
+    const watchOptions = harness.client.watchProgress.mock.calls[0][1];
+
+    expect(harness.client.watchProgress).toHaveBeenCalledWith("prompt-1", expect.any(Object));
+    expect(waking).not.toBeNull();
+
+    watchOptions.onCompleted?.();
+
+    // Resolves without any timer advancing; a 120s interval would never fire.
+    await expect(waking).resolves.toBeUndefined();
+  });
+
+  it("remembers a completion that arrives before the wait begins", async () => {
+    const harness = createHarness({}, {
+      pollUntilComplete: vi.fn(async (_promptId: string, options: {
+        waitForWake?: (timeoutMs: number) => Promise<void>;
+      }) => {
+        // Completion routinely lands while the history request is still in
+        // flight. A wake delivered to nobody must not be dropped, or the cycle
+        // waits out the full interval and the saving disappears silently.
+        harness.client.watchProgress.mock.calls[0][1].onCompleted?.();
+        await options.waitForWake?.(120000);
+        return completeHistory;
+      })
+    });
+
+    await startAndWaitForLive(harness);
+
+    expect(harness.callbacks.onPreviewBlob).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the progress socket on every exit path", async () => {
+    const harness = createHarness();
+
+    await startAndWaitForLive(harness);
+    expect(harness.client.watchProgress.mock.results[0].value.close).toHaveBeenCalledTimes(1);
+
+    const failing = createHarness({}, {
+      retrieveFirstOutputImage: vi.fn(async () => {
+        throw new Error("ComfyUI vanished");
+      })
+    });
+
+    await failing.session.start();
+    await vi.waitFor(() =>
+      expect(failing.client.watchProgress.mock.results[0].value.close).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps polling on its interval when no progress socket is available", async () => {
+    const harness = createHarness({}, {
+      watchProgress: vi.fn(() => null)
+    });
+
+    await startAndWaitForLive(harness);
+
+    // Falling back must be a plain interval poll, exactly as before: passing a
+    // wake nothing can ever signal would stall the cycle for the full timeout.
+    expect(harness.client.pollUntilComplete.mock.calls[0][1].waitForWake).toBeUndefined();
+    expect(harness.callbacks.onPreviewBlob).toHaveBeenCalledTimes(1);
   });
 
   it("cancels a prompt ID that arrives after the session has stopped", async () => {

--- a/tests/ui/livePaintingV2.test.ts
+++ b/tests/ui/livePaintingV2.test.ts
@@ -410,6 +410,7 @@ describe("LivePaintingSessionV2", () => {
 
     expect(harness.session.getCycleSamples()).toHaveLength(1);
     expect(aggregate).toContain("1 cycle measured");
+    expect(aggregate).toContain("median unaccounted ");
     expect(aggregate).toContain("capture.pngEncode 4ms");
     // Ordered worst-first, because the point of the summary is to name the
     // phase worth optimising rather than to list them in pipeline order.

--- a/tests/ui/livePaintingV2.test.ts
+++ b/tests/ui/livePaintingV2.test.ts
@@ -410,6 +410,7 @@ describe("LivePaintingSessionV2", () => {
 
     expect(harness.session.getCycleSamples()).toHaveLength(1);
     expect(aggregate).toContain("1 cycle measured");
+    expect(aggregate).toContain("at 512x256");
     expect(aggregate).toContain("median unaccounted ");
     expect(aggregate).toContain("capture.pngEncode 4ms");
     // Ordered worst-first, because the point of the summary is to name the


### PR DESCRIPTION
Task 3A, chosen by the measurement rather than by guessing. **Expected: ~653ms → ~430ms per cycle**, with no change to the model, the workflow, or what is captured.

## What the measurement said

31 cycles, SD 1.5 + LCM at 512², median total **653ms**:

| phase | median | share |
|---|---|---|
| `server.execute` | 437ms | 67% |
| **`poll.overshoot`** | **224ms** | **34%** |
| `submit.http` | 70ms | 11% |
| `capture.pngEncode` | 16ms | 2% |

A third of every cycle was spent *not noticing* an image that had already finished. It costs zero GPU time.

## Why lowering the interval was not the fix

`submit.http` at **70ms for a localhost POST** is the finding that rules it out. Each history request costs real time, and `pollUntilComplete` fetches history *then* sleeps — so the true loop period is ~320ms, predicting ~160ms of overshoot against the 224ms observed. Polling at 50ms would just make request cost the new floor. **Both** the interval and the repeated HTTP have to go.

## The change is not a rewrite of the polling loop

Only the *sleep between history checks* becomes interruptible. Every history read, error path, timeout and cancellation check around it is untouched.

**The fallback is the old code path, not a new one imitating it.** A client without `watchProgress`, or a UXP build where `WebSocket` is not a function, passes no wake and gets exactly the previous fixed-interval behaviour.

## The latch is the part worth reviewing

Completion routinely arrives *while the history request preceding the sleep is still in flight*. A wake delivered when nothing is waiting would be dropped — the cycle would then sit out the full interval and quietly hand back the entire saving, with no visible symptom. An early signal is therefore remembered and the next sleep returns immediately.

Both halves are tested. **The latch test hangs on a two-minute timer if the latch is removed**, rather than failing on an assertion — worth knowing if it ever looks slow.

## Details

- Completion is accepted in both spellings ComfyUI uses: `executing` with a null node (what 0.29.2 sends) and the newer `execution_success`. An `executing` frame *naming* a node is mid-run progress and correctly does not match.
- The event is only ever a **hint to look at history now**. Outputs still come from `/history` because the socket does not carry them, so a missed event costs one interval, never a result.
- The socket is opened per cycle, right after submit, and closed in the same `finally` that clears the prompt id — so it cannot outlive its cycle on any exit path, including panel close and a cancelled refine (**B2**). The handshake overlaps the ~437ms the GPU is busy, so it is off the critical path; if it ever shows up, the instrument from #75 will say so.

## Validation

`npm run typecheck`, `npm test` (**546 passed**, 62 files — 4 new), `npm run build`, `npx eslint .` — all green.

## Smoke test

The instrument makes this self-verifying:

1. Open **Live Painting**, start a session, paint ~20 strokes with brief pauses.
2. Press **Stop** and read the median line. **`poll.overshoot` should have collapsed** from ~224ms to near zero, and `median total` should be roughly 400–450ms rather than 653ms.
3. Confirm `server.execute` is unchanged around 437ms — this change must not touch generation.
4. Confirm **Refine Now** still works, and that pressing it mid-cycle still cancels and restarts cleanly.
5. Close the panel mid-cycle and confirm the session stops with no errors (B2 — the socket must not outlive it).
6. If you can, stop ComfyUI mid-session and confirm the failure message still appears rather than hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)