### PR TITLE
Spike: can OpenLayer download a model file itself

### DIFF
--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -141,6 +141,12 @@ import {
   importUpscaleResultResizingDocument
 } from "../photoshop/photoshopAdapter";
 import {
+  formatSpikeReport,
+  PROBE_MODELS_FOLDER,
+  runModelDownloadSpike,
+  summarizeSpike
+} from "./spikeModelDownload";
+import {
   createUpscaleResizePlan,
   formatUpscaleScale,
   validateUpscaleResultDimensions
@@ -779,6 +785,7 @@ export function renderApp(rootElement: HTMLElement) {
     checkWorkflowHealth: createActionRunner(elements, "checkWorkflowHealth", handleCheckWorkflowHealth),
     checkSetup: createActionRunner(elements, "checkSetup", handleCheckSetup),
     copyDiagnostics: createActionRunner(elements, "copyDiagnostics", handleCopyDiagnostics),
+    spikeModelDownload: createActionRunner(elements, "spikeModelDownload", handleSpikeModelDownload),
     exportLayerToFile: createActionRunner(elements, "exportLayerToFile", () => handleLayerExport("layer", "file")),
     exportLayerToComfyUI: createActionRunner(elements, "exportLayerToComfyUI", () => handleLayerExport("layer", "comfyui")),
     exportSelectionToFile: createActionRunner(elements, "exportSelectionToFile", () => handleLayerExport("selection", "file")),
@@ -854,6 +861,7 @@ export function renderApp(rootElement: HTMLElement) {
   bindActionControl(elements.checkWorkflowHealthButton, actionHandlers.checkWorkflowHealth);
   bindActionControl(elements.setupCheck, actionHandlers.checkSetup);
   bindActionControl(elements.copyDiagnosticsButton, actionHandlers.copyDiagnostics);
+  bindActionControl(elements.spikeModelDownloadButton, actionHandlers.spikeModelDownload);
   bindActionControl(elements.exportLayerFileButton, actionHandlers.exportLayerToFile);
   bindActionControl(elements.exportLayerComfyButton, actionHandlers.exportLayerToComfyUI);
   bindActionControl(elements.exportSelectionFileButton, actionHandlers.exportSelectionToFile);
@@ -1414,6 +1422,29 @@ export function renderApp(rootElement: HTMLElement) {
     } catch (caughtError) {
       setSetupStatus(elements, `Could not copy to the clipboard. ${getErrorMessage(caughtError)}`, "error");
     }
+  }
+
+  // SPIKE: delete with src/ui/spikeModelDownload.ts and its button.
+  async function handleSpikeModelDownload() {
+    elements.settingsDiagnosticsText.textContent = "Running model download spike...";
+
+    const results = await runModelDownloadSpike({
+      loadUxp: () => require("uxp") as never,
+      loadFs: () => {
+        try {
+          return (require as unknown as (name: string) => unknown)("fs");
+        } catch {
+          return undefined;
+        }
+      },
+      fetch: (...args) => fetch(...args),
+      modelsFolderPath: PROBE_MODELS_FOLDER
+    });
+
+    const report = `${summarizeSpike(results)}\n\n${formatSpikeReport(results)}`;
+    elements.settingsDiagnosticsReport.value = report;
+    elements.settingsDiagnosticsReport.hidden = false;
+    elements.settingsDiagnosticsText.textContent = summarizeSpike(results);
   }
 
   async function handleCopyDiagnostics() {

--- a/src/ui/appBindings.ts
+++ b/src/ui/appBindings.ts
@@ -25,6 +25,8 @@ export type ActionName =
   | "checkWorkflowHealth"
   | "checkSetup"
   | "copyDiagnostics"
+  // SPIKE: delete with src/ui/spikeModelDownload.ts.
+  | "spikeModelDownload"
   | "saveSettings"
   | "resetSettings"
   | "toggleNegativePrompt"

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -83,6 +83,7 @@ export type AppElements = {
   detectHardwareButton: HTMLElement;
   checkWorkflowHealthButton: HTMLElement;
   copyDiagnosticsButton: HTMLElement;
+  spikeModelDownloadButton: HTMLElement;
   saveSettingsButton: HTMLElement;
   resetSettingsButton: HTMLElement;
   generateButton: HTMLElement;
@@ -449,6 +450,8 @@ export function createAppMarkup() {
             <button class="button action-control" id="detect-gpu" data-openlayer-action="detectHardware" type="button">Detect GPU &amp; Recommend Models</button>
             <button class="button action-control" id="check-workflow-health" data-openlayer-action="checkWorkflowHealth" type="button">Check Workflow Health</button>
             <button class="button action-control" id="copy-diagnostics" data-openlayer-action="copyDiagnostics" type="button">Copy Diagnostics</button>
+            <!-- SPIKE, delete with src/ui/spikeModelDownload.ts once model acquisition is decided. -->
+            <button class="button action-control" id="spike-model-download" data-openlayer-action="spikeModelDownload" type="button">Spike: Model Download</button>
             <button class="button action-control" id="save-settings" data-openlayer-action="saveSettings" type="button">Save Settings</button>
             <button class="button action-control" id="reset-settings" data-openlayer-action="resetSettings" type="button">Reset Defaults</button>
           </div>
@@ -1443,6 +1446,7 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     detectHardwareButton: getElement<HTMLElement>(rootElement, "detect-gpu"),
     checkWorkflowHealthButton: getElement<HTMLElement>(rootElement, "check-workflow-health"),
     copyDiagnosticsButton: getElement<HTMLElement>(rootElement, "copy-diagnostics"),
+    spikeModelDownloadButton: getElement<HTMLElement>(rootElement, "spike-model-download"),
     saveSettingsButton: getElement<HTMLElement>(rootElement, "save-settings"),
     resetSettingsButton: getElement<HTMLElement>(rootElement, "reset-settings"),
     generateButton: getElement<HTMLElement>(rootElement, "generate"),

--- a/src/ui/spikeModelDownload.ts
+++ b/src/ui/spikeModelDownload.ts
@@ -1,0 +1,251 @@
+// THIS IS A SPIKE, NOT A FEATURE. It exists to answer whether OpenLayer can
+// download a model file itself, before anything is designed around the answer.
+// The button that calls it is meant to be deleted.
+//
+// Two unknowns block the design:
+//   1. Can UXP write to an arbitrary path (ComfyUI's models folder), or does it
+//      need the artist to pick the folder through a native dialog?
+//   2. Can a multi-gigabyte file reach disk without being buffered in memory?
+//      An 18.7 GiB model cannot be held as a Blob.
+//
+// Unknown 2 has a promising answer that avoids streaming entirely: HuggingFace
+// serves `accept-ranges: bytes`, verified from the command line, so the file can
+// be pulled as bounded ranged chunks and appended. That turns "can fetch
+// stream?" -- reportedly unreliable in UXP -- into "does UXP honour a Range
+// header, and can we append to a file?", which is what probes 4 and 5 ask.
+
+export type ProbeStatus = "pass" | "fail" | "unsupported";
+
+export type ProbeResult = Readonly<{
+  id: string;
+  question: string;
+  status: ProbeStatus;
+  detail: string;
+}>;
+
+// A small, ungated, real file on the same host the registry downloads from, so
+// the network probes exercise the actual CDN path rather than a stand-in.
+export const PROBE_RANGE_URL =
+  "https://huggingface.co/xinsir/controlnet-scribble-sdxl-1.0/resolve/main/diffusion_pytorch_model.safetensors";
+export const PROBE_RANGE_BYTES = 1048576;
+
+// Hardcoded because no setting records where ComfyUI lives yet -- discovering
+// that is part of what a real downloader would have to solve. For the spike it
+// only has to be right on the one machine the probe runs on, and a wrong path
+// reports itself as a failed resolve rather than failing silently.
+export const PROBE_MODELS_FOLDER = "C:/Users/11/pinokio/api/comfyui.git/app/models/upscale_models";
+
+type UxpLike = {
+  storage: {
+    formats: { binary: unknown; utf8?: unknown };
+    localFileSystem: Record<string, unknown>;
+  };
+};
+
+export type SpikeDeps = Readonly<{
+  loadUxp: () => UxpLike;
+  loadFs: () => unknown;
+  fetch: typeof fetch;
+  // Where a real download would have to land. Probed, never written to
+  // permanently -- the spike creates and deletes one small file.
+  modelsFolderPath: string;
+}>;
+
+export async function runModelDownloadSpike(deps: SpikeDeps): Promise<ProbeResult[]> {
+  const results: ProbeResult[] = [];
+  let arbitraryFolder: unknown;
+
+  results.push(await probe(
+    "arbitrary-path",
+    "Can UXP resolve ComfyUI's models folder without a picker?",
+    async () => {
+      const lfs = deps.loadUxp().storage.localFileSystem;
+      const getEntryWithUrl = lfs.getEntryWithUrl as
+        | ((url: string) => Promise<unknown>)
+        | undefined;
+
+      if (typeof getEntryWithUrl !== "function") {
+        return unsupported("localFileSystem.getEntryWithUrl does not exist in this UXP build.");
+      }
+
+      // UXP wants a file: URL. Native Windows separators are normalised so the
+      // probe reports on the path itself, not on our formatting of it.
+      const url = `file:${deps.modelsFolderPath.replace(/\\/g, "/")}`;
+      arbitraryFolder = await getEntryWithUrl(url);
+
+      if (!arbitraryFolder) {
+        return fail(`getEntryWithUrl returned nothing for ${url}`);
+      }
+
+      return pass(`Resolved ${url} with no dialog.`);
+    }
+  ));
+
+  results.push(await probe(
+    "arbitrary-write",
+    "Can it create and delete a file in that folder?",
+    async () => {
+      if (!arbitraryFolder) {
+        return unsupported("Skipped: the folder never resolved, so writing there could not be tried.");
+      }
+
+      const folder = arbitraryFolder as {
+        createFile?: (name: string, options?: { overwrite?: boolean }) => Promise<{
+          write: (data: unknown, options: { format: unknown }) => Promise<void>;
+          delete: () => Promise<void>;
+        }>;
+      };
+
+      if (typeof folder.createFile !== "function") {
+        return unsupported("The resolved entry has no createFile; it may be a file rather than a folder.");
+      }
+
+      const uxp = deps.loadUxp();
+      const file = await folder.createFile("openlayer-write-probe.tmp", { overwrite: true });
+      await file.write(new ArrayBuffer(16), { format: uxp.storage.formats.binary });
+      await file.delete();
+
+      return pass("Created, wrote 16 bytes to, and deleted a probe file.");
+    }
+  ));
+
+  results.push(await probe(
+    "fs-module",
+    "Is a Node-like fs module with file descriptors available?",
+    async () => {
+      const fs = deps.loadFs() as Record<string, unknown> | undefined;
+
+      if (!fs) {
+        return unsupported("require(\"fs\") is not available.");
+      }
+
+      const present = ["open", "write", "close", "appendFile", "writeFile", "lstat"]
+        .filter((name) => typeof fs[name] === "function");
+
+      if (present.length === 0) {
+        return unsupported("An fs module exists but exposes none of the expected methods.");
+      }
+
+      return pass(`fs exposes: ${present.join(", ")}.`);
+    }
+  ));
+
+  results.push(await probe(
+    "append",
+    "Can bytes be appended, so chunks accumulate without buffering the whole file?",
+    async () => {
+      const uxp = deps.loadUxp();
+      const lfs = uxp.storage.localFileSystem as {
+        getTemporaryFolder: () => Promise<{
+          createFile: (name: string, options?: { overwrite?: boolean }) => Promise<{
+            write: (data: unknown, options: Record<string, unknown>) => Promise<void>;
+            read?: (options: Record<string, unknown>) => Promise<ArrayBuffer>;
+            delete: () => Promise<void>;
+          }>;
+        }>;
+      };
+      const folder = await lfs.getTemporaryFolder();
+      const file = await folder.createFile("openlayer-append-probe.bin", { overwrite: true });
+      const chunk = new ArrayBuffer(1024);
+
+      await file.write(chunk, { format: uxp.storage.formats.binary });
+      // "append" is what the docs describe but the published typings omit, so
+      // this is exactly the claim worth testing rather than assuming.
+      await file.write(chunk, { format: uxp.storage.formats.binary, append: true });
+
+      let observed = -1;
+      if (typeof file.read === "function") {
+        const contents = await file.read({ format: uxp.storage.formats.binary });
+        observed = contents.byteLength;
+      }
+
+      await file.delete();
+
+      if (observed === 2048) return pass("Two 1 KiB writes with append:true produced 2048 bytes.");
+      if (observed === 1024) return fail("append:true was ignored -- the second write replaced the first (1024 bytes).");
+      if (observed < 0) return unsupported("Wrote both chunks, but this build cannot read the file back to confirm the size.");
+      return fail(`Two 1 KiB appends produced ${observed} bytes, which is neither 1024 nor 2048.`);
+    }
+  ));
+
+  results.push(await probe(
+    "ranged-fetch",
+    "Does UXP's fetch honour a Range header, so downloads stay bounded and resumable?",
+    async () => {
+      const response = await deps.fetch(PROBE_RANGE_URL, {
+        headers: { Range: `bytes=0-${PROBE_RANGE_BYTES - 1}` }
+      });
+
+      if (response.status !== 206) {
+        return fail(
+          `Expected HTTP 206 Partial Content, got ${response.status}. The whole ${response.headers.get("content-length") ?? "unknown"}-byte file would arrive at once.`
+        );
+      }
+
+      const buffer = await response.arrayBuffer();
+
+      if (buffer.byteLength !== PROBE_RANGE_BYTES) {
+        return fail(`Asked for ${PROBE_RANGE_BYTES} bytes, received ${buffer.byteLength}.`);
+      }
+
+      return pass(`HTTP 206 with exactly ${buffer.byteLength} bytes; ranged download works.`);
+    }
+  ));
+
+  return results;
+}
+
+// Every probe is isolated so one failure reports itself rather than aborting the
+// rest -- a spike that stops at the first problem answers one question instead
+// of five.
+async function probe(
+  id: string,
+  question: string,
+  run: () => Promise<Omit<ProbeResult, "id" | "question">>
+): Promise<ProbeResult> {
+  try {
+    return { id, question, ...(await run()) };
+  } catch (caughtError) {
+    const message = caughtError instanceof Error ? caughtError.message : String(caughtError);
+    return { id, question, status: "fail", detail: `Threw: ${message}` };
+  }
+}
+
+function pass(detail: string) {
+  return { status: "pass" as const, detail };
+}
+
+function fail(detail: string) {
+  return { status: "fail" as const, detail };
+}
+
+function unsupported(detail: string) {
+  return { status: "unsupported" as const, detail };
+}
+
+export function formatSpikeReport(results: readonly ProbeResult[]): string {
+  return results
+    .map((result) => `[${result.status.toUpperCase()}] ${result.question}\n    ${result.detail}`)
+    .join("\n");
+}
+
+// The verdict the spike exists to produce, so the report states a conclusion
+// instead of leaving five facts to be interpreted later.
+export function summarizeSpike(results: readonly ProbeResult[]): string {
+  const byId = new Map(results.map((result) => [result.id, result]));
+  const ok = (id: string) => byId.get(id)?.status === "pass";
+  const canPlaceFiles = ok("arbitrary-path") && ok("arbitrary-write");
+  const canAccumulate = ok("append") || ok("fs-module");
+  const canChunk = ok("ranged-fetch");
+
+  if (canPlaceFiles && canAccumulate && canChunk) {
+    return "FEASIBLE: OpenLayer can write to ComfyUI's models folder, accumulate a file in chunks, and pull bounded ranges. A direct downloader is buildable.";
+  }
+
+  const blockers: string[] = [];
+  if (!canPlaceFiles) blockers.push("no unattended write access to the models folder (a folder picker would be required)");
+  if (!canAccumulate) blockers.push("no way to grow a file incrementally (the whole model would have to fit in memory)");
+  if (!canChunk) blockers.push("no ranged download (the whole file would arrive in one response)");
+
+  return `BLOCKED: ${blockers.join("; ")}.`;
+}

--- a/src/ui/toolDescriptors.ts
+++ b/src/ui/toolDescriptors.ts
@@ -96,6 +96,8 @@ export const BUSY_ALWAYS_DISABLED_ACTIONS: readonly ActionElementKey[] = [
   "detectHardwareButton",
   "checkWorkflowHealthButton",
   "copyDiagnosticsButton",
+  // SPIKE: remove with the spike itself, taking the frozen count back to 35.
+  "spikeModelDownloadButton",
   "saveSettingsButton",
   "resetSettingsButton",
   "generateButton",

--- a/tests/ui/spikeModelDownload.test.ts
+++ b/tests/ui/spikeModelDownload.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatSpikeReport,
+  PROBE_RANGE_BYTES,
+  ProbeResult,
+  runModelDownloadSpike,
+  summarizeSpike
+} from "../../src/ui/spikeModelDownload";
+
+function result(id: string, status: ProbeResult["status"]): ProbeResult {
+  return { id, question: id, status, detail: "" };
+}
+
+describe("spike verdict", () => {
+  const allPassing = [
+    result("arbitrary-path", "pass"),
+    result("arbitrary-write", "pass"),
+    result("fs-module", "pass"),
+    result("append", "pass"),
+    result("ranged-fetch", "pass")
+  ];
+
+  it("calls a direct downloader buildable only when placement, accumulation and chunking all work", () => {
+    expect(summarizeSpike(allPassing)).toContain("FEASIBLE");
+  });
+
+  it("accepts fs as the accumulation route when append is unsupported", () => {
+    const results = allPassing.map((entry) =>
+      entry.id === "append" ? result("append", "unsupported") : entry
+    );
+
+    expect(summarizeSpike(results)).toContain("FEASIBLE");
+  });
+
+  it("blocks when neither append nor fs can grow a file, because the model would have to fit in memory", () => {
+    const results = allPassing.map((entry) =>
+      entry.id === "append" || entry.id === "fs-module"
+        ? result(entry.id, "unsupported")
+        : entry
+    );
+
+    expect(summarizeSpike(results)).toContain("BLOCKED");
+    expect(summarizeSpike(results)).toContain("incrementally");
+  });
+
+  it("names a folder picker as the consequence when the path cannot be resolved unattended", () => {
+    const results = allPassing.map((entry) =>
+      entry.id === "arbitrary-path" ? result("arbitrary-path", "unsupported") : entry
+    );
+
+    expect(summarizeSpike(results)).toContain("folder picker");
+  });
+
+  it("reports every blocker at once rather than only the first", () => {
+    const verdict = summarizeSpike([
+      result("arbitrary-path", "fail"),
+      result("arbitrary-write", "fail"),
+      result("fs-module", "unsupported"),
+      result("append", "fail"),
+      result("ranged-fetch", "fail")
+    ]);
+
+    expect(verdict).toContain("folder picker");
+    expect(verdict).toContain("incrementally");
+    expect(verdict).toContain("ranged download");
+  });
+});
+
+describe("spike probe isolation", () => {
+  // A spike that aborts on the first failure answers one question instead of
+  // five, which defeats the point of running it.
+  it("still reports the later probes when an early one throws", async () => {
+    const results = await runModelDownloadSpike({
+      loadUxp: () => {
+        throw new Error("no uxp here");
+      },
+      loadFs: () => undefined,
+      fetch: (async () => {
+        throw new Error("offline");
+      }) as unknown as typeof fetch,
+      modelsFolderPath: "C:/nowhere"
+    });
+
+    expect(results).toHaveLength(5);
+    expect(results.map((entry) => entry.id)).toEqual([
+      "arbitrary-path",
+      "arbitrary-write",
+      "fs-module",
+      "append",
+      "ranged-fetch"
+    ]);
+    expect(results.every((entry) => entry.status !== "pass")).toBe(true);
+  });
+
+  it("records a thrown error as the detail instead of losing it", async () => {
+    const results = await runModelDownloadSpike({
+      loadUxp: () => {
+        throw new Error("no uxp here");
+      },
+      loadFs: () => undefined,
+      fetch: (async () => {
+        throw new Error("offline");
+      }) as unknown as typeof fetch,
+      modelsFolderPath: "C:/nowhere"
+    });
+
+    expect(results[0].detail).toContain("no uxp here");
+    expect(results[4].detail).toContain("offline");
+  });
+
+  it("fails the range probe when the server ignores the header and returns the whole file", async () => {
+    const results = await runModelDownloadSpike({
+      loadUxp: () => {
+        throw new Error("unused");
+      },
+      loadFs: () => undefined,
+      fetch: (async () => ({
+        status: 200,
+        headers: { get: () => "2502139104" },
+        arrayBuffer: async () => new ArrayBuffer(0)
+      })) as unknown as typeof fetch,
+      modelsFolderPath: "C:/nowhere"
+    });
+
+    const range = results.find((entry) => entry.id === "ranged-fetch");
+    expect(range?.status).toBe("fail");
+    expect(range?.detail).toContain("206");
+  });
+
+  it("fails the range probe when a 206 arrives with the wrong number of bytes", async () => {
+    const results = await runModelDownloadSpike({
+      loadUxp: () => {
+        throw new Error("unused");
+      },
+      loadFs: () => undefined,
+      fetch: (async () => ({
+        status: 206,
+        headers: { get: () => null },
+        arrayBuffer: async () => new ArrayBuffer(PROBE_RANGE_BYTES - 1)
+      })) as unknown as typeof fetch,
+      modelsFolderPath: "C:/nowhere"
+    });
+
+    expect(results.find((entry) => entry.id === "ranged-fetch")?.status).toBe("fail");
+  });
+});
+
+describe("spike report formatting", () => {
+  it("puts the status first so the outcome is readable without parsing the sentence", () => {
+    const report = formatSpikeReport([
+      { id: "a", question: "Can it?", status: "pass", detail: "Yes." }
+    ]);
+
+    expect(report).toContain("[PASS] Can it?");
+    expect(report).toContain("Yes.");
+  });
+});

--- a/tests/ui/toolDescriptors.test.ts
+++ b/tests/ui/toolDescriptors.test.ts
@@ -94,8 +94,9 @@ describe("busy-state tables", () => {
       ...BUSY_GATED_ACTIONS.map(({ button }) => button)
     ];
 
-    // 35 = the original 29 plus Layer Tools' six export buttons.
-    expect(plainActions).toHaveLength(35);
+    // 36 = the original 29, plus Layer Tools' six export buttons, plus the
+    // model-download spike button. Deleting the spike takes this back to 35.
+    expect(plainActions).toHaveLength(36);
     expect(BUSY_GATED_ACTIONS).toHaveLength(11);
     expect(new Set(allActions).size).toBe(allActions.length);
   });
@@ -149,6 +150,8 @@ describe("busy-state tables", () => {
       "detectHardwareButton",
       "checkWorkflowHealthButton",
       "copyDiagnosticsButton",
+      // SPIKE: remove with the spike itself.
+      "spikeModelDownloadButton",
       "saveSettingsButton",
       "resetSettingsButton",
       "clearHistoryButton",


### PR DESCRIPTION
**This is a spike, not a feature.** The button and `src/ui/spikeModelDownload.ts` are meant to be deleted once the answer is in.

## The question

Assisted install was withheld in v0.12 because ComfyUI-Manager's `install_model` only accepts its own catalogue. The replacement is a direct downloader using the registry's verified URLs — and two unknowns block designing it:

1. Can UXP write to ComfyUI's models folder, or does it need a native folder picker?
2. Can an 18.7 GiB file reach disk without being buffered in memory? It cannot be held as a Blob.

## One unknown is already answered, from the command line

HuggingFace serves `accept-ranges: bytes`. Two separate 1 MiB ranged requests each returned **HTTP 206 with exactly 1,048,576 bytes**.

That reframes unknown 2. UXP's `fetch` streaming is [reported unreliable for large files](https://forums.creativeclouddeveloper.com/t/handling-files-as-readablestream-is-it-fully-supported/7259), but **streaming isn't needed**: ranged chunks plus append give bounded memory *and* resumable downloads, which streaming alone wouldn't. A dropped connection at 17 GiB resumes instead of restarting.

Docs also point the right way on unknown 1 — `getEntryWithUrl` with `localFileSystem: "fullAccess"` (which this manifest already requests) is documented to open a path without a dialog, though it's [reported missing on older Photoshop builds](https://forums.creativeclouddeveloper.com/t/localfilesystem-getentrywithurl-is-not-a-function/8224). We require 25.0.0+, so it should be present. Both need confirming in the host, which is what this spike does.

## The five probes

| # | Question | If it fails |
|---|---|---|
| 1 | Resolve ComfyUI's models folder with no picker | A folder picker becomes mandatory; the UX changes shape |
| 2 | Create, write and delete a file there | Writing needs a different route entirely |
| 3 | Is a Node-like `fs` with file descriptors present | Lose the fallback accumulation route |
| 4 | Do two 1 KiB appends produce **2048** bytes, not 1024 | No incremental growth — the model must fit in memory |
| 5 | Is a `Range` header honoured end to end | The whole file arrives in one response |

Each probe is isolated and reports independently — a spike that aborts on the first failure answers one question instead of five. The verdict function states a conclusion rather than leaving five facts to interpret, and accepts **either** append or `fs` as the accumulation route.

## Note on the hardcoded path

`PROBE_MODELS_FOLDER` points at your ComfyUI install. Nothing records where ComfyUI lives yet — discovering that is itself part of what a real downloader must solve. For a spike it only has to be right on the one machine it runs on, and a wrong path reports as a failed resolve rather than failing silently.

## Validation

`typecheck`, `test` (65 files / **578**), `build`, `lint` all clean. The pure logic — verdict, blocker enumeration, probe isolation, range validation — is unit-tested without the host.

Adding the button moves the frozen busy-table count 35 → 36 and adds one locked-action entry; both carry comments saying deleting the spike reverses them.

## What I need from you

Build, load in Photoshop, **Settings → Spike: Model Download**, then paste the report. It's one click and it prints everything at once — no per-step checklist.

The verdict line alone decides the next move: `FEASIBLE` means I design the downloader; `BLOCKED` names exactly which constraint kills it, and I'll say so early rather than building toward it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)