### PR TITLE
Build a .ccx alongside the plugin zip, and ask whether it installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,30 @@ This creates a zip package from `dist` in the `packages` folder. For the current
 packages/openlayer-v0.12.0-alpha.zip
 ```
 
+`npm run package` also writes `packages/openlayer-v0.12.0-alpha.ccx` beside it, from the same files.
+
+## Trying the one-click install (unverified — please report either way)
+
+Every release also attaches a `.ccx`. In principle Creative Cloud installs one by double-click, with
+no UXP Developer Tool and no developer mode — which is the difference between "install a developer
+tool first" and "double-click this".
+
+**Nobody knows whether it works.** A `.ccx` for this plugin is an ordinary zip with no signature
+(`docs/DISTRIBUTION_SPIKE.md`, Finding 1), so whether it installs depends on whether Creative Cloud's
+installer agent accepts an unsigned non-Marketplace package. Answering that needs a machine that has
+**never** had the UXP Developer Tool installed, and the author does not have one — so this ships
+untested on purpose rather than staying unbuilt for another release.
+
+If you have such a machine, this is the single most useful ten minutes anyone could give the project:
+
+1. Download `openlayer-vX.Y.Z-alpha.ccx` and double-click it.
+2. Report exactly what happens, including the boring outcomes:
+   - Creative Cloud installs it → open Photoshop, check **Plugins > OpenLayer** appears and renders.
+   - An error dialog → copy the **exact** text, including any error code.
+   - Nothing happens, or Windows asks which app should open the file → that is a real answer too.
+
+If it fails, use the UXP Developer Tool route below; it is the supported path and is unaffected.
+
 ## Loading In UXP Developer Tool
 
 1. Open Adobe UXP Developer Tool.

--- a/docs/DISTRIBUTION_SPIKE.md
+++ b/docs/DISTRIBUTION_SPIKE.md
@@ -1,7 +1,21 @@
 # CCX Distribution Spike
 
-Status: **three candidate packages built; the install question is unanswered and only Mehran can answer it.**
+Status: **`.ccx` generation is now automated and shipped; the install question is still unanswered
+and still needs a clean machine.**
 Written 2026-07-24 against `main` at v0.6.0. Read `docs/ORCHESTRATION.md` first.
+
+> **Update 2026-08-01 — the gate at the bottom of this document was reversed, deliberately.**
+> This spike ended by saying `.ccx` generation was gated on the install answer, "because building it
+> before the gate would be building on a guess". That reasoning has been inverted for one reason:
+> the question stayed open across v0.10, v0.11 and v0.12 because **nobody ever had an artifact to
+> hand to someone with a clean machine.** Finding 1 says the archive is a plain zip with no signing
+> step, so producing it costs nothing and risks nothing, and a GitHub Release asset can be added to
+> a published release at any time.
+>
+> `npm run package` now emits `openlayer-vX.Y.Z-alpha.ccx` beside the plugin zip, built from the
+> same entries with the manifest transform in `scripts/lib/ccxManifest.mjs`. What remains gated is
+> any *claim* that it installs — the README and release notes ask people to try it and report back,
+> and promise nothing.
 
 > **Update 2026-07-31.** Finding 2 was re-verified against the current release and is **live, not a
 > v0.6.0 curiosity**: `openlayer-v0.9.0-alpha.zip`, the file testers download today, stores 44 of its
@@ -136,3 +150,15 @@ hand-rolled zip is equivalent, and `renamedzip` tests whether the separator bug 
 
 No changes to `scripts/package.mjs`, no `.ccx` npm script, no release-workflow changes. All of that
 is gated on the answer above, and building it before the gate would be building on a guess.
+
+**Superseded 2026-08-01 — see the update at the top.** The packaging half is done:
+`scripts/package.mjs` writes a `.ccx` from the same entries as the plugin zip, and
+`scripts/lib/ccxManifest.mjs` applies the one content difference Finding 1 measured against Adobe's
+own output (`host` narrowed from a single-element array to an object). It is written directly rather
+than through `uxp plugin package`, because that CLI talks to the UXP Developer Tool Service on port
+14001 and would make UDT a build dependency — Finding 1 says the direct write produces the same
+artifact.
+
+The install question itself is untouched by that and is still the only thing that matters here. The
+current artifact to test is `openlayer-v0.12.0-alpha.ccx` from the GitHub Release, and the
+click-path above applies to it unchanged.

--- a/scripts/lib/ccxManifest.mjs
+++ b/scripts/lib/ccxManifest.mjs
@@ -1,0 +1,53 @@
+/**
+ * Manifest transform for `.ccx` packaging.
+ *
+ * `docs/DISTRIBUTION_SPIKE.md` Finding 1 compared a `.ccx` produced by Adobe's
+ * own `uxp plugin package` CLI against a hand-rolled zip of the same `dist/`.
+ * They were the same archive -- no signature file, no extra metadata, 42
+ * entries either way -- with exactly one difference in content: the packager
+ * rewrites `host` from this repo's array form to a single object when it
+ * packages for one target app.
+ *
+ *   source: "host": [{ "app": "PS", "minVersion": "25.0.0" }]
+ *   packed: "host": { "app": "PS", "minVersion": "25.0.0" }
+ *
+ * Both forms are valid in a source manifest, so this is not a bug fix. It is
+ * matched because the open question is whether Creative Cloud's installer
+ * agent will accept an unsigned third-party package at all, and the only way
+ * to get a clean answer is to differ from Adobe's own output in as few ways as
+ * possible. If the install fails while the archive is byte-comparable to a
+ * packager-built one, the answer is about trust policy rather than about
+ * anything this repo controls.
+ */
+
+/**
+ * Narrow a UXP manifest's `host` to the single-object form, when it is
+ * unambiguous to do so.
+ *
+ * An array of two or more hosts is left exactly as it is: narrowing it would
+ * mean choosing which app the package targets, and silently dropping the
+ * others is a worse outcome than shipping the array form the runtime already
+ * accepts. This project declares only Photoshop, so the multi-host branch is
+ * defensive rather than exercised.
+ *
+ * @param {string} manifestJson raw contents of manifest.json
+ * @returns {{ json: string, narrowed: boolean }}
+ */
+export function narrowManifestHostForCcx(manifestJson) {
+  const manifest = JSON.parse(manifestJson);
+
+  if (!Array.isArray(manifest.host) || manifest.host.length !== 1) {
+    return { json: manifestJson, narrowed: false };
+  }
+
+  // Rebuilt rather than mutated in place so key order matches the source
+  // manifest: `host` keeps its original position, which keeps a diff against
+  // the plugin zip's manifest readable.
+  const narrowedManifest = {};
+
+  for (const [key, value] of Object.entries(manifest)) {
+    narrowedManifest[key] = key === "host" ? value[0] : value;
+  }
+
+  return { json: `${JSON.stringify(narrowedManifest, null, 2)}\n`, narrowed: true };
+}

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -2,6 +2,7 @@ import { mkdir, readFile, readdir, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { writeZip } from "./lib/zipWriter.mjs";
+import { narrowManifestHostForCcx } from "./lib/ccxManifest.mjs";
 
 /**
  * Builds the plugin zip that is attached to a GitHub Release and loaded through
@@ -77,3 +78,35 @@ await writeZip(zipPath, entries);
 
 console.log(`Created ${zipPath}`);
 console.log(`  ${entries.length} files`);
+
+/**
+ * The `.ccx` is built from the same entries, because per Finding 1 of
+ * `docs/DISTRIBUTION_SPIKE.md` it is the same archive -- Adobe's own packager
+ * adds no signature and no metadata. It is written directly rather than by
+ * shelling out to `uxp plugin package`, because that CLI talks to the UXP
+ * Developer Tool Service on port 14001 and so would require UDT installed on
+ * whatever machine builds a release.
+ *
+ * Whether a double-click actually installs this on a machine that has never had
+ * UDT is still unanswered and cannot be answered here -- this machine has UDT,
+ * so a success proves nothing. It is built and published anyway: the archive
+ * costs nothing to produce, a release asset can be added at any time, and the
+ * question has stayed open across three releases precisely because nobody had
+ * an artifact to hand someone with a clean machine.
+ */
+const ccxPath = resolve(packagesDir, `openlayer-${releaseLabel}.ccx`);
+const manifestEntry = entries.find((entry) => entry.path === "manifest.json");
+const { json: ccxManifestJson, narrowed } = narrowManifestHostForCcx(
+  manifestEntry.data.toString("utf8")
+);
+const ccxEntries = entries.map((entry) =>
+  entry.path === "manifest.json"
+    ? { path: entry.path, data: Buffer.from(ccxManifestJson, "utf8") }
+    : entry
+);
+
+await rm(ccxPath, { force: true });
+await writeZip(ccxPath, ccxEntries);
+
+console.log(`Created ${ccxPath}`);
+console.log(`  ${ccxEntries.length} files${narrowed ? ", host narrowed to a single object" : ""}`);

--- a/tests/scripts/ccxManifest.test.ts
+++ b/tests/scripts/ccxManifest.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+// @ts-expect-error -- scripts/ is plain .mjs and sits outside the tsconfig `include`.
+import { narrowManifestHostForCcx } from "../../scripts/lib/ccxManifest.mjs";
+
+describe("narrowManifestHostForCcx", () => {
+  it("rewrites a single-host array to the object form Adobe's packager emits", () => {
+    const { json, narrowed } = narrowManifestHostForCcx(
+      JSON.stringify({
+        id: "com.openlayer.photoshop",
+        host: [{ app: "PS", minVersion: "25.0.0" }],
+        main: "index.html"
+      })
+    );
+
+    expect(narrowed).toBe(true);
+    expect(JSON.parse(json).host).toEqual({ app: "PS", minVersion: "25.0.0" });
+  });
+
+  it("keeps every other field and their order untouched", () => {
+    const { json } = narrowManifestHostForCcx(
+      JSON.stringify({
+        manifestVersion: 5,
+        id: "com.openlayer.photoshop",
+        host: [{ app: "PS", minVersion: "25.0.0" }],
+        entrypoints: [{ type: "panel", id: "openlayer.panel" }]
+      })
+    );
+
+    // Key order matters only for keeping a diff against the plugin zip's own
+    // manifest readable, but that is the whole reason the object is rebuilt
+    // rather than mutated, so it is worth pinning.
+    expect(Object.keys(JSON.parse(json))).toEqual([
+      "manifestVersion",
+      "id",
+      "host",
+      "entrypoints"
+    ]);
+    expect(JSON.parse(json).entrypoints).toEqual([{ type: "panel", id: "openlayer.panel" }]);
+  });
+
+  it("leaves a multi-host array alone rather than choosing a target app", () => {
+    const source = JSON.stringify({
+      host: [
+        { app: "PS", minVersion: "25.0.0" },
+        { app: "ID", minVersion: "18.0.0" }
+      ]
+    });
+    const { json, narrowed } = narrowManifestHostForCcx(source);
+
+    expect(narrowed).toBe(false);
+    expect(json).toBe(source);
+  });
+
+  it("leaves an already-narrowed host alone, so packaging stays idempotent", () => {
+    const source = JSON.stringify({ host: { app: "PS", minVersion: "25.0.0" } });
+    const { json, narrowed } = narrowManifestHostForCcx(source);
+
+    expect(narrowed).toBe(false);
+    expect(json).toBe(source);
+  });
+
+  it("narrows this repo's real manifest, which is the only one that ships", async () => {
+    const manifestPath = resolve(__dirname, "../../src/manifest.json");
+    const { json, narrowed } = narrowManifestHostForCcx(await readFile(manifestPath, "utf8"));
+    const manifest = JSON.parse(json);
+
+    expect(narrowed).toBe(true);
+    expect(manifest.host).toEqual({ app: "PS", minVersion: "25.0.0" });
+    // A .ccx whose manifest lost its entrypoints installs and then does nothing,
+    // which is the failure that would be hardest to diagnose remotely.
+    expect(Array.isArray(manifest.entrypoints)).toBe(true);
+    expect(manifest.entrypoints.length).toBeGreaterThan(0);
+    expect(manifest.id).toBe("com.openlayer.photoshop");
+  });
+});


### PR DESCRIPTION
Twelve releases, zero tester feedback. There is exactly one documented hard barrier at step one: **you must install Adobe UXP Developer Tool before OpenLayer runs at all.** This builds the artifact that might remove it.

## Why now, when the spike said to wait

`docs/DISTRIBUTION_SPIKE.md` ended by gating `.ccx` generation on the install question, because building first "would be building on a guess". That gate has now held across **v0.10, v0.11 and v0.12** — and not because the work is hard. It held because answering the question needs a machine that has never had UDT installed, nobody on the project has one, **so the artifact was never built and therefore never handed to anyone who does.**

Finding 1 of that same spike is what inverts the reasoning: a `.ccx` produced by Adobe's own `uxp plugin package` CLI turned out to be the same archive as a hand-rolled zip — no signature file, no added metadata, same entries — differing only in that the packager narrows `host` from a single-element array to an object.

**There is no signing step to reproduce.** Producing the file costs nothing, and a release asset can be attached to a published release at any time. Not building it has a cost; building it does not.

## What changed

- `npm run package` now writes `openlayer-vX.Y.Z-alpha.ccx` from **the same entry list** as the plugin zip, through **the same spec-correct writer** — so the backslash bug that made nine releases unpackable on macOS cannot reappear in one artifact and not the other.
- Written directly rather than via `uxp plugin package`, because that CLI talks to the UXP Developer Tool Service on port 14001 and would make **UDT a build dependency** on any machine cutting a release. Finding 1 says the direct write produces the same artifact.
- `scripts/lib/ccxManifest.mjs` applies the one content difference, deliberately narrowly: a single-element `host` array becomes an object; a **multi-host array is left alone** rather than silently choosing a target app; an already-narrowed manifest is returned untouched so packaging stays idempotent.

## Verified on the built artifact

| check | result |
|---|---|
| entries | 48, **identical set to the plugin zip** |
| backslash paths | 0 |
| `manifest.json` at root | yes |
| `assets/` directory present | yes |
| `host` form | `{"app":"PS","minVersion":"25.0.0"}` — object, matching Adobe's packager |
| version inside | `0.12.0` |
| entrypoints | 2 (panel + preview) |

## What this does NOT claim

**Nothing here says the install works.** The README section asks for a report and lists the boring outcomes — an error dialog with its exact text, or Windows not knowing what a `.ccx` is — as explicitly useful results, and points at the UXP Developer Tool route as the supported path either way.

## Validation

`npm run typecheck`, `npm test` (**554 passed**, 63 files — 5 new), `npm run build`, `npx eslint .` — all green.

> One aside worth recording: the first test run after adding the new file reported `547 passed, 1 error` with 62 files, then ran clean at 554/63 immediately after and on every run since. That is the same anomaly seen during the v0.11 release, where the error text was never captured. It correlates with a **just-created** test file, which points at a transient file-read/transform race on Windows rather than anything in the tests.

## Smoke test

Local, on your machine (which has UDT, so it cannot answer the real question):

1. `npm run package` and confirm it reports **two** artifacts, the `.ccx` line ending `host narrowed to a single object`.
2. Rename the `.ccx` to `.zip`, unpack it, and confirm `manifest.json` sits at the root beside `assets/`.
3. Confirm the existing UDT flow still works end to end — this must not disturb the supported path.

**The real test needs a clean machine** and is the one that matters. If you know anyone with Photoshop + Creative Cloud who has never enabled developer mode, that ten minutes is worth more than any feature on the roadmap right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)