### PR TITLE
Download missing models from the Setup screen

### DIFF
--- a/src/photoshop/modelFileDestination.ts
+++ b/src/photoshop/modelFileDestination.ts
@@ -1,0 +1,100 @@
+import type { DownloadDestination } from "../comfy/modelDownload";
+
+// Turns a granted UXP folder into a destination the download engine can append
+// to.
+//
+// The subtle part is measuring what is already on disk. Reading the file back
+// to learn its length would pull an 18 GiB model into memory -- the exact thing
+// the chunked design exists to avoid -- so the size comes from fs.lstat, which
+// the spike confirmed this UXP build exposes. Where lstat is unavailable the
+// answer is 0, which costs a restarted download but never a corrupt one.
+
+export type UxpFileLike = {
+  write: (data: ArrayBuffer, options: Record<string, unknown>) => Promise<void>;
+  delete: () => Promise<void>;
+};
+
+export type UxpFolderLike = {
+  nativePath?: string;
+  createFile: (name: string, options?: { overwrite?: boolean }) => Promise<UxpFileLike>;
+  getEntry?: (name: string) => Promise<UxpFileLike | null>;
+};
+
+export type DestinationDeps = Readonly<{
+  folder: UxpFolderLike;
+  fileName: string;
+  binaryFormat: unknown;
+  // Size in bytes, or null when it cannot be determined.
+  statSize?: (nativePath: string) => Promise<number | null>;
+}>;
+
+export function createFolderDestination(deps: DestinationDeps): DownloadDestination {
+  let file: UxpFileLike | null = null;
+  // Whether the next write must append rather than replace. This is not a
+  // preference: appending on a fresh download would concatenate onto a partial
+  // file we just decided to abandon, and replacing on a resumed download would
+  // destroy the bytes we just decided to keep.
+  let appendNext = false;
+
+  const openFile = async (): Promise<UxpFileLike> => {
+    if (file) return file;
+
+    const existing = typeof deps.folder.getEntry === "function"
+      ? await deps.folder.getEntry(deps.fileName).catch(() => null)
+      : null;
+
+    file = existing ?? await deps.folder.createFile(deps.fileName, { overwrite: true });
+    return file;
+  };
+
+  return {
+    // The engine always asks this before writing, so it is also the honest
+    // place to decide whether writing continues a file or starts one.
+    existingBytes: async () => {
+      const bytes = await measureExistingBytes(deps);
+      appendNext = bytes > 0;
+      return bytes;
+    },
+
+    append: async (chunk) => {
+      const target = await openFile();
+      await target.write(chunk, { format: deps.binaryFormat, append: appendNext });
+      appendNext = true;
+    },
+
+    discard: async () => {
+      const target = await openFile().catch(() => null);
+
+      if (target) {
+        await target.delete();
+      }
+
+      file = null;
+      appendNext = false;
+    }
+  };
+}
+
+async function measureExistingBytes(deps: DestinationDeps): Promise<number> {
+  if (typeof deps.statSize !== "function") return 0;
+
+  const folderPath = deps.folder.nativePath;
+  if (!folderPath) return 0;
+
+  try {
+    const size = await deps.statSize(joinNativePath(folderPath, deps.fileName));
+    return typeof size === "number" && Number.isFinite(size) && size > 0 ? size : 0;
+  } catch {
+    // No file yet, or a build that cannot stat. Either way, start at zero:
+    // a needlessly restarted download is recoverable, a wrongly resumed one
+    // silently produces a corrupt model.
+    return 0;
+  }
+}
+
+export function joinNativePath(folderPath: string, fileName: string): string {
+  const trimmed = folderPath.replace(/[\\/]+$/, "");
+  const separator = trimmed.includes("\\") && !trimmed.includes("/") ? "\\" : "/";
+
+  return `${trimmed}${separator}${fileName}`;
+}

--- a/src/photoshop/modelFolderAccess.ts
+++ b/src/photoshop/modelFolderAccess.ts
@@ -58,6 +58,8 @@ export async function acquireModelsFolder(
   }
 
   // 2. The quiet route. Free when it works, and the spike proved it resolves.
+  let directFailure = "";
+
   if (typeof deps.getEntryWithUrl === "function" && targetPath) {
     try {
       const folder = await deps.getEntryWithUrl(`file:${targetPath.replace(/\\/g, "/")}`);
@@ -65,15 +67,25 @@ export async function acquireModelsFolder(
       if (folder && await deps.canWrite(folder)) {
         return { kind: "ready", route: "direct", folder, note: "Writing straight to ComfyUI's models folder; no permission needed." };
       }
-    } catch {
-      // Falls through to the picker, which is the whole point of trying first.
+
+      directFailure = folder
+        ? "the folder resolved but could not be written to"
+        : "the folder path did not resolve";
+    } catch (caughtError) {
+      // Recorded, not swallowed. Falling back silently once hid a plain
+      // programming error -- an unbound UXP method -- behind what looked like a
+      // permissions problem, and cost a debugging round trip.
+      directFailure = messageOf(caughtError);
     }
   }
 
   if (!allowPicker) {
     return {
       kind: "needs-grant",
-      note: "OpenLayer needs permission to write into ComfyUI's models folder. Choose it once and it will be remembered."
+      note: withReason(
+        "OpenLayer needs permission to write into ComfyUI's models folder. Choose it once and it will be remembered.",
+        directFailure
+      )
     };
   }
 
@@ -87,7 +99,10 @@ export async function acquireModelsFolder(
   try {
     picked = await deps.pickFolder();
   } catch (caughtError) {
-    return { kind: "failed", note: `The folder picker failed. ${caughtError instanceof Error ? caughtError.message : String(caughtError)}` };
+    return {
+      kind: "failed",
+      note: withReason(`The folder picker failed. ${messageOf(caughtError)}`, directFailure)
+    };
   }
 
   if (!picked) {
@@ -108,6 +123,16 @@ export async function acquireModelsFolder(
   }
 
   return { kind: "ready", route: "granted", folder: picked, note: "Folder granted. OpenLayer will remember it for future downloads." };
+}
+
+function messageOf(caughtError: unknown) {
+  return caughtError instanceof Error ? caughtError.message : String(caughtError);
+}
+
+// Both halves matter when this goes wrong: what the artist should do, and what
+// actually failed underneath.
+function withReason(note: string, reason: string) {
+  return reason ? `${note} (Direct access failed: ${reason})` : note;
 }
 
 // A chosen folder is only the right one if the model can actually land where

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -110,11 +110,8 @@ import {
 import {
   AssistedInstallItem,
   AssistedInstallPlan,
-  createInstallModelRequest,
-  evaluateQueuePrecondition,
   planAssistedInstall
 } from "../comfy/assistedInstall";
-import { isManagerSecurityLevelError, ManagerClient } from "../comfy/managerClient";
 import {
   createInstallConfirmationView,
   createInstallStatusLine,
@@ -140,6 +137,20 @@ import {
   importOutpaintResultExpandingCanvas,
   importUpscaleResultResizingDocument
 } from "../photoshop/photoshopAdapter";
+import {
+  downloadModelFile,
+  formatBytesForDownload,
+  formatDownloadProgress
+} from "../comfy/modelDownload";
+import {
+  acquireModelsFolder,
+  describeFolderMismatch,
+  FolderAccessDeps
+} from "../photoshop/modelFolderAccess";
+import {
+  createFolderDestination,
+  UxpFolderLike
+} from "../photoshop/modelFileDestination";
 import {
   formatSpikeReport,
   PROBE_MODELS_FOLDER,
@@ -359,6 +370,76 @@ type UpscaleResizeSource = Readonly<{
 type AppUpscaleImportContext = InpaintImportContext<UpscaleResizeSource, AppGeneratedImageResult>;
 type LiveGeneratedImageResult = DocumentContextBound<{ blob: Blob }>;
 
+// Where a granted models folder is remembered between sessions. A token that
+// stops working is treated as "ask again", never as an error -- Adobe documents
+// that folders moving or permissions changing can invalidate one.
+const MODELS_FOLDER_TOKEN_KEY = "openlayer.modelsFolderToken";
+
+function createFolderAccessDeps(): FolderAccessDeps {
+  const uxp = require("uxp") as {
+    storage: {
+      formats: { binary: unknown };
+      localFileSystem: Record<string, unknown>;
+    };
+  };
+  const lfs = uxp.storage.localFileSystem;
+
+  return {
+    getEntryWithUrl: lfs.getEntryWithUrl as ((url: string) => Promise<unknown>) | undefined,
+    pickFolder: lfs.getFolder as (() => Promise<unknown | null>) | undefined,
+    createPersistentToken: lfs.createPersistentToken as ((entry: unknown) => Promise<string>) | undefined,
+    getEntryForPersistentToken: lfs.getEntryForPersistentToken as ((token: string) => Promise<unknown>) | undefined,
+    readStoredToken: () => {
+      try {
+        return localStorage.getItem(MODELS_FOLDER_TOKEN_KEY);
+      } catch {
+        return null;
+      }
+    },
+    writeStoredToken: (token) => {
+      try {
+        if (token === null) localStorage.removeItem(MODELS_FOLDER_TOKEN_KEY);
+        else localStorage.setItem(MODELS_FOLDER_TOKEN_KEY, token);
+      } catch {
+        // Not remembering is survivable; it costs one extra picker next time.
+      }
+    },
+    // The spike's central finding: a folder that resolves is not necessarily a
+    // folder that can be written to, so every route proves itself first.
+    canWrite: async (folder) => {
+      const target = folder as UxpFolderLike | null;
+      if (!target || typeof target.createFile !== "function") return false;
+
+      try {
+        const probe = await target.createFile("openlayer-write-check.tmp", { overwrite: true });
+        await probe.write(new ArrayBuffer(1), { format: uxp.storage.formats.binary });
+        await probe.delete();
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  };
+}
+
+// Reads a file's size without reading the file. Pulling an 18 GiB model into
+// memory to learn its length would defeat the entire chunked design, so this
+// goes through fs.lstat, which the feasibility spike confirmed is present.
+async function readNativeFileSize(nativePath: string): Promise<number | null> {
+  try {
+    const fs = (require as unknown as (name: string) => {
+      lstat?: (path: string) => Promise<{ size?: number }>;
+    })("fs");
+
+    if (typeof fs?.lstat !== "function") return null;
+
+    const stats = await fs.lstat(nativePath);
+    return typeof stats?.size === "number" ? stats.size : null;
+  } catch {
+    return null;
+  }
+}
+
 export function renderApp(rootElement: HTMLElement) {
   let currentView: AppView = "home";
   let isBusy = false;
@@ -416,7 +497,6 @@ export function renderApp(rootElement: HTMLElement) {
   // Null means "no ComfyUI-Manager", which is a normal install and not an error.
   // Install buttons appear only when this is set, so a row never offers an
   // action that would fail the moment it was pressed.
-  let setupManagerVersion: string | null = null;
   let setupInstallPlan: AssistedInstallPlan | null = null;
   // At most one row may be confirming, and at most one install may run. Both are
   // single-slot on purpose: the confirmation is per item by design, and the
@@ -424,6 +504,9 @@ export function renderApp(rootElement: HTMLElement) {
   // would be indistinguishable in its status counts.
   let setupConfirmingKey: string | null = null;
   let setupInstallingKey: string | null = null;
+  // Polled between chunks by the download engine. A partial file is resumable,
+  // so stopping is always safe.
+  let setupDownloadCancelled = false;
   const historyEntries: HistoryEntry[] = [];
   const objectUrls = createObjectUrlRegistry();
 
@@ -1207,16 +1290,6 @@ export function renderApp(rootElement: HTMLElement) {
         setupVramTotalBytes = null;
       }
 
-      // Also a bonus, and for the same reason as the device report: a ComfyUI
-      // without ComfyUI-Manager is a perfectly normal install. It costs the
-      // screen its Install buttons and nothing else, so it must not fail the
-      // check that produced the list those buttons sit on.
-      try {
-        setupManagerVersion = await new ManagerClient(elements.serverUrl.value).getManagerVersion();
-      } catch {
-        setupManagerVersion = null;
-      }
-
       setupReport = evaluateSetupRequirements({
         pluginVersion: APP_VERSION,
         inventory,
@@ -1240,10 +1313,6 @@ export function renderApp(rootElement: HTMLElement) {
       setupReport = createUncheckedSetupReport();
       hasCheckedSetup = false;
       setupCheckedAtLabel = null;
-      // An unchecked report offers nothing to install anyway, but clearing this
-      // means a Manager seen on an earlier check cannot leave Install buttons
-      // behind on a screen that no longer knows what is missing.
-      setupManagerVersion = null;
       renderSetupTab();
       // Reported on this screen's own bar and nowhere else. Writing the reason
       // to the panel-wide error line would put a red Setup message on Settings
@@ -1277,7 +1346,7 @@ export function renderApp(rootElement: HTMLElement) {
     });
     renderSetupSections(elements.setupSections, view.sections, handleSetupCopy, {
       getOffer: (requirementKey) =>
-        getInstallOffer(setupInstallPlan, setupManagerVersion, requirementKey),
+        getInstallOffer(setupInstallPlan, requirementKey),
       confirmingKey: setupConfirmingKey,
       installingKey: setupInstallingKey,
       busy: setupInstallingKey !== null,
@@ -1288,6 +1357,10 @@ export function renderApp(rootElement: HTMLElement) {
       onCancel: () => {
         setupConfirmingKey = null;
         renderSetupTab();
+      },
+      onStop: () => {
+        setupDownloadCancelled = true;
+        setSetupStatus(elements, "Stopping after the current chunk...", "idle");
       },
       onConfirm: (item) => {
         void handleInstallModel(item);
@@ -1325,9 +1398,9 @@ export function renderApp(rootElement: HTMLElement) {
       return;
     }
 
-    const manager = new ManagerClient(elements.serverUrl.value);
     setupConfirmingKey = null;
     setupInstallingKey = item.key;
+    setupDownloadCancelled = false;
     renderSetupTab();
 
     const report = (step: InstallStep) => {
@@ -1335,37 +1408,81 @@ export function renderApp(rootElement: HTMLElement) {
     };
 
     try {
-      report("checking-queue");
+      report("resolving-folder");
 
-      const verdict = evaluateQueuePrecondition(await manager.getQueueStatus());
+      const access = await acquireModelsFolder(item.targetPath, createFolderAccessDeps(), {
+        // The picker is opened only because the artist just pressed Download on
+        // this specific model, never speculatively.
+        allowPicker: true
+      });
 
-      if (!verdict.allowed) {
-        setSetupStatus(elements, verdict.message, "error");
+      if (access.kind !== "ready") {
+        setSetupStatus(elements, access.note, access.kind === "failed" ? "error" : "idle");
         return;
       }
 
-      report("queueing");
-      await manager.enqueueModelInstall(createInstallModelRequest(item));
-      await manager.startQueue();
+      const mismatch = describeFolderMismatch(
+        (access.folder as { nativePath?: string }).nativePath ?? null,
+        item.targetFolder
+      );
+
+      if (mismatch) {
+        // Warned, not refused: extra_model_paths.yaml can make an unexpected
+        // folder correct, and OpenLayer cannot see that file.
+        setSetupStatus(elements, mismatch, "idle");
+      }
 
       report("downloading");
-      await waitForManagerQueue(manager);
+
+      const outcome = await downloadModelFile(
+        {
+          url: item.downloadUrl,
+          expectedBytes: typeof item.sizeBytes === "number" ? item.sizeBytes : null
+        },
+        {
+          fetch: (...args) => fetch(...args),
+          destination: createFolderDestination({
+            folder: access.folder as UxpFolderLike,
+            fileName: item.modelName,
+            binaryFormat: (require("uxp") as { storage: { formats: { binary: unknown } } }).storage.formats.binary,
+            statSize: readNativeFileSize
+          }),
+          isCancelled: () => setupDownloadCancelled,
+          onProgress: (progress) => {
+            setSetupStatus(
+              elements,
+              `${item.modelName}: ${formatDownloadProgress(progress)}`,
+              "idle"
+            );
+          }
+        }
+      );
+
+      if (outcome.kind === "cancelled") {
+        setSetupStatus(
+          elements,
+          `Download stopped at ${formatBytesForDownload(outcome.receivedBytes)}. Pressing Download again resumes from there.`,
+          "idle"
+        );
+        return;
+      }
+
+      if (outcome.kind === "failed") {
+        setSetupStatus(elements, `Could not download ${item.modelName}. ${outcome.reason}`, "error");
+        return;
+      }
 
       report("verifying");
     } catch (caughtError) {
-      // A blocked security level is the most likely failure here and the least
-      // self-explanatory, so it keeps its own message rather than being folded
-      // into a generic HTTP failure the user can do nothing with.
       setSetupStatus(
         elements,
-        isManagerSecurityLevelError(caughtError)
-          ? caughtError.message
-          : `Could not install ${item.modelName}. ${getErrorMessage(caughtError)}`,
+        `Could not download ${item.modelName}. ${getErrorMessage(caughtError)}`,
         "error"
       );
       return;
     } finally {
       setupInstallingKey = null;
+      setupDownloadCancelled = false;
     }
 
     // The claim that it worked comes from re-reading ComfyUI's own inventory,
@@ -1389,32 +1506,6 @@ export function renderApp(rootElement: HTMLElement) {
    * The download itself is ComfyUI-Manager's and correctly survives this --
    * what stops is OpenLayer asking about it.
    */
-  async function waitForManagerQueue(manager: ManagerClient) {
-    const deadline = Date.now() + MANAGER_QUEUE_TIMEOUT_MS;
-
-    while (Date.now() < deadline) {
-      if (resourcesDisposed) {
-        return;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, MANAGER_QUEUE_POLL_MS));
-
-      if (resourcesDisposed) {
-        return;
-      }
-
-      const status = await manager.getQueueStatus();
-
-      if (!status.is_processing && status.done_count >= status.total_count) {
-        return;
-      }
-    }
-
-    throw new Error(
-      "ComfyUI-Manager is still working after a long wait. The download may still be running -- check ComfyUI-Manager, then check again here."
-    );
-  }
-
   async function handleSetupCopy(action: SetupRowAction) {
     try {
       await navigator.clipboard.writeText(action.value);
@@ -5123,12 +5214,6 @@ function formatGigabytes(bytes: number): string {
   return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
 }
 
-// Model weights are gigabytes over a home connection, so the ceiling is hours
-// rather than minutes and the poll is slow on purpose: this only asks whether
-// ComfyUI-Manager is still busy, and asking twice a second would tell us
-// nothing a five-second interval does not.
-const MANAGER_QUEUE_POLL_MS = 5000;
-const MANAGER_QUEUE_TIMEOUT_MS = 6 * 60 * 60 * 1000;
 
 const SETUP_EXPECTATION_TONES: Record<VramExpectation, string> = {
   comfortable: "is-setup-ready",
@@ -5294,6 +5379,7 @@ type SetupInstallContext = {
   busy: boolean;
   onRequest: (requirementKey: string) => void;
   onCancel: () => void;
+  onStop: () => void;
   onConfirm: (item: AssistedInstallItem) => void;
 };
 
@@ -5440,9 +5526,15 @@ function createSetupRowElement(
       const installButton = document.createElement("button");
       installButton.type = "button";
       installButton.className = "button setup-row-action is-install";
-      installButton.textContent = isInstalling ? "Installing..." : "Install";
-      installButton.disabled = install.busy;
-      installButton.addEventListener("click", () => install.onRequest(row.key));
+      // A model download is gigabytes over a home connection, so the row that
+      // started one has to be able to stop it. The partial file is resumable,
+      // which is what makes stopping safe to offer rather than a trap.
+      installButton.textContent = isInstalling ? "Stop" : "Download";
+      installButton.disabled = install.busy && !isInstalling;
+      installButton.addEventListener("click", () => {
+        if (isInstalling) install.onStop();
+        else install.onRequest(row.key);
+      });
       actions.append(installButton);
     }
 

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -384,11 +384,19 @@ function createFolderAccessDeps(): FolderAccessDeps {
   };
   const lfs = uxp.storage.localFileSystem;
 
+  // Every one of these must stay bound to localFileSystem. Passing the bare
+  // function reference loses `this`, and UXP's implementations use it -- the
+  // picker fails with "this.__getInitialLocation is not a function", and
+  // getEntryWithUrl fails the same way but silently, because its caller treats
+  // a throw as "fall back to the picker".
+  const bound = <T>(method: unknown): T | undefined =>
+    typeof method === "function" ? ((method as (...args: never[]) => unknown).bind(lfs) as T) : undefined;
+
   return {
-    getEntryWithUrl: lfs.getEntryWithUrl as ((url: string) => Promise<unknown>) | undefined,
-    pickFolder: lfs.getFolder as (() => Promise<unknown | null>) | undefined,
-    createPersistentToken: lfs.createPersistentToken as ((entry: unknown) => Promise<string>) | undefined,
-    getEntryForPersistentToken: lfs.getEntryForPersistentToken as ((token: string) => Promise<unknown>) | undefined,
+    getEntryWithUrl: bound<(url: string) => Promise<unknown>>(lfs.getEntryWithUrl),
+    pickFolder: bound<() => Promise<unknown | null>>(lfs.getFolder),
+    createPersistentToken: bound<(entry: unknown) => Promise<string>>(lfs.createPersistentToken),
+    getEntryForPersistentToken: bound<(token: string) => Promise<unknown>>(lfs.getEntryForPersistentToken),
     readStoredToken: () => {
       try {
         return localStorage.getItem(MODELS_FOLDER_TOKEN_KEY);

--- a/src/ui/setupInstallModel.ts
+++ b/src/ui/setupInstallModel.ts
@@ -19,41 +19,25 @@ export type InstallPhase =
   | { kind: "confirming"; requirementKey: string }
   | { kind: "working"; requirementKey: string; step: InstallStep };
 
-export type InstallStep = "checking-queue" | "queueing" | "downloading" | "verifying";
+export type InstallStep = "resolving-folder" | "downloading" | "verifying";
 
 const STEP_MESSAGES: Record<InstallStep, (modelName: string) => string> = {
-  "checking-queue": () => "Checking that ComfyUI-Manager is free...",
-  queueing: (modelName) => `Handing ${modelName} to ComfyUI-Manager...`,
-  downloading: (modelName) => `Downloading ${modelName}. This does not stop if you leave the screen.`,
+  "resolving-folder": () => "Finding ComfyUI's models folder...",
+  downloading: (modelName) => `Downloading ${modelName}...`,
   verifying: () => "Download finished. Re-checking what ComfyUI can see..."
 };
 
 /**
- * Assisted install is withheld from this release.
+ * Assisted install was withheld through v0.12 because it was built on
+ * ComfyUI-Manager's `install_model`, which only accepts models already in the
+ * Manager's own curated catalogue -- 7 of the 16 this registry pins, several at
+ * URLs that are not ours. The full reasoning is in the git history of this file.
  *
- * ComfyUI-Manager's `/manager/queue/install_model` is not the "download this
- * URL for me" endpoint this feature was built against. Before it does anything
- * it calls `check_whitelist_for_model`, which requires an exact match on
- * `save_path` + `base` + `filename` against the Manager's own curated
- * `model-list.json`. OpenLayer sends its own values -- the real ComfyUI folder
- * name and an artist-facing label -- so every request is rejected with HTTP 400
- * and nothing installs at all.
- *
- * Mapping the fields across is not a fix, which is why this is a flag and not a
- * patch. Only 7 of the 16 models the registry pins are in that catalogue, and
- * for several of the 7 the catalogue's URL is not ours: the Manager fetches
- * `ae.safetensors` from `black-forest-labs/FLUX.1-schnell`, where this project
- * deliberately uses the `Comfy-Org/z_image_turbo` mirror because the Black
- * Forest Labs repos answer 401 without a token. Delegating that download saves
- * an authentication page under the model's filename -- exactly the failure the
- * licence-gate refusal exists to prevent, reintroduced by the mechanism meant
- * to be the safe path.
- *
- * Everything below and in `assistedInstall.ts` is kept: the plan, the refusals
- * and their reasons are all correct and are what a working version is built on.
- * What is missing is a transport that honours the registry's pinned URLs.
+ * It downloads directly now, honouring the registry's pinned URLs, so the
+ * catalogue restriction is gone along with the flag. Everything that was kept
+ * during the withholding -- the plan, the refusals and their reasons -- is the
+ * part that was always correct, and is unchanged.
  */
-export const ASSISTED_INSTALL_ENABLED = false;
 
 /**
  * Whether a requirement row may show an Install button.
@@ -67,29 +51,23 @@ export const ASSISTED_INSTALL_ENABLED = false;
  */
 export function getInstallOffer(
   plan: AssistedInstallPlan | null,
-  managerVersion: string | null,
   requirementKey: string
 ): InstallOffer {
-  if (!ASSISTED_INSTALL_ENABLED) {
-    return { kind: "hidden" };
-  }
-
-  return findInstallOffer(plan, managerVersion, requirementKey);
+  return findInstallOffer(plan, requirementKey);
 }
 
 /**
- * The offer logic on its own, without the release flag.
+ * The offer logic on its own.
  *
- * Kept separate and exported so the plan-and-Manager rules stay under test
- * while `ASSISTED_INSTALL_ENABLED` is false. Turning the feature back on must
- * not mean rediscovering what these rules were.
+ * A row is never offered a Download button that would fail the moment it was
+ * pressed, so every licence-gate and wrong-folder refusal is decided here in
+ * `plan.installable` rather than discovered mid-download.
  */
 export function findInstallOffer(
   plan: AssistedInstallPlan | null,
-  managerVersion: string | null,
   requirementKey: string
 ): InstallOffer {
-  if (!plan || !managerVersion) {
+  if (!plan) {
     return { kind: "hidden" };
   }
 
@@ -115,8 +93,8 @@ export function createInstallConfirmationView(item: AssistedInstallItem): Instal
     ],
     note:
       item.layout === "repo-folder"
-        ? "ComfyUI-Manager downloads this in the background. This entry is a repository folder rather than a single file, so check the result before relying on it."
-        : "ComfyUI-Manager downloads this in the background. Nothing else is installed, and nothing is changed in Photoshop.",
+        ? "This entry is a repository folder rather than a single file, so OpenLayer cannot download it here. Use the model page."
+        : "OpenLayer downloads this itself and can resume if it is interrupted. Nothing else is installed, and nothing is changed in Photoshop.",
     confirmLabel: "Download",
     cancelLabel: "Cancel"
   };
@@ -141,11 +119,11 @@ export function createInstallStatusLine(step: InstallStep, modelName: string): s
 }
 
 /**
- * What the screen says once an install has finished and the setup check has
+ * What the screen says once a download has finished and the setup check has
  * re-run. The claim is deliberately made from the re-checked report rather than
- * from the installer reporting success: ComfyUI-Manager reports that it
- * finished its queue item, which is not the same as ComfyUI being able to see a
- * usable model in the folder its loader reads.
+ * from the download reporting success: bytes landing on disk is not the same
+ * fact as ComfyUI being able to see a usable model in the folder its loader
+ * reads, and only the second one is what the artist needs.
  */
 export function describeInstallResult(
   modelName: string,
@@ -153,7 +131,7 @@ export function describeInstallResult(
 ): { message: string; tone: "ready" | "error" } {
   return stillMissing
     ? {
-        message: `ComfyUI-Manager finished, but ComfyUI still cannot see ${modelName}. Refresh ComfyUI, then check again.`,
+        message: `The download finished, but ComfyUI still cannot see ${modelName}. Refresh ComfyUI, then check again.`,
         tone: "error"
       }
     : { message: `${modelName} is installed and ComfyUI can see it.`, tone: "ready" };

--- a/tests/photoshop/modelFolderAccess.test.ts
+++ b/tests/photoshop/modelFolderAccess.test.ts
@@ -52,6 +52,31 @@ describe("acquiring the models folder", () => {
     expect(result.kind).toBe("needs-grant");
   });
 
+  // A silent fallback once hid an unbound UXP method behind what looked like a
+  // permissions problem. The reason must survive into the message.
+  it("reports why the direct route failed instead of hiding it behind the fallback", async () => {
+    const result = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => {
+        throw new Error("this.__getInitialLocation is not a function");
+      }
+    }));
+
+    expect(result.note).toContain("__getInitialLocation");
+  });
+
+  it("distinguishes a path that did not resolve from one that is not writable", async () => {
+    const unresolved = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => null
+    }));
+    const unwritable = await acquireModelsFolder("C:/comfy/models/loras", deps({
+      getEntryWithUrl: async () => ({ name: "loras" }),
+      canWrite: async () => false
+    }));
+
+    expect(unresolved.note).toContain("did not resolve");
+    expect(unwritable.note).toContain("could not be written to");
+  });
+
   it("asks for a grant rather than opening a picker unprompted", async () => {
     const pickFolder = vi.fn();
 

--- a/tests/ui/setupInstallModel.test.ts
+++ b/tests/ui/setupInstallModel.test.ts
@@ -3,7 +3,6 @@ import { planAssistedInstall } from "../../src/comfy/assistedInstall";
 import { listRunnableWorkflowPresets } from "../../src/comfy/presetRegistry";
 import { evaluateSetupRequirements } from "../../src/comfy/setupRequirements";
 import {
-  ASSISTED_INSTALL_ENABLED,
   createInstallConfirmationView,
   createInstallStatusLine,
   describeDownloadSource,
@@ -15,32 +14,26 @@ import type { ComfyModelInventory, WorkflowPresetDefinition } from "../../src/co
 
 const PLUGIN_VERSION = "9.9.9";
 const FIXED_TIMESTAMP = "2026-08-01T00:00:00.000Z";
-const MANAGER_VERSION = "V3.41";
 
 describe("setup install view model", () => {
-  // ComfyUI-Manager's install_model endpoint rejects every request OpenLayer
-  // can currently build, so no row may offer a button. This asserts the release
-  // flag through the function the panel actually calls, rather than trusting the
-  // constant on its own: a row appearing here is a row that errors in the host.
-  it("offers no install at all while assisted install is withheld", () => {
+  // OpenLayer downloads directly now, so a row no longer depends on
+  // ComfyUI-Manager being installed at all. What must stay true is that only
+  // rows the plan considers installable ever grow a button.
+  it("offers an install for a row the plan considers installable", () => {
     const plan = planAssistedInstall(missingReport());
     const item = plan.installable[0];
 
-    expect(ASSISTED_INSTALL_ENABLED).toBe(false);
     expect(item).toBeDefined();
-    expect(getInstallOffer(plan, MANAGER_VERSION, item.key).kind).toBe("hidden");
+    expect(getInstallOffer(plan, item.key)).toEqual({ kind: "offered", item });
   });
 
-  it("keeps the plan-and-Manager rules under test while the feature is off", () => {
+  it("hides every offer when there is no plan to consult", () => {
     const plan = planAssistedInstall(missingReport());
     const item = plan.installable[0];
 
-    expect(item).toBeDefined();
-    expect(findInstallOffer(plan, MANAGER_VERSION, item.key)).toEqual({ kind: "offered", item });
-    // The same row, with ComfyUI-Manager absent, must not grow a button that
-    // would fail the moment it was pressed.
-    expect(findInstallOffer(plan, null, item.key).kind).toBe("hidden");
-    expect(findInstallOffer(null, MANAGER_VERSION, item.key).kind).toBe("hidden");
+    expect(findInstallOffer(plan, item.key)).toEqual({ kind: "offered", item });
+    expect(findInstallOffer(null, item.key).kind).toBe("hidden");
+    expect(findInstallOffer(plan, "no-such-requirement").kind).toBe("hidden");
   });
 
   it("never offers an install for a requirement the plan excluded", () => {
@@ -49,8 +42,8 @@ describe("setup install view model", () => {
     const gated = report.models.find((model) => model.licenseGated);
 
     expect(gated).toBeDefined();
-    expect(findInstallOffer(plan, MANAGER_VERSION, gated!.key).kind).toBe("hidden");
-    expect(getInstallOffer(plan, MANAGER_VERSION, gated!.key).kind).toBe("hidden");
+    expect(findInstallOffer(plan, gated!.key).kind).toBe("hidden");
+    expect(getInstallOffer(plan, gated!.key).kind).toBe("hidden");
   });
 
   it("puts the file, the size, the destination and the host in the confirmation", () => {
@@ -77,7 +70,7 @@ describe("setup install view model", () => {
 
   it("names the model in the download step, because that is the slow one", () => {
     expect(createInstallStatusLine("downloading", "ae.safetensors")).toContain("ae.safetensors");
-    expect(createInstallStatusLine("checking-queue", "ae.safetensors")).toContain("ComfyUI-Manager");
+    expect(createInstallStatusLine("resolving-folder", "ae.safetensors")).toContain("models folder");
   });
 
   it("reports the result from the re-check, not from the installer finishing", () => {


### PR DESCRIPTION
Wires the engine from #81 to the Setup screen's Missing rows and turns assisted install back on.

## The flag is gone, not flipped

`ASSISTED_INSTALL_ENABLED` existed because the transport was ComfyUI-Manager's `install_model`, which only accepts models already in the Manager's own catalogue — 7 of the 16 this registry pins, several at URLs that aren't ours. OpenLayer downloads directly now, honouring the registry's pinned URLs, so the restriction is gone along with the flag.

**Everything kept during the withholding was the part that was always correct, and is unchanged.** Licence-gated models, wrong-folder files and models with no pinned URL are still refused, still for the reasons written down at the time. A row never grows a button that would fail the moment it was pressed.

Offers no longer depend on ComfyUI-Manager existing at all, so the manager-version condition and the queue-polling code it needed are **deleted** rather than left to rot — `waitForManagerQueue`, `evaluateQueuePrecondition`, `createInstallModelRequest`, the timeout constants and the `ManagerClient` import.

## You can stop it

The button becomes **Stop** while its own download runs. A model is gigabytes over a home connection, so the row that started one has to be able to stop it — and because the partial file resumes, stopping is safe to offer rather than a trap. Pressing **Download** again continues from where it left off.

I nearly shipped this without a stop control. An 18 GB download with no way out is a worse failure than not having the feature.

## The size problem, and why lstat matters

Resuming needs a partial file's length. Reading the file back to get it would pull an 18 GiB model into memory — exactly what the chunked design exists to prevent. It goes through **`fs.lstat`**, which the spike confirmed this UXP build exposes. Where lstat is unavailable the answer is 0: a restarted download is recoverable, a wrongly resumed one silently produces a corrupt model.

## Folder access follows the spike's split finding

The spike found the path **resolved with no dialog** but the write **failed**. So: resolve quietly, prove it's writable with a real probe file, and only then ask — once — remembering the grant with a persistent token. A stale token means "ask again", never an error.

A folder that doesn't match the expected subfolder **warns without refusing**. Your `extra_model_paths.yaml` can make an unusual location correct, and OpenLayer can't see that file; refusing would be OpenLayer overruling you about your own setup.

## Unchanged on purpose

Success is still claimed from **re-reading ComfyUI's own inventory**, never from the download reporting completion. Bytes on disk and a model ComfyUI can load are different facts, and only the second one matters.

## Validation

`typecheck`, `test` (67 files / **612**), `build`, `lint` — all clean.

## Smoke test

The honest one is short: **Setup → find a Missing row → Download.** Watch the percentage move, press **Stop** partway, then press **Download** again and confirm it resumes rather than restarting. If a folder picker appears, it should appear *once* and not again on the next download.

Worth knowing: the first model you try may be the one that reveals whether the direct write works on your machine or whether the picker is needed — the spike said those two disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)