### PR TITLE
Guide sketches with the literal lineart extractor, not the photo model

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Sketch to Image uses the same Photoshop capture and ComfyUI upload path, then ru
 
 - `epicrealism_naturalSinRC1VAE.safetensors`
 - `control_v11p_sd15_lineart_fp16.safetensors`
-- `LineArtPreprocessor`
+- `LineartStandardPreprocessor`
 - `ControlNetLoader`
 - `ControlNetApplyAdvanced`
 

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -70,7 +70,7 @@ Required ComfyUI setup:
 
 - Checkpoint: `epicrealism_naturalSinRC1VAE.safetensors`
 - ControlNet model: `control_v11p_sd15_lineart_fp16.safetensors`
-- Node classes: `LineArtPreprocessor`, `ControlNetLoader`, and `ControlNetApplyAdvanced`
+- Node classes: `LineartStandardPreprocessor`, `ControlNetLoader`, and `ControlNetApplyAdvanced`
 
 Quick test:
 

--- a/docs/sketch-to-image-linecn.md
+++ b/docs/sketch-to-image-linecn.md
@@ -7,7 +7,7 @@ OpenLayer v0.2.1 added the Sketch to Image screen and capture/import foundation.
 - Checkpoint: `epicrealism_naturalSinRC1VAE.safetensors`
 - ControlNet style: SD 1.5 LineArt
 - ControlNet model: `control_v11p_sd15_lineart_fp16.safetensors`
-- Preprocessor: `LineArtPreprocessor`
+- Preprocessor: `LineartStandardPreprocessor`
 - OpenLayer preset id: `sketch2img-linecn-basic`
 
 ## Workflow File
@@ -27,7 +27,7 @@ The preset requires these ComfyUI node classes:
 - `CheckpointLoaderSimple`
 - `LoadImage`
 - `CLIPTextEncode`
-- `LineArtPreprocessor`
+- `LineartStandardPreprocessor`
 - `ControlNetLoader`
 - `ControlNetApplyAdvanced`
 - `VAEEncode`

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -1231,7 +1231,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
       },
       {
         id: SKETCH2IMG_LINECN_BASIC_NODES.lineArtPreprocessor,
-        classType: "LineArtPreprocessor",
+        classType: "LineartStandardPreprocessor",
         requiredInputs: ["image"]
       },
       {

--- a/src/comfy/setupManifest.ts
+++ b/src/comfy/setupManifest.ts
@@ -27,7 +27,7 @@ import { getModelTargetFolder, getModelTargetPath, getRequiredModelKey, listPres
  * fails that test.
  */
 export const CUSTOM_NODE_PACKAGES: Record<string, { name: string; repoUrl: string }> = {
-  LineArtPreprocessor: {
+  LineartStandardPreprocessor: {
     name: "comfyui_controlnet_aux",
     repoUrl: "https://github.com/Fannovel16/comfyui_controlnet_aux"
   },

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -745,7 +745,7 @@ export function createAppMarkup() {
             </div>
             <div class="source-card-body">
               <span class="source-title" id="sketch-source-title">No source captured</span>
-              <span class="source-card-meta" id="sketch-source-meta">ComfyUI LineArtPreprocessor creates the guide.</span>
+              <span class="source-card-meta" id="sketch-source-meta">ComfyUI Standard Lineart creates the guide.</span>
             </div>
           </div>
         </section>

--- a/src/ui/toolErrorMessages.ts
+++ b/src/ui/toolErrorMessages.ts
@@ -74,7 +74,9 @@ export function getSketchFailureHint(error: unknown) {
   }
 
   if (
-    details.includes("lineartpreprocessor") ||
+    // Matches both the old LineArtPreprocessor and the LineartStandardPreprocessor
+    // now shipped — "lineartpreprocessor" is not a substring of the latter.
+    details.includes("lineart") ||
     details.includes("controlnet") ||
     details.includes("aio aux preprocessor") ||
     details.includes("missing node")
@@ -110,7 +112,9 @@ export function getFriendlySketchErrorMessage(error: unknown) {
   }
 
   if (
-    details.includes("lineartpreprocessor") ||
+    // Matches both the old LineArtPreprocessor and the LineartStandardPreprocessor
+    // now shipped — "lineartpreprocessor" is not a substring of the latter.
+    details.includes("lineart") ||
     details.includes("controlnet") ||
     details.includes("aio aux preprocessor") ||
     details.includes("missing node")

--- a/src/workflows/api/sketch2img-linecn-basic.json
+++ b/src/workflows/api/sketch2img-linecn-basic.json
@@ -45,16 +45,15 @@
   },
   "12": {
     "inputs": {
-      "coarse": "disable",
       "resolution": 512,
       "image": [
         "10",
         0
       ]
     },
-    "class_type": "LineArtPreprocessor",
+    "class_type": "LineartStandardPreprocessor",
     "_meta": {
-      "title": "LineArt Preprocessor"
+      "title": "Standard Lineart Preprocessor"
     }
   },
   "13": {

--- a/src/workflows/source/sketch2img-linecn-basic.workflow.json
+++ b/src/workflows/source/sketch2img-linecn-basic.workflow.json
@@ -272,7 +272,7 @@
     },
     {
       "id": 12,
-      "type": "LineArtPreprocessor",
+      "type": "LineartStandardPreprocessor",
       "pos": [
         482.798828125,
         790
@@ -300,11 +300,11 @@
           ]
         }
       ],
-      "title": "LineArt Preprocessor",
+      "title": "Standard Lineart Preprocessor",
       "properties": {
         "cnr_id": "comfyui_controlnet_aux",
         "ver": "e8b689a513c3e6b63edc44066560ca5919c0576e",
-        "Node name for S&R": "LineArtPreprocessor",
+        "Node name for S&R": "LineartStandardPreprocessor",
         "ue_properties": {
           "widget_ue_connectable": {},
           "input_ue_unconnectable": {},
@@ -312,7 +312,8 @@
         }
       },
       "widgets_values": [
-        "disable",
+        6,
+        8,
         512
       ]
     },

--- a/tests/comfy/workflowCompatibility.test.ts
+++ b/tests/comfy/workflowCompatibility.test.ts
@@ -76,7 +76,7 @@ describe("workflow compatibility", () => {
   it("reports missing ComfyUI node classes without touching ComfyUI", () => {
     const preset = getWorkflowPreset("sketch2img-linecn-basic");
     const availableNodes = createAvailableNodes(preset);
-    delete availableNodes.LineArtPreprocessor;
+    delete availableNodes.LineartStandardPreprocessor;
 
     const result = evaluateWorkflowCompatibility(preset, {
       selectedModelName: "epicrealism_naturalSinRC1VAE.safetensors",

--- a/tests/comfy/workflowDiagnostics.test.ts
+++ b/tests/comfy/workflowDiagnostics.test.ts
@@ -36,7 +36,7 @@ describe("workflow diagnostics", () => {
   it("explains missing ComfyUI setup as setup-required", () => {
     const preset = getWorkflowPreset("sketch2img-linecn-basic");
     const availableNodes = createAvailableNodes(preset);
-    delete availableNodes.LineArtPreprocessor;
+    delete availableNodes.LineartStandardPreprocessor;
 
     const message = createWorkflowDiagnosticMessage(preset, {
       selectedModelName: "epicrealism_naturalSinRC1VAE.safetensors",
@@ -46,7 +46,7 @@ describe("workflow diagnostics", () => {
 
     expect(message.isWarning).toBe(true);
     expect(message.summary).toContain("needs setup");
-    expect(message.detail).toContain("LineArtPreprocessor");
+    expect(message.detail).toContain("LineartStandardPreprocessor");
   });
 
   it("explains missing required model files", () => {

--- a/tests/comfy/workflowFiles.test.ts
+++ b/tests/comfy/workflowFiles.test.ts
@@ -29,7 +29,7 @@ function loadApiWorkflow(preset: WorkflowPresetDefinition): ComfyWorkflow {
 const EXPECTED_CUSTOM_NODE_CLASSES = [
   "Florence2ModelLoader",
   "Florence2Run",
-  "LineArtPreprocessor",
+  "LineartStandardPreprocessor",
   // Flux.2's quantised model. Note only the UNET loader appears: its text
   // encoder is a safetensors file read by core CLIPLoader, so CLIPLoaderGGUF is
   // mapped in the registry but not required by any shipped preset.

--- a/tests/comfy/workflowHealth.test.ts
+++ b/tests/comfy/workflowHealth.test.ts
@@ -117,7 +117,7 @@ describe("workflow health", () => {
   it("reports missing ComfyUI node classes", () => {
     const preset = getWorkflowPreset("sketch2img-linecn-basic");
     const availableNodes = createAvailableNodes(preset);
-    delete availableNodes.LineArtPreprocessor;
+    delete availableNodes.LineartStandardPreprocessor;
 
     const item = createWorkflowHealthItem(preset, {
       availableNodes,
@@ -127,7 +127,7 @@ describe("workflow health", () => {
     });
 
     expect(item.state).toBe("missing-node");
-    expect(item.summary).toContain("LineArtPreprocessor");
+    expect(item.summary).toContain("LineartStandardPreprocessor");
   });
 
   it("keeps enriched setup issues routed to missing-model and missing-node states", () => {

--- a/tests/ui/toolErrorMessages.test.ts
+++ b/tests/ui/toolErrorMessages.test.ts
@@ -45,6 +45,15 @@ describe("hints recognise each tool's characteristic failure", () => {
     expect(hint).toContain("ControlNet");
   });
 
+  // The shipped preset now uses LineartStandardPreprocessor, whose lowercased name
+  // does NOT contain "lineartpreprocessor" — the substring the hint used to match on.
+  it("still recognises the rejection naming the Standard Lineart node we actually ship", () => {
+    const hint = getSketchFailureHint(comfyRejection("LineartStandardPreprocessor node type not found"));
+
+    expect(hint).toContain("LineArt");
+    expect(hint).toContain("ControlNet");
+  });
+
   it("names the whole Flux Fill stack for Outpaint, which is the setup people get wrong", () => {
     const hint = getOutpaintFailureHint(comfyRejection("missing node: ImagePadForOutpaint"));
 


### PR DESCRIPTION
## The defect

`sketch2img-linecn-basic` fed the user's sketch to `LineArtPreprocessor` — a neural net trained to extract line art **from photographs**. Our input is already line art, so the model runs out of distribution and is free to drop and invent strokes.

## Measured, not assumed

Both nodes run on the same 512×512 probe sketch on the live rig (ComfyUI 0.29.2), scored against the pixels actually drawn:

| node | recall | precision | max line value |
|---|---|---|---|
| `LineartStandardPreprocessor` | **100.0%** | **100.0%** | 135 |
| `LineArtPreprocessor` (old) | 90.4% | 94.5% | 246 |

The old node discarded **9.6% of the user's strokes** and emitted **5.5% that were never drawn**. The replacement reproduces the input exactly — 4857 lit pixels for 4857 drawn.

## Why this is cheap

`LineartStandardPreprocessor` ships in the **same already-installed** `comfyui_controlnet_aux` package and is not a neural net — it's a blur-difference edge threshold. No new download, no new dependency.

Preprocessing is **kept, not dropped**: a raw black-on-white Photoshop export still needs inverting to the dark-background/bright-line polarity ControlNet lineart models expect. Verified both nodes produce it (98% of output pixels below luma 32).

## Caught in passing

The setup hint matched on the substring `"lineartpreprocessor"`, which is **not** contained in `"lineartstandardpreprocessor"`. The branch telling people which custom nodes to install would have silently stopped firing. Widened to `"lineart"` and covered with a test that fails on the old matcher.

## One thing to watch in the smoke test

The literal extractor's lines top out at luma **135** vs the AI model's **246** — perfect placement, lower amplitude. It's possible the guide drives ControlNet more weakly at the current `strength: 0.8`. That's a visual judgement I can't make from pixel stats, so it's the thing worth looking at when comparing output images.

## Validation

`npm run typecheck && npm test && npm run build && npx eslint .` — all clean, **555 tests** (554 + the new matcher test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)