### PR TITLE
Download models in resumable chunks, and get at the folder two ways

### DIFF
--- a/src/comfy/modelDownload.ts
+++ b/src/comfy/modelDownload.ts
@@ -1,0 +1,248 @@
+// The download engine for model files, built on what the feasibility spike
+// established (PR #80): UXP can append to a file, and HuggingFace honours a
+// Range header. So a model arrives as a sequence of bounded ranged chunks that
+// are appended to disk, and memory never holds more than one chunk -- an 18.7
+// GiB model is no harder than a 700 MiB one.
+//
+// Resume falls out of the same mechanism for free, which matters more here than
+// it looks: a connection that drops at 17 GiB resumes from 17 GiB instead of
+// starting over.
+
+export const DEFAULT_CHUNK_BYTES = 8 * 1024 * 1024;
+
+export type DownloadProgress = Readonly<{
+  receivedBytes: number;
+  totalBytes: number | null;
+  // Null rather than 0 when the total is unknown, so a caller can never render
+  // a confident "0%" for something it has not measured.
+  fraction: number | null;
+  resumedFromBytes: number;
+}>;
+
+// The destination is an interface rather than a UXP file so the engine is
+// testable without a host, and so the two access routes the spike found (direct
+// path, or a folder the artist granted) are interchangeable here.
+export type DownloadDestination = Readonly<{
+  // Bytes already on disk for this file, or 0 if it does not exist yet.
+  existingBytes: () => Promise<number>;
+  append: (chunk: ArrayBuffer) => Promise<void>;
+  // Called when a partial file must be thrown away rather than resumed.
+  discard: () => Promise<void>;
+}>;
+
+export type DownloadRequest = Readonly<{
+  url: string;
+  // From the registry. Null when the registry does not publish one; the
+  // download still runs, it just cannot be size-verified at the end.
+  expectedBytes: number | null;
+  chunkBytes?: number;
+}>;
+
+export type DownloadDeps = Readonly<{
+  fetch: typeof fetch;
+  destination: DownloadDestination;
+  onProgress?: (progress: DownloadProgress) => void;
+  // Polled between chunks. Cancelling mid-chunk is not worth the complexity:
+  // one chunk is seconds at most, and the partial file is resumable anyway.
+  isCancelled?: () => boolean;
+}>;
+
+export type DownloadOutcome =
+  | { kind: "completed"; totalBytes: number; resumedFromBytes: number }
+  | { kind: "cancelled"; receivedBytes: number }
+  | { kind: "failed"; reason: string; receivedBytes: number };
+
+export async function downloadModelFile(
+  request: DownloadRequest,
+  deps: DownloadDeps
+): Promise<DownloadOutcome> {
+  const chunkBytes = request.chunkBytes ?? DEFAULT_CHUNK_BYTES;
+
+  if (!Number.isInteger(chunkBytes) || chunkBytes <= 0) {
+    return { kind: "failed", reason: "The download chunk size must be a positive whole number of bytes.", receivedBytes: 0 };
+  }
+
+  let received: number;
+
+  try {
+    received = await deps.destination.existingBytes();
+  } catch (caughtError) {
+    return { kind: "failed", reason: `Could not inspect the partial download. ${messageOf(caughtError)}`, receivedBytes: 0 };
+  }
+
+  // A partial file larger than the finished model is not a resume point, it is
+  // a different file that happens to share a name. Starting over is the only
+  // safe reading.
+  if (request.expectedBytes !== null && received > request.expectedBytes) {
+    try {
+      await deps.destination.discard();
+      received = 0;
+    } catch (caughtError) {
+      return { kind: "failed", reason: `A partial file is larger than the expected model and could not be removed. ${messageOf(caughtError)}`, receivedBytes: received };
+    }
+  }
+
+  if (request.expectedBytes !== null && received === request.expectedBytes) {
+    return { kind: "completed", totalBytes: received, resumedFromBytes: received };
+  }
+
+  const resumedFrom = received;
+  let total: number | null = request.expectedBytes;
+
+  report(deps, received, total, resumedFrom);
+
+  while (total === null || received < total) {
+    if (deps.isCancelled?.()) {
+      return { kind: "cancelled", receivedBytes: received };
+    }
+
+    const rangeEnd = total === null ? received + chunkBytes - 1 : Math.min(received + chunkBytes, total) - 1;
+
+    if (rangeEnd < received) {
+      return { kind: "failed", reason: "Computed an empty byte range; refusing to loop.", receivedBytes: received };
+    }
+
+    let response: Response;
+
+    try {
+      response = await deps.fetch(request.url, { headers: { Range: `bytes=${received}-${rangeEnd}` } });
+    } catch (caughtError) {
+      return { kind: "failed", reason: `Network error at byte ${received}. ${messageOf(caughtError)}`, receivedBytes: received };
+    }
+
+    // A 200 means the server ignored the Range header and is sending the whole
+    // file. Reading that body would defeat the entire bounded-memory design, so
+    // it is refused rather than tolerated.
+    if (response.status === 200) {
+      return {
+        kind: "failed",
+        reason: "The server ignored the Range header and tried to send the whole file at once, which cannot be downloaded safely.",
+        receivedBytes: received
+      };
+    }
+
+    // 416 means the server has nothing past this offset. That is either a clean
+    // finish or a source shorter than the registry claims -- the final size
+    // check below can tell those apart, and says so precisely. Reporting "HTTP
+    // 416" here instead would hide a real mismatch behind a status code.
+    if (response.status === 416) {
+      break;
+    }
+
+    if (response.status !== 206) {
+      return { kind: "failed", reason: describeHttpFailure(response.status), receivedBytes: received };
+    }
+
+    if (total === null) {
+      total = parseTotalFromContentRange(response.headers?.get?.("content-range") ?? null);
+    }
+
+    let chunk: ArrayBuffer;
+
+    try {
+      chunk = await response.arrayBuffer();
+    } catch (caughtError) {
+      return { kind: "failed", reason: `Could not read the response body at byte ${received}. ${messageOf(caughtError)}`, receivedBytes: received };
+    }
+
+    if (chunk.byteLength === 0) {
+      return { kind: "failed", reason: `The server returned an empty chunk at byte ${received}, so the download cannot progress.`, receivedBytes: received };
+    }
+
+    try {
+      await deps.destination.append(chunk);
+    } catch (caughtError) {
+      return { kind: "failed", reason: `Could not write to disk at byte ${received}. ${messageOf(caughtError)}`, receivedBytes: received };
+    }
+
+    received += chunk.byteLength;
+    report(deps, received, total, resumedFrom);
+  }
+
+  if (request.expectedBytes !== null && received !== request.expectedBytes) {
+    return {
+      kind: "failed",
+      reason: `The download finished at ${received} bytes but the registry expects ${request.expectedBytes}. The file is incomplete or the source changed.`,
+      receivedBytes: received
+    };
+  }
+
+  return { kind: "completed", totalBytes: received, resumedFromBytes: resumedFrom };
+}
+
+// Licence-gated weights sit behind an account agreement. Sending an anonymous
+// request produces a 401/403 that reads like a bug, so the caller is expected to
+// check this first and send the artist to the model page instead.
+export function describeHttpFailure(status: number): string {
+  if (status === 401 || status === 403) {
+    return `The server refused the download (HTTP ${status}). This usually means the model is licence-gated and needs its terms accepted on the model page first.`;
+  }
+
+  if (status === 404) {
+    return "The download URL returned 404. The pinned file may have moved or been renamed upstream.";
+  }
+
+  if (status === 429) {
+    return "The server is rate-limiting the download (HTTP 429). Waiting and resuming will continue from where it stopped.";
+  }
+
+  return `The server returned HTTP ${status}.`;
+}
+
+// "bytes 0-8388607/2502139104" -> 2502139104
+export function parseTotalFromContentRange(header: string | null): number | null {
+  if (!header) return null;
+
+  const match = /\/(\d+)\s*$/.exec(header.trim());
+  if (!match) return null;
+
+  const total = Number(match[1]);
+  return Number.isInteger(total) && total > 0 ? total : null;
+}
+
+export function formatDownloadProgress(progress: DownloadProgress): string {
+  const received = formatBytesForDownload(progress.receivedBytes);
+
+  if (progress.totalBytes === null || progress.fraction === null) {
+    return `${received} downloaded`;
+  }
+
+  const percent = Math.floor(progress.fraction * 100);
+  const resumeNote = progress.resumedFromBytes > 0
+    ? ` (resumed from ${formatBytesForDownload(progress.resumedFromBytes)})`
+    : "";
+
+  return `${percent}% - ${received} of ${formatBytesForDownload(progress.totalBytes)}${resumeNote}`;
+}
+
+// Deliberately not the shared formatBytes: that one returns "unknown" for 0,
+// which is right for an unmeasured file size and wrong for a download that has
+// genuinely received nothing yet.
+export function formatBytesForDownload(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "unknown";
+  if (bytes === 0) return "0 B";
+
+  const units = ["B", "KiB", "MiB", "GiB"];
+  let value = bytes;
+  let unit = 0;
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+
+  return `${unit === 0 ? value : value.toFixed(1)} ${units[unit]}`;
+}
+
+function report(deps: DownloadDeps, received: number, total: number | null, resumedFrom: number) {
+  deps.onProgress?.({
+    receivedBytes: received,
+    totalBytes: total,
+    fraction: total === null || total === 0 ? null : Math.min(received / total, 1),
+    resumedFromBytes: resumedFrom
+  });
+}
+
+function messageOf(caughtError: unknown) {
+  return caughtError instanceof Error ? caughtError.message : String(caughtError);
+}

--- a/src/photoshop/modelFolderAccess.ts
+++ b/src/photoshop/modelFolderAccess.ts
@@ -1,0 +1,124 @@
+// Getting a writable handle on ComfyUI's models folder.
+//
+// The feasibility spike (PR #80) found the two halves disagree: UXP resolved the
+// folder path with no dialog at all, but creating a file inside it failed. So
+// neither route can be assumed, and this tries the quiet one first and falls
+// back to asking the artist.
+//
+// A granted folder is remembered with a UXP persistent token, so the picker
+// appears once rather than once per download. Adobe is explicit that a token can
+// stop working -- the folder moves, permissions change -- so an unusable token
+// is treated as "ask again", never as an error.
+
+export type FolderAccessRoute = "direct" | "granted" | "picker-needed";
+
+export type FolderAccessResult =
+  | { kind: "ready"; route: FolderAccessRoute; folder: unknown; note: string }
+  | { kind: "needs-grant"; note: string }
+  | { kind: "failed"; note: string };
+
+export type FolderAccessDeps = Readonly<{
+  // Resolve a path with no dialog. Undefined on builds without the API.
+  getEntryWithUrl?: (url: string) => Promise<unknown>;
+  // Show the native folder picker. Resolves null when the artist cancels.
+  pickFolder?: () => Promise<unknown | null>;
+  createPersistentToken?: (entry: unknown) => Promise<string>;
+  getEntryForPersistentToken?: (token: string) => Promise<unknown>;
+  readStoredToken: () => string | null;
+  writeStoredToken: (token: string | null) => void;
+  // Proves a handle is actually writable. The spike's whole finding was that
+  // resolving a folder says nothing about being able to write in it.
+  canWrite: (folder: unknown) => Promise<boolean>;
+}>;
+
+export async function acquireModelsFolder(
+  targetPath: string,
+  deps: FolderAccessDeps,
+  options?: { allowPicker?: boolean }
+): Promise<FolderAccessResult> {
+  const allowPicker = options?.allowPicker ?? false;
+
+  // 1. A folder the artist already granted. Preferred over the direct route
+  // because it is known to have worked once, and costs no dialog.
+  const storedToken = deps.readStoredToken();
+
+  if (storedToken && typeof deps.getEntryForPersistentToken === "function") {
+    try {
+      const folder = await deps.getEntryForPersistentToken(storedToken);
+
+      if (folder && await deps.canWrite(folder)) {
+        return { kind: "ready", route: "granted", folder, note: "Using the ComfyUI models folder you granted earlier." };
+      }
+
+      // Resolved but unusable: the folder moved, or permissions changed.
+      deps.writeStoredToken(null);
+    } catch {
+      deps.writeStoredToken(null);
+    }
+  }
+
+  // 2. The quiet route. Free when it works, and the spike proved it resolves.
+  if (typeof deps.getEntryWithUrl === "function" && targetPath) {
+    try {
+      const folder = await deps.getEntryWithUrl(`file:${targetPath.replace(/\\/g, "/")}`);
+
+      if (folder && await deps.canWrite(folder)) {
+        return { kind: "ready", route: "direct", folder, note: "Writing straight to ComfyUI's models folder; no permission needed." };
+      }
+    } catch {
+      // Falls through to the picker, which is the whole point of trying first.
+    }
+  }
+
+  if (!allowPicker) {
+    return {
+      kind: "needs-grant",
+      note: "OpenLayer needs permission to write into ComfyUI's models folder. Choose it once and it will be remembered."
+    };
+  }
+
+  // 3. Ask. Only ever reached deliberately, never as a surprise mid-download.
+  if (typeof deps.pickFolder !== "function") {
+    return { kind: "failed", note: "This Photoshop build cannot show a folder picker, so the models folder cannot be granted." };
+  }
+
+  let picked: unknown | null;
+
+  try {
+    picked = await deps.pickFolder();
+  } catch (caughtError) {
+    return { kind: "failed", note: `The folder picker failed. ${caughtError instanceof Error ? caughtError.message : String(caughtError)}` };
+  }
+
+  if (!picked) {
+    return { kind: "needs-grant", note: "No folder was chosen, so nothing was downloaded." };
+  }
+
+  if (!await deps.canWrite(picked)) {
+    return { kind: "failed", note: "That folder cannot be written to. Choose the ComfyUI models folder, or one you own." };
+  }
+
+  if (typeof deps.createPersistentToken === "function") {
+    try {
+      deps.writeStoredToken(await deps.createPersistentToken(picked));
+    } catch {
+      // Remembering is an optimisation. A download that works but asks again
+      // next time is far better than refusing to proceed.
+    }
+  }
+
+  return { kind: "ready", route: "granted", folder: picked, note: "Folder granted. OpenLayer will remember it for future downloads." };
+}
+
+// A chosen folder is only the right one if the model can actually land where
+// ComfyUI looks for it. Warning is right rather than refusing: the artist may
+// have a valid extra_model_paths.yaml layout we cannot see from here.
+export function describeFolderMismatch(chosenPath: string | null, expectedSubfolder: string): string | null {
+  if (!chosenPath) return null;
+
+  const normalized = chosenPath.replace(/\\/g, "/").toLowerCase().replace(/\/+$/, "");
+
+  if (normalized.endsWith(`/${expectedSubfolder.toLowerCase()}`)) return null;
+
+  return `This folder does not end in "${expectedSubfolder}". ComfyUI looks for this model there, so it may not be found unless your extra_model_paths.yaml says otherwise.`;
+}

--- a/tests/comfy/modelDownload.test.ts
+++ b/tests/comfy/modelDownload.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DownloadDestination,
+  DownloadProgress,
+  downloadModelFile,
+  formatBytesForDownload,
+  formatDownloadProgress,
+  parseTotalFromContentRange
+} from "../../src/comfy/modelDownload";
+
+function memoryDestination(startingBytes = 0) {
+  const state = { bytes: startingBytes, discarded: 0, writes: [] as number[] };
+  const destination: DownloadDestination = {
+    existingBytes: async () => state.bytes,
+    append: async (chunk) => {
+      state.writes.push(chunk.byteLength);
+      state.bytes += chunk.byteLength;
+    },
+    discard: async () => {
+      state.discarded += 1;
+      state.bytes = 0;
+    }
+  };
+
+  return { destination, state };
+}
+
+// Serves a file of `total` bytes, honouring Range the way HuggingFace does.
+function rangeServer(total: number) {
+  const calls: string[] = [];
+  const serverFetch = (async (_url: string, init?: { headers?: Record<string, string> }) => {
+    const header = init?.headers?.Range ?? "";
+    calls.push(header);
+    const match = /bytes=(\d+)-(\d+)/.exec(header)!;
+    const start = Number(match[1]);
+    const end = Math.min(Number(match[2]), total - 1);
+
+    if (start >= total) {
+      return { status: 416, headers: { get: () => null }, arrayBuffer: async () => new ArrayBuffer(0) };
+    }
+
+    return {
+      status: 206,
+      headers: { get: (name: string) => (name === "content-range" ? `bytes ${start}-${end}/${total}` : null) },
+      arrayBuffer: async () => new ArrayBuffer(end - start + 1)
+    };
+  }) as unknown as typeof fetch;
+
+  return { serverFetch, calls };
+}
+
+describe("chunked model download", () => {
+  it("downloads a file in bounded chunks rather than one response", async () => {
+    const { destination, state } = memoryDestination();
+    const { serverFetch, calls } = rangeServer(1000);
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000, chunkBytes: 400 },
+      { fetch: serverFetch, destination }
+    );
+
+    expect(outcome).toEqual({ kind: "completed", totalBytes: 1000, resumedFromBytes: 0 });
+    expect(calls).toEqual(["bytes=0-399", "bytes=400-799", "bytes=800-999"]);
+    expect(state.writes).toEqual([400, 400, 200]);
+  });
+
+  it("resumes from the bytes already on disk instead of starting over", async () => {
+    const { destination, state } = memoryDestination(800);
+    const { serverFetch, calls } = rangeServer(1000);
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000, chunkBytes: 400 },
+      { fetch: serverFetch, destination }
+    );
+
+    expect(calls).toEqual(["bytes=800-999"]);
+    expect(outcome).toEqual({ kind: "completed", totalBytes: 1000, resumedFromBytes: 800 });
+    expect(state.writes).toEqual([200]);
+  });
+
+  it("does nothing when the file is already complete", async () => {
+    const { destination } = memoryDestination(1000);
+    const { serverFetch, calls } = rangeServer(1000);
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000 },
+      { fetch: serverFetch, destination }
+    );
+
+    expect(calls).toEqual([]);
+    expect(outcome.kind).toBe("completed");
+  });
+
+  // A file bigger than the finished model is not a resume point; it is a
+  // different file wearing the same name.
+  it("discards an oversized partial file and starts again", async () => {
+    const { destination, state } = memoryDestination(5000);
+    const { serverFetch } = rangeServer(1000);
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000, chunkBytes: 1000 },
+      { fetch: serverFetch, destination }
+    );
+
+    expect(state.discarded).toBe(1);
+    expect(outcome).toEqual({ kind: "completed", totalBytes: 1000, resumedFromBytes: 0 });
+  });
+
+  it("learns the total from Content-Range when the registry publishes no size", async () => {
+    const { destination } = memoryDestination();
+    const { serverFetch } = rangeServer(900);
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: null, chunkBytes: 500 },
+      { fetch: serverFetch, destination }
+    );
+
+    expect(outcome).toEqual({ kind: "completed", totalBytes: 900, resumedFromBytes: 0 });
+  });
+});
+
+describe("download refusals", () => {
+  // Reading a 200 body would defeat the whole bounded-memory design.
+  it("refuses a server that ignores Range and sends the whole file", async () => {
+    const { destination } = memoryDestination();
+    const wholeFile = (async () => ({
+      status: 200,
+      headers: { get: () => null },
+      arrayBuffer: async () => new ArrayBuffer(1000)
+    })) as unknown as typeof fetch;
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000 },
+      { fetch: wholeFile, destination }
+    );
+
+    expect(outcome.kind).toBe("failed");
+    expect(outcome.kind === "failed" && outcome.reason).toContain("whole file at once");
+  });
+
+  it("explains a 403 as a licence gate rather than a bug", async () => {
+    const { destination } = memoryDestination();
+    const refused = (async () => ({
+      status: 403,
+      headers: { get: () => null },
+      arrayBuffer: async () => new ArrayBuffer(0)
+    })) as unknown as typeof fetch;
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000 },
+      { fetch: refused, destination }
+    );
+
+    expect(outcome.kind === "failed" && outcome.reason).toContain("licence-gated");
+  });
+
+  it("stops instead of looping when the server returns an empty chunk", async () => {
+    const { destination } = memoryDestination();
+    const empty = (async () => ({
+      status: 206,
+      headers: { get: () => "bytes 0-0/1000" },
+      arrayBuffer: async () => new ArrayBuffer(0)
+    })) as unknown as typeof fetch;
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000, chunkBytes: 100 },
+      { fetch: empty, destination }
+    );
+
+    expect(outcome.kind === "failed" && outcome.reason).toContain("empty chunk");
+  });
+
+  it("reports a short download rather than declaring success", async () => {
+    const { destination } = memoryDestination();
+    const { serverFetch } = rangeServer(600);
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000, chunkBytes: 1000 },
+      { fetch: serverFetch, destination }
+    );
+
+    expect(outcome.kind).toBe("failed");
+    expect(outcome.kind === "failed" && outcome.reason).toContain("incomplete or the source changed");
+  });
+
+  it("keeps the partial file's byte count on a network failure so it can resume", async () => {
+    const { destination } = memoryDestination(400);
+    const dropped = (async () => {
+      throw new Error("socket hang up");
+    }) as unknown as typeof fetch;
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000 },
+      { fetch: dropped, destination }
+    );
+
+    expect(outcome).toEqual({ kind: "failed", reason: expect.stringContaining("socket hang up"), receivedBytes: 400 });
+  });
+});
+
+describe("cancellation", () => {
+  it("stops between chunks and reports what it already has", async () => {
+    const { destination } = memoryDestination();
+    const { serverFetch, calls } = rangeServer(1000);
+    let chunks = 0;
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000, chunkBytes: 200 },
+      { fetch: serverFetch, destination, isCancelled: () => chunks++ >= 2 }
+    );
+
+    expect(outcome).toEqual({ kind: "cancelled", receivedBytes: 400 });
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe("progress reporting", () => {
+  it("reports monotonically increasing bytes with a fraction", async () => {
+    const { destination } = memoryDestination();
+    const { serverFetch } = rangeServer(1000);
+    const seen: DownloadProgress[] = [];
+
+    await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000, chunkBytes: 500 },
+      { fetch: serverFetch, destination, onProgress: (progress) => seen.push(progress) }
+    );
+
+    expect(seen.map((entry) => entry.receivedBytes)).toEqual([0, 500, 1000]);
+    expect(seen[seen.length - 1].fraction).toBe(1);
+  });
+
+  // Same rule as formatBytes(0): an unmeasured total must never render as a
+  // confident percentage.
+  it("reports a null fraction, not zero, when the total is unknown", async () => {
+    const { destination } = memoryDestination();
+    const noRange = (async () => ({
+      status: 206,
+      headers: { get: () => null },
+      arrayBuffer: async () => new ArrayBuffer(100)
+    })) as unknown as typeof fetch;
+    const seen: DownloadProgress[] = [];
+
+    await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: null, chunkBytes: 100 },
+      {
+        fetch: noRange,
+        destination,
+        onProgress: (progress) => seen.push(progress),
+        isCancelled: () => seen.length > 2
+      }
+    );
+
+    expect(seen[0].fraction).toBeNull();
+    expect(formatDownloadProgress(seen[1])).toContain("downloaded");
+    expect(formatDownloadProgress(seen[1])).not.toContain("%");
+  });
+
+  it("mentions the resume point so a resumed download does not look like a fresh one", () => {
+    const text = formatDownloadProgress({
+      receivedBytes: 900,
+      totalBytes: 1000,
+      fraction: 0.9,
+      resumedFromBytes: 500
+    });
+
+    expect(text).toContain("90%");
+    expect(text).toContain("resumed from");
+  });
+});
+
+describe("byte formatting", () => {
+  it("says 0 B rather than unknown, because a download that received nothing did measure it", () => {
+    expect(formatBytesForDownload(0)).toBe("0 B");
+  });
+
+  it("scales to sensible units", () => {
+    expect(formatBytesForDownload(512)).toBe("512 B");
+    expect(formatBytesForDownload(2502139104)).toBe("2.3 GiB");
+    expect(formatBytesForDownload(20082414560)).toBe("18.7 GiB");
+  });
+
+  it("says unknown for nonsense", () => {
+    expect(formatBytesForDownload(-1)).toBe("unknown");
+    expect(formatBytesForDownload(Number.NaN)).toBe("unknown");
+  });
+});
+
+describe("content-range parsing", () => {
+  it("reads the total from a well-formed header", () => {
+    expect(parseTotalFromContentRange("bytes 0-8388607/2502139104")).toBe(2502139104);
+  });
+
+  it("returns null for headers it cannot trust", () => {
+    expect(parseTotalFromContentRange(null)).toBeNull();
+    expect(parseTotalFromContentRange("bytes 0-100/*")).toBeNull();
+    expect(parseTotalFromContentRange("nonsense")).toBeNull();
+  });
+});
+
+describe("guard rails", () => {
+  it("refuses a nonsense chunk size instead of looping forever", async () => {
+    const { destination } = memoryDestination();
+    const never = vi.fn();
+
+    const outcome = await downloadModelFile(
+      { url: "https://example.test/model", expectedBytes: 1000, chunkBytes: 0 },
+      { fetch: never as unknown as typeof fetch, destination }
+    );
+
+    expect(outcome.kind).toBe("failed");
+    expect(never).not.toHaveBeenCalled();
+  });
+});

--- a/tests/photoshop/modelFolderAccess.test.ts
+++ b/tests/photoshop/modelFolderAccess.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  acquireModelsFolder,
+  describeFolderMismatch,
+  FolderAccessDeps
+} from "../../src/photoshop/modelFolderAccess";
+
+function deps(overrides: Partial<FolderAccessDeps> = {}): FolderAccessDeps {
+  let stored: string | null = null;
+
+  return {
+    readStoredToken: () => stored,
+    writeStoredToken: (token) => {
+      stored = token;
+    },
+    canWrite: async () => true,
+    ...overrides
+  };
+}
+
+describe("acquiring the models folder", () => {
+  it("uses the quiet direct route when it both resolves and is writable", async () => {
+    const result = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => ({ name: "loras" })
+    }));
+
+    expect(result.kind).toBe("ready");
+    expect(result.kind === "ready" && result.route).toBe("direct");
+  });
+
+  it("normalises Windows separators into the file: URL UXP wants", async () => {
+    const seen: string[] = [];
+
+    await acquireModelsFolder("C:\\comfy\\models\\loras", deps({
+      getEntryWithUrl: async (url) => {
+        seen.push(url);
+        return { name: "loras" };
+      }
+    }));
+
+    expect(seen).toEqual(["file:C:/comfy/models/loras"]);
+  });
+
+  // This is the exact split the spike found: the path resolved, the write did
+  // not. Resolving must never be mistaken for access.
+  it("does not accept a folder that resolves but cannot be written to", async () => {
+    const result = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => ({ name: "loras" }),
+      canWrite: async () => false
+    }));
+
+    expect(result.kind).toBe("needs-grant");
+  });
+
+  it("asks for a grant rather than opening a picker unprompted", async () => {
+    const pickFolder = vi.fn();
+
+    const result = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => null,
+      pickFolder
+    }));
+
+    expect(result.kind).toBe("needs-grant");
+    expect(pickFolder).not.toHaveBeenCalled();
+  });
+
+  it("opens the picker and remembers the choice when asked to", async () => {
+    let stored: string | null = null;
+    const result = await acquireModelsFolder("C:/comfy/models/loras", {
+      readStoredToken: () => stored,
+      writeStoredToken: (token) => {
+        stored = token;
+      },
+      canWrite: async () => true,
+      getEntryWithUrl: async () => null,
+      pickFolder: async () => ({ name: "picked" }),
+      createPersistentToken: async () => "token-123"
+    }, { allowPicker: true });
+
+    expect(result.kind === "ready" && result.route).toBe("granted");
+    expect(stored).toBe("token-123");
+  });
+
+  it("prefers a remembered folder over the direct route, with no dialog", async () => {
+    const getEntryWithUrl = vi.fn();
+
+    const result = await acquireModelsFolder("C:/comfy/models/loras", {
+      readStoredToken: () => "token-123",
+      writeStoredToken: () => undefined,
+      canWrite: async () => true,
+      getEntryWithUrl,
+      getEntryForPersistentToken: async () => ({ name: "remembered" })
+    });
+
+    expect(result.kind === "ready" && result.route).toBe("granted");
+    expect(getEntryWithUrl).not.toHaveBeenCalled();
+  });
+
+  // Adobe documents that persistent tokens can stop working. A stale token must
+  // read as "ask again", never as a hard failure.
+  it("forgets a token that no longer resolves and falls back", async () => {
+    let stored: string | null = "stale";
+
+    const result = await acquireModelsFolder("C:/comfy/models/loras", {
+      readStoredToken: () => stored,
+      writeStoredToken: (token) => {
+        stored = token;
+      },
+      canWrite: async () => true,
+      getEntryForPersistentToken: async () => {
+        throw new Error("token no longer valid");
+      },
+      getEntryWithUrl: async () => ({ name: "loras" })
+    });
+
+    expect(stored).toBeNull();
+    expect(result.kind === "ready" && result.route).toBe("direct");
+  });
+
+  it("forgets a token that resolves to something no longer writable", async () => {
+    let stored: string | null = "stale";
+
+    await acquireModelsFolder("C:/comfy/models/loras", {
+      readStoredToken: () => stored,
+      writeStoredToken: (token) => {
+        stored = token;
+      },
+      canWrite: async (folder) => (folder as { name: string }).name !== "moved",
+      getEntryForPersistentToken: async () => ({ name: "moved" }),
+      getEntryWithUrl: async () => ({ name: "loras" })
+    });
+
+    expect(stored).toBeNull();
+  });
+
+  it("treats a cancelled picker as a non-event, not a failure", async () => {
+    const result = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => null,
+      pickFolder: async () => null
+    }), { allowPicker: true });
+
+    expect(result.kind).toBe("needs-grant");
+    expect(result.note).toContain("nothing was downloaded");
+  });
+
+  it("rejects a granted folder that cannot be written to", async () => {
+    const result = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => null,
+      pickFolder: async () => ({ name: "read-only" }),
+      canWrite: async () => false
+    }), { allowPicker: true });
+
+    expect(result.kind).toBe("failed");
+    expect(result.note).toContain("cannot be written to");
+  });
+
+  // Remembering is an optimisation; failing to remember must not block a
+  // download that otherwise works.
+  it("still proceeds when the folder cannot be remembered", async () => {
+    const result = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => null,
+      pickFolder: async () => ({ name: "picked" }),
+      createPersistentToken: async () => {
+        throw new Error("tokens unavailable");
+      }
+    }), { allowPicker: true });
+
+    expect(result.kind).toBe("ready");
+  });
+
+  it("reports a build with no picker at all rather than hanging", async () => {
+    const result = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => null
+    }), { allowPicker: true });
+
+    expect(result.kind).toBe("failed");
+    expect(result.note).toContain("cannot show a folder picker");
+  });
+});
+
+describe("folder mismatch warning", () => {
+  it("stays quiet when the folder matches what ComfyUI expects", () => {
+    expect(describeFolderMismatch("C:/comfy/models/loras", "loras")).toBeNull();
+    expect(describeFolderMismatch("C:\\comfy\\models\\Loras\\", "loras")).toBeNull();
+  });
+
+  // Warn rather than refuse: extra_model_paths.yaml can make an unexpected
+  // folder correct, and we cannot see it from here.
+  it("warns without refusing when the folder looks wrong", () => {
+    const warning = describeFolderMismatch("C:/comfy/models/checkpoints", "loras");
+
+    expect(warning).toContain("loras");
+    expect(warning).toContain("extra_model_paths.yaml");
+  });
+});


### PR DESCRIPTION
The **engine half** of model acquisition — the transport and the folder access, both fully tested. **No UI yet**: the Setup wiring lands as its own reviewable change, because mixing a new transport with new UI would make a failure impossible to attribute.

## Built on what the spike measured

Files arrive as **bounded ranged chunks**, appended to disk. Memory never holds more than one chunk, so an 18.7 GiB model is no harder than a 700 MiB one. Resume falls out of the same mechanism — a connection that drops at 17 GiB continues from 17 GiB rather than starting over, which for a 12 GB-class download is the difference between usable and not.

## Verified live, not just mocked

Run against the real HuggingFace CDN before committing:

- three genuine 4 MiB chunks downloaded
- clean cancel between chunks
- resume that requested from **exactly byte 12582912** and landed at 16 MiB

The throwaway live test was deleted; the suite stays offline and deterministic.

## Refusals are the interesting part

| Situation | Behaviour |
|---|---|
| HTTP **200** (server ignored `Range`) | **Refused** — reading that body would defeat bounded memory entirely |
| HTTP **401/403** | Explained as a licence gate, not a bug |
| HTTP **416** | Breaks, then lets the size check say what is actually wrong |
| Short download | Reports the byte mismatch instead of declaring success |
| Empty chunk | Stops rather than looping forever |
| Partial file **larger** than expected | Discarded — it is a different file wearing the same name |

**A test caught a real defect.** 416 was reported as a bare `HTTP 416`, which hid the case where the source is genuinely shorter than the registry claims. It now defers to the final size check, which names both numbers.

## Folder access tries the quiet route first

The spike found the two halves disagree: the path **resolved with no dialog**, but writing there **failed**. So resolving is never mistaken for access — every route is write-tested before use.

1. A folder granted earlier (persistent token) — no dialog
2. The direct path — no dialog, free when it works
3. Ask the artist once, then remember it

Adobe documents that persistent tokens can stop working when a folder moves or permissions change, so a stale token reads as **"ask again"**, never an error. Failing to remember a folder never blocks a download that otherwise works. The picker never opens unprompted — `allowPicker` must be passed deliberately.

A folder that does not match the expected subfolder **warns rather than refuses**: `extra_model_paths.yaml` can make an unexpected location correct, and we cannot see it from here.

## Small consistency note

Progress reports a **null** fraction, never `0%`, when the total is unknown — same rule as `formatBytes(0)`.

## Validation

`typecheck`, `test` (67 files / **612**, up from 578), `build`, `lint` — all clean.

## What is not here

The Setup screen still shows no download button; `ASSISTED_INSTALL_ENABLED` stays `false`. Next PR wires this engine to the Missing rows, with per-item confirmation before anything downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)