### PR TITLE
Release v0.13.0-alpha: LoRA support, Depth ControlNet, and two broken presets fixed

### DIFF
--- a/.claude/agents/WFL.md
+++ b/.claude/agents/WFL.md
@@ -27,7 +27,7 @@ Read `docs/ORCHESTRATION.md` first, every time. It is the durable source of trut
 Judge everything against these. A suggestion that ignores them wastes the developer's time.
 
 **Hardware ceiling.** The only verified machine is an **RTX 4070 Ti, 12 GB VRAM**, 31.7 GB system
-RAM, Windows 11. ComfyUI 0.27.1, Python 3.10.11, PyTorch 2.6.0+cu124. Anything you recommend must run
+RAM, Windows 11. ComfyUI 0.30.0, Python 3.10.11, PyTorch 2.6.0+cu124. Anything you recommend must run
 in 12 GB, and you must say how — fp8, GGUF quant, tiled VAE, sequential offload — with a measured or
 sourced figure, not a guess. For reference, Krea-2 Turbo at 1024² 8 steps takes ~38-48 s on this card
 with offloading; SD 1.5 + LCM at 512² 5 steps is ~0.5-0.7 s. If a model cannot beat those on quality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## v0.13.0-alpha - 2026-08-07
+
+LoRAs, at last: every preset that loads a model and a text encoder — eleven of them, across Text to Image, Image to Image and Sketch to Image — now takes an optional LoRA. The panel has been able to list the LoRAs on your disk since long before it could use one.
+
+Two presets that were quietly broken are fixed. Sketch to Image fed ControlNet a blank control image for light-on-dark art, so the sketch was ignored with no error at all. The Flux.2 dev (GGUF) preset that headlined v0.12.0 could not actually be run: its model dropdown never listed a `.gguf` file, and choosing it and pressing Generate failed outright. Both were reported by a tester using the release, which is what the alpha is for.
+
+### Added
+
+- **An optional LoRA on eleven presets.** One dropdown and one strength control per tool. Choosing nothing leaves the workflow byte-identical to the one that ships, because a LoRA cannot be a permanently wired node whose value is merely set: ComfyUI's `LoraLoader` has no "none" entry, so a wired-in loader would force everyone to own and load a LoRA they may not want. The loader is spliced into the graph only when a LoRA is actually chosen, and the model and text-encode inputs downstream are rewired to it. This is the first time building a workflow changes its shape rather than its values, so each preset declares its own wiring rather than having it guessed — three genuinely different shapes turned up among the eleven, including one where the LoRA must be applied before a sampling-mode wrapper rather than at the sampler.
+- **A Depth ControlNet Sketch to Image preset.** LineArt and Scribble both hold the drawn stroke; neither carries depth. This one conditions on estimated scene depth, so it holds perspective and the relative distance of forms — the preset to reach for when a generated element has to sit inside an existing composite at the right camera angle. It works from any shaded image, not only a line drawing, and needs one new ControlNet model. No new custom node package: the depth estimator comes from `comfyui_controlnet_aux`, which the sketch presets already required.
+- **A Scribble Sketch to Image preset**, on the PiDiNet edge detector and the Scribble ControlNet, for loose gestural strokes where LineArt holds the drawn line too tightly. Its ControlNet model was already installed for most users and it needs no new node package.
+
+### Fixed
+
+- **Sketch to Image ignored the sketch entirely for a whole class of drawing.** `LineartStandardPreprocessor` assumes dark strokes on white paper, so light-on-dark art and solid filled shapes produced a pure-black control image — measured at 0% ink on a 1024px filled silhouette. ControlNet had no signal, the preset degraded to plain text-to-image, and nothing anywhere reported a problem. It now uses a learned, polarity-robust detector (`AnyLineArtPreprocessor_aux`, 1.14% ink on the same source). Both sketch preprocessors also run at 1024 rather than a hardcoded 512, which had been discarding line detail before ControlNet ever saw it.
+- **The Flux.2 dev (GGUF) preset could not be selected or run.** Its Model dropdown asked ComfyUI's core `UNETLoader` for the file list, and that loader does not enumerate `.gguf` files at all — so a correctly installed quantised model was invisible no matter where it was placed. Pressing Generate then failed regardless, because the builder required a negative-prompt target on a preset that deliberately has none, Flux.2 being guidance-distilled with no negative conditioning node in its reference graph.
+
+### Changed
+
+- The Flux.2 GGUF workflow is now bundled with the panel like every other preset's, instead of being fetched at runtime — it was the only runnable preset left out of that map.
+
+### Known limitations
+
+- **The LoRA list cannot be filtered by which model a LoRA suits, and a mismatched one fails silently.** ComfyUI reports only a LoRA's name, size and timestamps; nothing reachable over the wire says what it was trained against. The metadata that would say is not served, and is not reliable even when read directly — two LoRAs on the reference machine declare `ss_base_model_version: sd_1.5` while their tensor keys are plainly Flux. So the panel lists every LoRA, labels the entries whose *filenames* suggest a match or a mismatch, sorts likely matches first, and warns. Picking a LoRA meant for another model loads without any error and then does nothing: an unchanged image is the symptom to expect.
+- **A LoRA roughly doubles Flux.2's inference time**, which is already minutes per image on a 12 GB card.
+- **Whether a Krea-2 LoRA trained on Raw behaves correctly on the Turbo checkpoint is unverified.** Krea's own guidance is to train on Raw and marks Turbo as not recommended for training, but no source addresses applying the result at Turbo's 8 steps.
+- **The Depth preset downloads its depth estimator on first use.** The ControlNet weight is a normal setup download, but `DepthAnythingV2Preprocessor` fetches its own estimator the first time it runs, so the first generation is much slower than later ones. Depth estimation also needs tonal variation — a flat line drawing gives it little to read.
+- Batch generation is designed but not built; the design note is in `docs/BATCH_GENERATION.md`. Image to Image cannot batch at all without further work, because it builds its latent from the captured layer.
+- **Assisted install remains withheld, and the Setup screen still only reports and copies.** ComfyUI-Manager's `install_model` endpoint only accepts entries from its own curated catalogue, which holds 7 of the 16 model files this project pins, and for several of those its download URL is not the one the registry pins. Unchanged from v0.12.0.
+- **The Flux.2 GGUF preset is slow on a 12 GB card, by a wide margin** — an 18.7 GB quantised model plus a 16.8 GB text encoder means ComfyUI streams most of it from system RAM. It also needs `mistral_3_small_flux2_fp8.safetensors`, which is licence-gated: accept the licence in a browser and download it by hand.
+- **Live Painting is experimental.** The live tier needs an SD 1.5 LCM LoRA in `models/loras/`; the Refine tier additionally needs the three Krea-2 Turbo files.
+- Setup and Workflow Health overlap on purpose for now. Setup answers "what do I need and where does it go"; Health answers "can I run this preset right now".
+- "What will run well" reads the VRAM ComfyUI reports for its primary device. With ComfyUI stopped, every preset falls back to "Not known".
+- The panel still cannot open a browser, which is why rows offer Copy Link rather than a button that opens the page.
+- **The `.ccx` one-click install is verified on one configuration only** — Windows 11, Photoshop 2025 (26.1.0). macOS and every other Photoshop version remain untested.
+- The Layer Tools card on Home does not dim when ComfyUI is unreachable, unlike the generation tools.
+- Layer, canvas, selection, and mask capture is limited to 16 megapixels (4096 x 4096) until a downscale option is added.
+- The Preview panel offers each tool's primary import only.
+- The setup pack contains no model weights — it ships the list and the downloader instead, so an internet connection is required.
+- Inpaint and Outpaint remain experimental and should be tested on duplicate layers or disposable documents.
+- CI covers pure TypeScript behavior but does not run Photoshop, UXP Developer Tool, or ComfyUI integration tests.
+
 ## v0.12.0-alpha - 2026-08-01
 
 Two things for people running Flux: a Text to Image preset for the GGUF-quantised FLUX.2-dev, and the end of a long-standing embarrassment — every preset the panel lists is now one you can actually run, because the two that never could have been are gone rather than still promising a workflow that was never coming.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.12.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
+`v0.13.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
 
-New in `v0.12.0-alpha`:
+New in `v0.13.0-alpha`:
 
-- **A Flux.2 dev (GGUF) Text to Image preset**, built on ComfyUI's own shipped Flux.2 template and the advanced sampler chain. Experimental, and honestly slow on a 12 GB card: an 18.7 GB model plus a 16.8 GB text encoder means minutes per image, not seconds.
-- **Every preset the panel lists is now one you can actually run.** The two Flux1-dev presets that had been advertising themselves as awaiting a workflow JSON since v0.2.2 are removed rather than finished — the full-precision weight has no 12 GB story and `txt2img-flux1-dev-fp8` already covers Flux Text to Image.
-- **Assisted install is withheld from this release.** It was built on the belief that ComfyUI-Manager's install endpoint would fetch a given URL on request; it will not, and only accepts models from its own curated catalogue on its own terms. The Setup screen therefore still reports and copies, as in v0.11.0. See the CHANGELOG for the full reasoning — including why mapping the fields across would not have fixed it.
+- **An optional LoRA on eleven presets**, across Text to Image, Image to Image and Sketch to Image. One dropdown and one strength control per tool. Choosing nothing leaves the shipped workflow untouched — the loader is spliced into the graph only when you actually pick a LoRA.
+- **A Depth ControlNet Sketch to Image preset.** LineArt and Scribble hold the drawn stroke; this one holds the scene's perspective, which is what you want when a generated element has to sit in an existing composite at the right camera angle. Needs one new ControlNet model, no new node package.
+- **Sketch to Image no longer ignores your sketch.** Light-on-dark art and solid filled shapes produced a blank control image, so ControlNet had no signal and the preset quietly became plain text-to-image. Fixed, and both sketch preprocessors now run at 1024 instead of 512.
+- **The Flux.2 dev (GGUF) preset actually runs now.** In v0.12.0 its model dropdown never listed a `.gguf` file and pressing Generate failed outright. Both were reported by a tester on the release.
 
 Also new in `v0.11.0-alpha`:
 
@@ -111,13 +112,15 @@ The earlier card-based dashboard established OpenLayer's honest available/experi
 
 </details>
 
-v0.12.0-alpha tester focus:
+v0.13.0-alpha tester focus:
 
-- Open **Setup** with ComfyUI running and confirm **no row anywhere offers an Install button**, including missing rows, with ComfyUI-Manager installed. Every row should offer only Copy Link, Copy Folder Path and Copy Page, exactly as in v0.11.0. This is the check that matters most in this release: an Install button appearing is a button that errors.
-- To make a missing row that is *not* licence-gated, temporarily rename a model you already have — `models/upscale_models/4x-UltraSharp.pth` is the smallest at 64 MB — then click **Check Again**. Confirm that row reports Missing, still offers no Install button, and names the folder and size correctly. Rename it back afterwards.
-- Open **Check Workflow Health** and confirm the **Flux.2 dev (GGUF)** preset appears, is marked experimental, and reports only the Mistral-3 encoder as missing if that is the only file you lack — not the 18.7 GB GGUF model you already have.
-- Confirm the two Flux1-dev presets are **gone** from every preset list, and that no remaining preset says it needs a workflow JSON.
-- Confirm the panel footer reads `v0.12.0`.
+- Open **Text to Image**, pick `txt2img-krea2-turbo`, and confirm a **LoRA (optional)** row appears with `None` selected and no strength field. Generate once with `None` — it must succeed — then pick a LoRA and generate again at the same seed. The two images must differ.
+- Switch the Workflow dropdown across every preset in Text to Image, Image to Image and Sketch to Image and confirm the LoRA row appears for all of them. Confirm it does **not** appear on Inpaint, Outpaint or Upscale.
+- Set a different LoRA in each of the three tools and generate in each. None should leak into another tool.
+- Pick a LoRA whose name mentions a different model family than the preset. It should still be selectable, marked `(name suggests another model)`, and generating should **succeed with a visibly unchanged image** — that is the silent failure the warning describes, not a bug.
+- Open **Sketch to Image**, pick the new **Depth ControlNet** preset, and generate from a *shaded* layer rather than flat line art. The first run downloads the depth estimator and is much slower than later ones.
+- Draw light strokes on a dark layer and run **LineArt**. The result must follow the drawing rather than ignoring it.
+- Confirm the panel footer reads `v0.13.0`.
 
 Also worth rechecking from v0.11.0-alpha:
 
@@ -152,7 +155,7 @@ Also worth rechecking from v0.9.0-alpha:
 - Run `npm run setup-pack` and confirm it reports no source/API mismatches at all.
 - Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
-Known v0.12.0-alpha boundaries:
+Known v0.13.0-alpha boundaries:
 
 - **The Setup screen reports and copies. It does not download or install anything.** Assisted install was built for this release and withheld: ComfyUI-Manager's install endpoint only accepts models from its own curated catalogue, matched exactly on `save_path`, `base` and `filename`, so every request OpenLayer could build was rejected. Only 7 of the 16 models this project pins are in that catalogue, and for several of those the catalogue's URL is not the one the registry verified — so the fix is a download path that honours our own URLs, not a field mapping. Full reasoning in the CHANGELOG.
 - The **Flux.2 GGUF preset is slow on a 12 GB card**: minutes per image, not seconds, and its text encoder is licence-gated, so accept the licence in a browser and download it by hand.
@@ -326,10 +329,10 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.12.0-alpha.zip
+packages/openlayer-v0.13.0-alpha.zip
 ```
 
-`npm run package` also writes `packages/openlayer-v0.12.0-alpha.ccx` beside it, from the same files.
+`npm run package` also writes `packages/openlayer-v0.13.0-alpha.ccx` beside it, from the same files.
 
 ## One-click install (verified 2026-08-03)
 
@@ -339,7 +342,7 @@ other installed plugin.
 
 This was an open question across three releases and is now answered. What was checked, on Windows 11
 with Photoshop 2025 (26.1.0): the package installs, Adobe's Unified Plugin Installer Agent reports it
-as `Enabled OpenLayer 0.12.0` under *Photoshop 2025 64*, it unpacks to
+as `Enabled OpenLayer 0.13.0` under *Photoshop 2025 64*, it unpacks to
 `%APPDATA%\Adobe\UXP\Plugins\External\com.openlayer.photoshop_<version>\` with no `debug.json` — a
 packaged install rather than a developer load — and the panel opens and works in Photoshop.
 
@@ -494,7 +497,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.12.0-alpha test result:
+Use this quick pass before reporting a v0.13.0-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.

--- a/docs/BATCH_GENERATION.md
+++ b/docs/BATCH_GENERATION.md
@@ -1,0 +1,171 @@
+# Batch / multi-variation generation — design
+
+Status: **draft for review**. No code written. Written 2026-08-07.
+
+Generate several variations from one prompt in a single run, look at them, and
+import the one that works. Today every generation is one image, so exploring
+means clicking Generate repeatedly and losing each previous result.
+
+---
+
+## What is actually true today
+
+Verified against the current tree rather than assumed.
+
+**ComfyUI already batches.** `batch_size` is a plain input on the empty-latent
+node, and it is already present in **8 of the shipped workflows**:
+
+| Preset | Latent node with `batch_size` |
+| --- | --- |
+| `txt2img-basic`, `txt2img-krea2-turbo` | `EmptyLatentImage` |
+| `txt2img-flux1-dev-fp8`, `txt2img-z-image-turbo` | `EmptySD3LatentImage` |
+| `txt2img-flux2-dev-gguf` | `EmptyFlux2LatentImage` |
+| `sketch2img-linecn-basic`, `-scribble-basic`, `-depth-basic` | `EmptyLatentImage` |
+
+The three **img2img** presets do not have one: they build their latent with
+`VAEEncode` from the captured layer, so there is no `batch_size` to set. Batching
+those needs a `RepeatLatentBatch` node spliced in — the same kind of topology
+change the LoRA work introduced, and a separate piece of work from this one.
+
+Inpaint, outpaint, upscale and prompt-from-layer are out of scope: their output
+is a patch or a caption tied to one region, and "four variations" is not a
+meaningful thing to import.
+
+**Nothing currently reads more than one image back.** `findImageOutput`
+(`src/comfy/comfyClient.ts:954`) takes `output.images?.[0]` and returns the
+first match; `retrieveFirstOutputImage` wraps it. ComfyUI's history already
+contains every image of the batch — the client simply discards them.
+
+**There is no `batchSize` injection name** in `WorkflowInjectionName`
+(`src/comfy/types.ts`).
+
+---
+
+## Correcting an assumption
+
+The earlier concern — that batch breaks the generation controller's
+one-run-at-a-time invariant (A4) — **does not hold**, and it changed the shape of
+this design.
+
+`createGenerationController` (`src/ui/generationController.ts:110`) gates on
+*which run is current*: `publish`, `assertCanCommit` and `finish` all compare a
+run id. A batch is still **one prompt, one prompt id, one run**. The controller
+never inspects the result's shape; `runPipeline` is generic in `TImage` and
+simply hands whatever it retrieved to `commit`.
+
+So A4 is untouched. What breaks is narrower and real:
+
+1. **The result type.** `retrieveFirstOutputImage` returns one
+   `GeneratedImageResult`; `commit` takes one.
+2. **Preview URL ownership (A5).** `createResultPreviewPanel`
+   (`src/ui/previewState.ts:99`) owns exactly two URL slots — one result, one
+   live frame. N results need N owned slots, all revoked together.
+3. **Import.** One result means "Import" is unambiguous. N results is a
+   product question, not a plumbing one — see the decisions below.
+
+That reframing means the risky part is the **preview panel and import UX**, not
+the run controller.
+
+---
+
+## Proposed design
+
+### Getting N images back
+
+Add `findImageOutputs` alongside `findImageOutput` (keeping the single-image
+path untouched for every tool that is not batching), and a
+`retrieveOutputImages` that returns `GeneratedImageResult[]`.
+
+`runPipeline` needs no change: `TImage` becomes `GeneratedImageResult[]` for the
+batching tools, and `commit` receives the array. The run-integrity gates are
+shape-agnostic and stay exactly as they are.
+
+### Setting the batch size
+
+A new `batchSize` injection name, targeting each preset's existing empty-latent
+node. **No graph surgery** — this is an ordinary value injection, unlike the
+LoRA work. Eight presets get it by adding one line each to their injection map.
+
+### Preview
+
+The result panel gains a **thumbnail strip** under the main image. The main
+image shows the selected variation; clicking a thumbnail selects it. With a
+batch of 1 the strip is hidden and the panel behaves exactly as it does today —
+that fallback is what keeps the change safe for every existing flow.
+
+Ownership: one `OwnedObjectUrl` per variation, released as a set whenever a new
+run commits or the panel clears. The existing single `resultUrl` slot becomes
+the *selected* one, which keeps `showResult(blob)` working unchanged for
+non-batch tools.
+
+### Live preview during the run
+
+Unchanged. ComfyUI streams preview frames for the batch as a single image strip
+or the first member depending on the sampler; either way the existing
+`showProgress` path handles it, and the thumbnail strip only appears once the
+run completes.
+
+---
+
+## Decisions needed before implementation
+
+These change what gets built, so they are yours rather than mine.
+
+### D1 — What does Import do with N images?
+
+| Option | Behaviour |
+| --- | --- |
+| **A (recommended)** | "Import to Layers" imports **only the selected** variation. One extra button, "Import All", adds every variation as its own layer. |
+| B | Import always brings in all N as layers; the artist deletes the ones they do not want. |
+| C | Import only ever brings in the selected one; no bulk option. |
+
+A keeps today's one-click behaviour identical for a batch of 1, and makes the
+bulk case explicit rather than surprising. B risks dumping four full-size layers
+into a document on a single click.
+
+### D2 — Default and maximum batch size
+
+Cost is linear: on the reference machine Krea-2 Turbo is ~38–48 s per image, so
+a batch of 4 is roughly 3 minutes. `txt2img-flux2-dev-gguf` measured **207 s for
+one image**, so a batch of 4 is ~14 minutes.
+
+Recommendation: **default 1** (today's behaviour, so nothing changes until
+asked), **maximum 4**, and a visible time-estimate note once the batch size is
+above 1. A different, lower cap specifically for Flux.2 is worth considering.
+
+### D3 — One history entry per run, or per image?
+
+Recommendation: **one entry per imported image**, created at import time rather
+than at generation time — history exists to get a result back, and a variation
+that was never imported has no layer to return to. This needs confirming against
+how `addHistoryEntry` is used today.
+
+### D4 — Does the sketch tool get batching in the first pass?
+
+The three sketch presets can batch with the same one-line injection as txt2img,
+since their latent is empty and only the ControlNet reads the captured image. It
+is nearly free. The question is whether the thumbnail strip is worth the panel
+space on that card in the first pass, or whether pass 1 should be txt2img only.
+
+---
+
+## Staging
+
+1. **Retrieval + injection** — `findImageOutputs`, `retrieveOutputImages`,
+   `batchSize` injection on the 8 eligible presets, plus tests. No UI. Nothing
+   user-visible changes because the panel still asks for 1.
+2. **Preview strip + selection + import** — the real UI work, gated on D1–D4.
+3. **img2img batching** — `RepeatLatentBatch` splice, reusing the insertion
+   machinery the LoRA work established. Separate piece.
+
+Stage 1 is safe to build before the decisions land; stage 2 is not.
+
+---
+
+## What this design does not do
+
+- No parallel runs. One prompt, one run, one cancel — unchanged.
+- No change to how cancellation works: cancelling a batch cancels the whole
+  prompt, as it does now.
+- No re-roll-one-variation feature. That needs per-image seeds and is a
+  different design.

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,10 +33,10 @@
       "operatingSystem": "Windows, macOS",
       "applicationCategory": "DesignApplication",
       "applicationSubCategory": "Adobe Photoshop plugin",
-      "softwareVersion": "0.12.0-alpha",
+      "softwareVersion": "0.13.0-alpha",
       "description": "Open-source Photoshop UXP plugin that connects to a local ComfyUI server for AI image generation: text to image, image to image, sketch to image, inpaint, outpaint, and upscale with Stable Diffusion, SDXL, and Flux models.",
       "url": "https://mehran-ahmadi.com/OpenLayer/",
-      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.12.0-alpha",
+      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.13.0-alpha",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Mehran Ahmadi", "url": "https://github.com/MehranMarxian" }
     }
@@ -65,7 +65,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.12.0 · free &amp; open source</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.13.0 · free &amp; open source</p>
           <h1 id="hero-title">Local AI layers,<br><span class="grad">inside Photoshop.</span></h1>
           <p class="hero-lede">
             OpenLayer connects Photoshop to <strong>your own ComfyUI server</strong>.
@@ -74,7 +74,7 @@
             <strong>No cloud. No credits. No subscription.</strong>
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.12.0-alpha">Download alpha</a>
+            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.13.0-alpha">Download alpha</a>
             <a class="button button-secondary" href="https://github.com/MehranMarxian/OpenLayer">Star on GitHub</a>
           </div>
           <ul class="signal-list" aria-label="Project signals">
@@ -285,7 +285,7 @@
             <article class="setup-step">
               <span>1</span>
               <h3>Download and double-click</h3>
-              <p>Grab <code>openlayer-v0.12.0-alpha.ccx</code> from the <a href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.12.0-alpha">latest release</a> and double-click it. Creative Cloud installs the panel — no developer tools, nothing to build.</p>
+              <p>Grab <code>openlayer-v0.13.0-alpha.ccx</code> from the <a href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.13.0-alpha">latest release</a> and double-click it. Creative Cloud installs the panel — no developer tools, nothing to build.</p>
             </article>
             <article class="setup-step">
               <span>2</span>
@@ -322,11 +322,11 @@
             </article>
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.12.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.13.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
-              <p>v0.12.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
+              <p>v0.13.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
             </article>
             <article class="status-card">
               <h3>Flux Fill is experimental</h3>
@@ -342,14 +342,15 @@
             <summary>Honest alpha boundaries</summary>
             <ul class="check-list two-col">
               <li><code>txt2img-basic</code>, <code>img2img-basic</code>, and <code>sketch2img-linecn-basic</code> are starter workflows, not final production presets.</li>
-              <li>Sketch to Image currently targets SD 1.x LINECN with <code>epicrealism_naturalSinRC1VAE.safetensors</code> and <code>control_v11p_sd15_lineart_fp16.safetensors</code>.</li>
+              <li>Sketch to Image targets SD 1.x with <code>epicrealism_naturalSinRC1VAE.safetensors</code> and offers LineArt, Scribble and Depth ControlNet presets, each needing its own ControlNet model.</li>
               <li>Custom ComfyUI workflows may need node ID updates in the preset registry.</li>
               <li>GPU-aware recommendations are advisory only. OpenLayer does not auto-switch models or workflows yet.</li>
               <li>Layer, canvas, and mask capture is limited to 16 megapixels until a downscale option is added.</li>
               <li>Inpaint and Outpaint should be tested on duplicate layers first.</li>
               <li>Prompt from Layer requires the local Florence-2 PromptGen model and the comfyui-florence2 nodes. The custom-scripts pack is no longer needed.</li>
               <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-              <li>Custom workflow import, LoRA browser, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.12.0 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>Custom workflow import, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.13.0 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>The LoRA list cannot be filtered by which model a LoRA suits: ComfyUI reports only a name and size. Entries are labelled from their filenames and likely matches sorted first, but a mismatched LoRA loads without error and quietly does nothing.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
               <li>Progress is shown in the generation status panel rather than pinned to the screen header, so it scrolls with the form.</li>
@@ -431,7 +432,7 @@
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.12.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.13.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a>
       </p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/comfy/loraCompatibility.ts
+++ b/src/comfy/loraCompatibility.ts
@@ -1,4 +1,20 @@
-import { WorkflowPresetDefinition } from "./types";
+import { WorkflowLoraSelection, WorkflowPresetDefinition } from "./types";
+
+/**
+ * Value of the "None" entry in the LoRA dropdown.
+ *
+ * Not the empty string, which is the obvious choice and is wrong here.
+ * `readSelectValue` falls back to an option's *label* when its value is empty,
+ * because UXP selects do not always report `.value` -- harmless for every other
+ * dropdown in the panel, where the value and the label are the same string, but
+ * for an empty-valued "None" it hands back the literal text "None". That then
+ * reads as a LoRA choice: the strength field appears and ComfyUI rejects the
+ * prompt, because no file is called None.
+ *
+ * A sentinel that is neither empty nor a plausible filename survives that
+ * fallback intact.
+ */
+export const NO_LORA_VALUE = "__openlayer_no_lora__";
 
 /**
  * A guess, from the filename alone, about whether a LoRA suits a preset.
@@ -76,6 +92,50 @@ export function getLoraFamilyHint(loraName: string, preset: WorkflowPresetDefini
   }
 
   return "unknown";
+}
+
+/**
+ * Whether a raw dropdown value represents an actual LoRA choice.
+ *
+ * The bare label "None" is rejected as well as the sentinel. With the sentinel
+ * in place `readSelectValue` should never fall back to the label, so this is
+ * belt and braces -- but the fallback is a UXP behaviour rather than a choice
+ * this code controls, and the failure it caused was a rejected prompt rather
+ * than anything obvious. A real LoRA file would be "None.safetensors", which
+ * is a different string and still selectable.
+ */
+export function isLoraSelected(rawValue: string): boolean {
+  const trimmed = rawValue.trim();
+
+  return trimmed !== "" && trimmed !== NO_LORA_VALUE && trimmed !== "None";
+}
+
+/**
+ * Turns the two raw control values into a selection, or undefined for "None".
+ *
+ * Pure so the "None" case can be pinned by a test: it was a live defect, and
+ * the failure was invisible in the builder -- the workflow was built correctly
+ * from whatever it was handed, and the wrong thing was handed to it.
+ */
+export function resolveLoraSelection(
+  rawName: string,
+  rawStrength: string,
+  defaultStrength: number
+): WorkflowLoraSelection | undefined {
+  if (!isLoraSelected(rawName)) {
+    return undefined;
+  }
+
+  const parsed = Number.parseFloat(rawStrength);
+  // A blank or junk strength falls back rather than sending NaN to ComfyUI,
+  // which would fail validation with a far less obvious message.
+  const strength = Number.isFinite(parsed) ? parsed : defaultStrength;
+
+  return {
+    loraName: rawName.trim(),
+    strengthModel: strength,
+    strengthClip: strength
+  };
 }
 
 /** Short suffix for a dropdown entry. Empty when there is nothing useful to say. */

--- a/src/comfy/loraCompatibility.ts
+++ b/src/comfy/loraCompatibility.ts
@@ -1,0 +1,92 @@
+import { WorkflowPresetDefinition } from "./types";
+
+/**
+ * A guess, from the filename alone, about whether a LoRA suits a preset.
+ *
+ * `unknown` is the honest majority case and must stay usable: the panel labels
+ * it and lets the artist proceed.
+ */
+export type LoraFamilyHint = "matches" | "foreign" | "unknown";
+
+/**
+ * Tokens that name a model family in the wild. A filename containing one of
+ * these for a family the preset does not use is very likely trained for
+ * something else.
+ *
+ * This is filename matching, not detection. It exists because nothing better is
+ * reachable: ComfyUI serves only a LoRA's name, size and timestamps
+ * (`/models/loras` and `/experiment/models/loras` both stop there), so the
+ * panel cannot inspect a file it is offering. The safetensors metadata that
+ * would answer the question is not served, and is not trustworthy anyway --
+ * measured on the reference machine, `illustration.safetensors` and
+ * `meat_v1.safetensors` both declare `ss_base_model_version: sd_1.5` while
+ * their tensor keys (`transformer.single_transformer_blocks.*`) are plainly
+ * Flux. A filename says less but at least does not actively lie.
+ */
+const FOREIGN_FAMILY_TOKENS = [
+  "flux",
+  "sdxl",
+  "sd15",
+  "sd1.5",
+  "sd_1.5",
+  "z-image",
+  "zimage",
+  "z_image",
+  "pony",
+  "illustrious",
+  "wan",
+  "qwen",
+  "hunyuan",
+  "sd3"
+] as const;
+
+function normalize(loraName: string): string {
+  return loraName.toLowerCase().replace(/\\/g, "/");
+}
+
+/**
+ * What the filename suggests about this LoRA's fit for the preset.
+ *
+ * Deliberately asymmetric: it returns `matches` only on a positive token the
+ * preset itself declares, and never infers a match from the absence of a
+ * foreign token. Over-claiming a match is the one error that would actively
+ * mislead, because a mismatched LoRA fails silently rather than erroring.
+ */
+export function getLoraFamilyHint(loraName: string, preset: WorkflowPresetDefinition): LoraFamilyHint {
+  const matchTokens = preset.loraInsertion?.familyTokens ?? [];
+  const normalized = normalize(loraName);
+
+  if (matchTokens.some((token) => normalized.includes(token.toLowerCase()))) {
+    return "matches";
+  }
+
+  const ownTokens = matchTokens.map((token) => token.toLowerCase());
+
+  for (const token of FOREIGN_FAMILY_TOKENS) {
+    // A token the preset claims as its own is never foreign, even if it also
+    // appears in this list -- a Qwen-based preset would otherwise flag its own
+    // LoRAs.
+    if (ownTokens.includes(token)) {
+      continue;
+    }
+
+    if (normalized.includes(token)) {
+      return "foreign";
+    }
+  }
+
+  return "unknown";
+}
+
+/** Short suffix for a dropdown entry. Empty when there is nothing useful to say. */
+export function formatLoraHintSuffix(hint: LoraFamilyHint): string {
+  if (hint === "matches") {
+    return "  (name matches this model)";
+  }
+
+  if (hint === "foreign") {
+    return "  (name suggests another model)";
+  }
+
+  return "";
+}

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -441,6 +441,69 @@ const KREA2_TURBO_TXT2IMG_NODES = {
  * workflow stops at 22, and applyLoraSelection refuses to overwrite an
  * occupied id rather than trusting this comment to stay true.
  */
+/**
+ * A checkpoint loader is its own CLIP source: CheckpointLoaderSimple outputs
+ * MODEL on slot 0 and CLIP on slot 1, where a diffusion-model stack has two
+ * separate loaders. Both shapes splice the same way, which is why the insertion
+ * declares a slot rather than assuming one.
+ */
+const TXT2IMG_BASIC_LORA_INSERTION = {
+  nodeId: "10",
+  familyTokens: ["sd15", "sd1.5", "sd_1.5"],
+  modelSource: { nodeId: TXT2IMG_BASIC_NODES.checkpointLoader, slot: 0 },
+  clipSource: { nodeId: TXT2IMG_BASIC_NODES.checkpointLoader, slot: 1 },
+  modelConsumers: [{ nodeId: TXT2IMG_BASIC_NODES.sampler, inputName: "model" }],
+  clipConsumers: [
+    { nodeId: TXT2IMG_BASIC_NODES.positivePrompt, inputName: "clip" },
+    { nodeId: TXT2IMG_BASIC_NODES.negativePrompt, inputName: "clip" }
+  ]
+} as const;
+
+const FLUX1_DEV_FP8_TXT2IMG_LORA_INSERTION = {
+  nodeId: "36",
+  familyTokens: ["flux"],
+  modelSource: { nodeId: FLUX1_DEV_FP8_TXT2IMG_NODES.checkpointLoader, slot: 0 },
+  clipSource: { nodeId: FLUX1_DEV_FP8_TXT2IMG_NODES.checkpointLoader, slot: 1 },
+  modelConsumers: [{ nodeId: FLUX1_DEV_FP8_TXT2IMG_NODES.sampler, inputName: "model" }],
+  clipConsumers: [
+    { nodeId: FLUX1_DEV_FP8_TXT2IMG_NODES.positivePrompt, inputName: "clip" },
+    { nodeId: FLUX1_DEV_FP8_TXT2IMG_NODES.negativePrompt, inputName: "clip" }
+  ]
+} as const;
+
+/**
+ * The model consumer here is ModelSamplingAuraFlow, not the sampler. A LoRA has
+ * to be applied *before* the sampling-mode wrapper, so the wrapper is what gets
+ * rewired -- pointing the sampler at the LoRA instead would silently bypass
+ * ModelSamplingAuraFlow and change how the model is sampled.
+ */
+const Z_IMAGE_TURBO_TXT2IMG_LORA_INSERTION = {
+  nodeId: "24",
+  familyTokens: ["z-image", "zimage", "z_image"],
+  modelSource: { nodeId: Z_IMAGE_TURBO_TXT2IMG_NODES.diffusionModelLoader, slot: 0 },
+  clipSource: { nodeId: Z_IMAGE_TURBO_TXT2IMG_NODES.clipLoader, slot: 0 },
+  modelConsumers: [{ nodeId: Z_IMAGE_TURBO_TXT2IMG_NODES.modelSampling, inputName: "model" }],
+  clipConsumers: [
+    { nodeId: Z_IMAGE_TURBO_TXT2IMG_NODES.positivePrompt, inputName: "clip" },
+    { nodeId: Z_IMAGE_TURBO_TXT2IMG_NODES.negativePrompt, inputName: "clip" }
+  ]
+} as const;
+
+/**
+ * Only one clip consumer, because Flux.2 is guidance-distilled and the
+ * reference graph has no negative conditioning node at all. The model consumer
+ * is BasicGuider rather than a KSampler, this preset being built on the
+ * advanced sampler chain.
+ */
+const FLUX2_DEV_GGUF_TXT2IMG_LORA_INSERTION = {
+  nodeId: "49",
+  familyTokens: ["flux2", "flux-2", "flux_2"],
+  modelSource: { nodeId: FLUX2_DEV_GGUF_TXT2IMG_NODES.diffusionModelLoader, slot: 0 },
+  clipSource: { nodeId: FLUX2_DEV_GGUF_TXT2IMG_NODES.clipLoader, slot: 0 },
+  modelConsumers: [{ nodeId: FLUX2_DEV_GGUF_TXT2IMG_NODES.guider, inputName: "model" }],
+  clipConsumers: [{ nodeId: FLUX2_DEV_GGUF_TXT2IMG_NODES.positivePrompt, inputName: "clip" }]
+} as const;
+
 const KREA2_TURBO_TXT2IMG_LORA_INSERTION = {
   nodeId: "23",
   familyTokens: ["krea2", "krea-2", "krea_2"],
@@ -1078,6 +1141,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelSource: CHECKPOINT_MODEL_SOURCE,
     capability: TXT2IMG_BASIC_CAPABILITY,
     injections: TXT2IMG_BASIC_INJECTIONS,
+    loraInsertion: TXT2IMG_BASIC_LORA_INSERTION,
     compatibilityNote: "txt2img-basic uses the standard CheckpointLoaderSimple SD/SDXL workflow.",
     requiredNodes: [
       {
@@ -1128,6 +1192,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     capability: FLUX1_DEV_FP8_TXT2IMG_CAPABILITY,
     requiredModels: [FLUX1_DEV_FP8_CHECKPOINT],
     injections: FLUX1_DEV_FP8_TXT2IMG_INJECTIONS,
+    loraInsertion: FLUX1_DEV_FP8_TXT2IMG_LORA_INSERTION,
     compatibilityNote:
       "txt2img-flux1-dev-fp8 follows the attached CheckpointLoaderSimple Flux workflow. KSampler CFG stays 1; OpenLayer maps the UI CFG control to FluxGuidance.",
     requiredNodes: [
@@ -1818,6 +1883,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelStack: [...Z_IMAGE_TURBO_STACK],
     requiredModels: [...Z_IMAGE_TURBO_STACK],
     injections: Z_IMAGE_TURBO_TXT2IMG_INJECTIONS,
+    loraInsertion: Z_IMAGE_TURBO_TXT2IMG_LORA_INSERTION,
     requiredNodes: [
       {
         id: Z_IMAGE_TURBO_TXT2IMG_NODES.diffusionModelLoader,
@@ -2034,6 +2100,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelStack: [...FLUX2_DEV_GGUF_STACK],
     requiredModels: [...FLUX2_DEV_GGUF_STACK],
     injections: FLUX2_DEV_GGUF_TXT2IMG_INJECTIONS,
+    loraInsertion: FLUX2_DEV_GGUF_TXT2IMG_LORA_INSERTION,
     requiredNodes: [
       {
         id: FLUX2_DEV_GGUF_TXT2IMG_NODES.diffusionModelLoader,

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -287,6 +287,21 @@ const SKETCH2IMG_LINECN_BASIC_NODES = {
   saveImage: "9"
 } as const;
 
+// Same graph shape as the LineArt preset -- only the preprocessor and the
+// ControlNet it feeds differ -- so the node ids deliberately match.
+const SKETCH2IMG_SCRIBBLE_BASIC_NODES = {
+  checkpointLoader: "4",
+  loadImage: "10",
+  positivePrompt: "6",
+  negativePrompt: "7",
+  latentImage: "5",
+  scribblePreprocessor: "12",
+  controlNetLoader: "13",
+  controlNetApply: "14",
+  sampler: "3",
+  saveImage: "9"
+} as const;
+
 const INPAINT_BASIC_NODES = {
   checkpointLoader: "4",
   loadImage: "10",
@@ -462,6 +477,20 @@ const SKETCH2IMG_LINECN_BASIC_INJECTIONS = {
   cfg: target(SKETCH2IMG_LINECN_BASIC_NODES.sampler, "cfg"),
   denoise: target(SKETCH2IMG_LINECN_BASIC_NODES.sampler, "denoise"),
   controlStrength: target(SKETCH2IMG_LINECN_BASIC_NODES.controlNetApply, "strength")
+} as const;
+
+const SKETCH2IMG_SCRIBBLE_BASIC_INJECTIONS = {
+  checkpoint: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.checkpointLoader, "ckpt_name"),
+  sourceImage: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.loadImage, "image"),
+  positivePrompt: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.positivePrompt, "text"),
+  negativePrompt: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.negativePrompt, "text"),
+  width: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.latentImage, "width"),
+  height: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.latentImage, "height"),
+  seed: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.sampler, "seed"),
+  steps: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.sampler, "steps"),
+  cfg: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.sampler, "cfg"),
+  denoise: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.sampler, "denoise"),
+  controlStrength: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.controlNetApply, "strength")
 } as const;
 
 const INPAINT_BASIC_INJECTIONS = {
@@ -711,6 +740,26 @@ const SKETCH2IMG_LINECN_BASIC_CAPABILITY: WorkflowCapability = {
     modelSelectorLabel: "Checkpoint",
     primaryActionLabel: "Generate Sketch to Image",
     experimentalNote: "Starter SD 1.x LineArt ControlNet workflow."
+  }
+};
+
+const SKETCH2IMG_SCRIBBLE_BASIC_CAPABILITY: WorkflowCapability = {
+  toolType: "sketch2img",
+  loaderType: "checkpoint",
+  artistLabel: "Sketch to Image",
+  technicalLabel: "sketch2img-scribble-basic",
+  requiredPhotoshopInputs: [{ anyOf: ["active-layer", "canvas"], label: "an active layer or captured canvas" }],
+  controls: ["prompt", "negativePrompt", "steps", "cfg", "denoise", "seed", "controlStrength"],
+  output: {
+    kind: "source-sized-image",
+    size: "source",
+    importBehavior: "new-layer"
+  },
+  uiHints: {
+    showModelSelector: true,
+    modelSelectorLabel: "Checkpoint",
+    primaryActionLabel: "Generate Sketch to Image",
+    experimentalNote: "Starter SD 1.x Scribble ControlNet workflow."
   }
 };
 
@@ -1188,7 +1237,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     capability: SKETCH2IMG_LINECN_BASIC_CAPABILITY,
     injections: SKETCH2IMG_LINECN_BASIC_INJECTIONS,
     compatibilityNote:
-      "sketch2img-linecn-basic generates from an empty latent at the sketch size while the SD 1.5 LineArt ControlNet guides structure, so colors render fully instead of inheriting the white sketch paper. Keep denoise at 1 for a full render, or lower it only when blending with a colored source.",
+      "sketch2img-linecn-basic generates from an empty latent at the sketch size while the SD 1.5 LineArt ControlNet guides structure, so colors render fully instead of inheriting the white sketch paper. Keep denoise at 1 for a full render, or lower it only when blending with a colored source. It uses the AnyLine detector rather than the standard Lineart preprocessor, which returns a blank control image -- and so silently degrades to plain text-to-image -- for light-on-dark art or solid filled shapes.",
     requiredModels: [
       {
         kind: "controlnet",
@@ -1231,7 +1280,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
       },
       {
         id: SKETCH2IMG_LINECN_BASIC_NODES.lineArtPreprocessor,
-        classType: "LineartStandardPreprocessor",
+        classType: "AnyLineArtPreprocessor_aux",
         requiredInputs: ["image"]
       },
       {
@@ -1251,6 +1300,90 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
       },
       {
         id: SKETCH2IMG_LINECN_BASIC_NODES.saveImage,
+        classType: "SaveImage",
+        requiredInputs: ["images"]
+      }
+    ]
+  },
+  {
+    id: "sketch2img-scribble-basic",
+    label: "sketch2img-scribble-basic",
+    displayName: "Scribble ControlNet",
+    mode: "sketch2img",
+    description: "Experimental SD 1.x Scribble ControlNet sketch guidance workflow.",
+    workflowFile: "workflows/api/sketch2img-scribble-basic.json",
+    sourceWorkflowFile: "workflows/source/sketch2img-scribble-basic.workflow.json",
+    status: "stable",
+    recommendedSettings: { steps: 20, cfg: 7 },
+    supportedModelFamilies: ["sd1"],
+    experimentalModelFamilies: ["sdxl", "sd3", "flux", "zImage"],
+    modelSource: CHECKPOINT_MODEL_SOURCE,
+    capability: SKETCH2IMG_SCRIBBLE_BASIC_CAPABILITY,
+    injections: SKETCH2IMG_SCRIBBLE_BASIC_INJECTIONS,
+    compatibilityNote:
+      "sketch2img-scribble-basic suits loose, gestural strokes: it keeps the sketch's broad shapes and lets the model invent the detail, where the LineArt preset holds the drawn line. Pick Scribble for a rough thumbnail, LineArt for clean inked art. It uses the PiDiNet edge detector rather than the plain Scribble preprocessor, which returns a blank control image -- and so silently degrades to plain text-to-image -- for light-on-dark art or solid filled shapes.",
+    requiredModels: [
+      {
+        kind: "controlnet",
+        objectInfoNode: "ControlNetLoader",
+        inputName: "control_net_name",
+        label: "Scribble ControlNet",
+        modelName: "control_v11p_sd15_scribble_fp16.safetensors",
+        setupHint: "Install an SD 1.5 Scribble ControlNet model in ComfyUI's controlnet models folder.",
+        downloadUrl:
+          "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11p_sd15_scribble_fp16.safetensors",
+        sourcePageUrl: "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors",
+        downloadSizeBytes: 722601100
+      }
+    ],
+    requiredNodes: [
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.checkpointLoader,
+        classType: "CheckpointLoaderSimple",
+        requiredInputs: ["ckpt_name"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.loadImage,
+        classType: "LoadImage",
+        requiredInputs: ["image"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.positivePrompt,
+        classType: "CLIPTextEncode",
+        requiredInputs: ["text", "clip"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.negativePrompt,
+        classType: "CLIPTextEncode",
+        requiredInputs: ["text", "clip"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.latentImage,
+        classType: "EmptyLatentImage",
+        requiredInputs: ["width", "height", "batch_size"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.scribblePreprocessor,
+        classType: "Scribble_PiDiNet_Preprocessor",
+        requiredInputs: ["image"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.controlNetLoader,
+        classType: "ControlNetLoader",
+        requiredInputs: ["control_net_name"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.controlNetApply,
+        classType: "ControlNetApplyAdvanced",
+        requiredInputs: ["positive", "negative", "control_net", "image", "strength", "start_percent", "end_percent"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.sampler,
+        classType: "KSampler",
+        requiredInputs: ["seed", "steps", "cfg", "denoise", "model", "positive", "negative", "latent_image"]
+      },
+      {
+        id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.saveImage,
         classType: "SaveImage",
         requiredInputs: ["images"]
       }

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -313,6 +313,23 @@ const SKETCH2IMG_SCRIBBLE_BASIC_NODES = {
   saveImage: "9"
 } as const;
 
+// Third variant of the same graph. Depth differs from LineArt and Scribble in
+// what it preserves: those two hold the drawn *stroke*, while depth holds the
+// scene's geometry, which is what matters when a generated image has to sit in
+// an existing Photoshop composite at the right perspective.
+const SKETCH2IMG_DEPTH_BASIC_NODES = {
+  checkpointLoader: "4",
+  loadImage: "10",
+  positivePrompt: "6",
+  negativePrompt: "7",
+  latentImage: "5",
+  depthPreprocessor: "12",
+  controlNetLoader: "13",
+  controlNetApply: "14",
+  sampler: "3",
+  saveImage: "9"
+} as const;
+
 const INPAINT_BASIC_NODES = {
   checkpointLoader: "4",
   loadImage: "10",
@@ -502,6 +519,20 @@ const SKETCH2IMG_SCRIBBLE_BASIC_INJECTIONS = {
   cfg: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.sampler, "cfg"),
   denoise: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.sampler, "denoise"),
   controlStrength: target(SKETCH2IMG_SCRIBBLE_BASIC_NODES.controlNetApply, "strength")
+} as const;
+
+const SKETCH2IMG_DEPTH_BASIC_INJECTIONS = {
+  checkpoint: target(SKETCH2IMG_DEPTH_BASIC_NODES.checkpointLoader, "ckpt_name"),
+  sourceImage: target(SKETCH2IMG_DEPTH_BASIC_NODES.loadImage, "image"),
+  positivePrompt: target(SKETCH2IMG_DEPTH_BASIC_NODES.positivePrompt, "text"),
+  negativePrompt: target(SKETCH2IMG_DEPTH_BASIC_NODES.negativePrompt, "text"),
+  width: target(SKETCH2IMG_DEPTH_BASIC_NODES.latentImage, "width"),
+  height: target(SKETCH2IMG_DEPTH_BASIC_NODES.latentImage, "height"),
+  seed: target(SKETCH2IMG_DEPTH_BASIC_NODES.sampler, "seed"),
+  steps: target(SKETCH2IMG_DEPTH_BASIC_NODES.sampler, "steps"),
+  cfg: target(SKETCH2IMG_DEPTH_BASIC_NODES.sampler, "cfg"),
+  denoise: target(SKETCH2IMG_DEPTH_BASIC_NODES.sampler, "denoise"),
+  controlStrength: target(SKETCH2IMG_DEPTH_BASIC_NODES.controlNetApply, "strength")
 } as const;
 
 const INPAINT_BASIC_INJECTIONS = {
@@ -771,6 +802,26 @@ const SKETCH2IMG_SCRIBBLE_BASIC_CAPABILITY: WorkflowCapability = {
     modelSelectorLabel: "Checkpoint",
     primaryActionLabel: "Generate Sketch to Image",
     experimentalNote: "Starter SD 1.x Scribble ControlNet workflow."
+  }
+};
+
+const SKETCH2IMG_DEPTH_BASIC_CAPABILITY: WorkflowCapability = {
+  toolType: "sketch2img",
+  loaderType: "checkpoint",
+  artistLabel: "Sketch to Image",
+  technicalLabel: "sketch2img-depth-basic",
+  requiredPhotoshopInputs: [{ anyOf: ["active-layer", "canvas"], label: "an active layer or captured canvas" }],
+  controls: ["prompt", "negativePrompt", "steps", "cfg", "denoise", "seed", "controlStrength"],
+  output: {
+    kind: "source-sized-image",
+    size: "source",
+    importBehavior: "new-layer"
+  },
+  uiHints: {
+    showModelSelector: true,
+    modelSelectorLabel: "Checkpoint",
+    primaryActionLabel: "Generate Sketch to Image",
+    experimentalNote: "Starter SD 1.x Depth ControlNet workflow."
   }
 };
 
@@ -1395,6 +1446,93 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
       },
       {
         id: SKETCH2IMG_SCRIBBLE_BASIC_NODES.saveImage,
+        classType: "SaveImage",
+        requiredInputs: ["images"]
+      }
+    ]
+  },
+  {
+    id: "sketch2img-depth-basic",
+    label: "sketch2img-depth-basic",
+    displayName: "Depth ControlNet",
+    mode: "sketch2img",
+    description: "SD 1.x sketch-to-image workflow that conditions on the source layer's depth rather than its lines.",
+    workflowFile: "workflows/api/sketch2img-depth-basic.json",
+    sourceWorkflowFile: "workflows/source/sketch2img-depth-basic.workflow.json",
+    status: "stable",
+    recommendedSettings: { steps: 20, cfg: 7 },
+    supportedModelFamilies: ["sd1"],
+    experimentalModelFamilies: ["sdxl", "sd3", "flux", "zImage"],
+    modelSource: CHECKPOINT_MODEL_SOURCE,
+    capability: SKETCH2IMG_DEPTH_BASIC_CAPABILITY,
+    injections: SKETCH2IMG_DEPTH_BASIC_INJECTIONS,
+    compatibilityNote:
+      "sketch2img-depth-basic conditions on estimated scene depth, so it holds perspective and the relative distance of forms while leaving surface detail free -- the preset to reach for when a generated element has to sit inside an existing composite at the right camera angle. LineArt and Scribble hold the drawn stroke instead, and neither carries depth. It works from any shaded image, not only a line drawing, and a flat drawing with no tonal variation gives the estimator little to read. DepthAnythingV2Preprocessor downloads its own estimator weights on first run, the same way the LineArt and Scribble preprocessors do, so the first generation after install is slower than later ones.",
+    requiredModels: [
+      {
+        kind: "controlnet",
+        objectInfoNode: "ControlNetLoader",
+        inputName: "control_net_name",
+        label: "Depth ControlNet",
+        modelName: "control_v11f1p_sd15_depth_fp16.safetensors",
+        setupHint: "Install an SD 1.5 Depth ControlNet model in ComfyUI's controlnet models folder.",
+        downloadUrl:
+          "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors/resolve/main/control_v11f1p_sd15_depth_fp16.safetensors",
+        sourcePageUrl: "https://huggingface.co/comfyanonymous/ControlNet-v1-1_fp16_safetensors",
+        downloadSizeBytes: 722601100
+      }
+    ],
+    requiredNodes: [
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.checkpointLoader,
+        classType: "CheckpointLoaderSimple",
+        requiredInputs: ["ckpt_name"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.loadImage,
+        classType: "LoadImage",
+        requiredInputs: ["image"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.positivePrompt,
+        classType: "CLIPTextEncode",
+        requiredInputs: ["text", "clip"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.negativePrompt,
+        classType: "CLIPTextEncode",
+        requiredInputs: ["text", "clip"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.latentImage,
+        classType: "EmptyLatentImage",
+        requiredInputs: ["width", "height", "batch_size"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.depthPreprocessor,
+        // Only `image` is required; ckpt_name and resolution are optional inputs
+        // that the workflow pins explicitly so a run is reproducible rather than
+        // dependent on whatever default the node pack ships that week.
+        classType: "DepthAnythingV2Preprocessor",
+        requiredInputs: ["image"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.controlNetLoader,
+        classType: "ControlNetLoader",
+        requiredInputs: ["control_net_name"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.controlNetApply,
+        classType: "ControlNetApplyAdvanced",
+        requiredInputs: ["positive", "negative", "control_net", "image", "strength", "start_percent", "end_percent"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.sampler,
+        classType: "KSampler",
+        requiredInputs: ["seed", "steps", "cfg", "denoise", "model", "positive", "negative", "latent_image"]
+      },
+      {
+        id: SKETCH2IMG_DEPTH_BASIC_NODES.saveImage,
         classType: "SaveImage",
         requiredInputs: ["images"]
       }

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -504,6 +504,57 @@ const FLUX2_DEV_GGUF_TXT2IMG_LORA_INSERTION = {
   clipConsumers: [{ nodeId: FLUX2_DEV_GGUF_TXT2IMG_NODES.positivePrompt, inputName: "clip" }]
 } as const;
 
+const IMG2IMG_BASIC_LORA_INSERTION = {
+  nodeId: "12",
+  familyTokens: ["sd15", "sd1.5", "sd_1.5"],
+  modelSource: { nodeId: IMG2IMG_BASIC_NODES.checkpointLoader, slot: 0 },
+  clipSource: { nodeId: IMG2IMG_BASIC_NODES.checkpointLoader, slot: 1 },
+  modelConsumers: [{ nodeId: IMG2IMG_BASIC_NODES.sampler, inputName: "model" }],
+  clipConsumers: [
+    { nodeId: IMG2IMG_BASIC_NODES.positivePrompt, inputName: "clip" },
+    { nodeId: IMG2IMG_BASIC_NODES.negativePrompt, inputName: "clip" }
+  ]
+} as const;
+
+
+
+/** Same wrapper caveat as the txt2img Z-Image preset: rewire modelSampling. */
+const Z_IMAGE_TURBO_IMG2IMG_LORA_INSERTION = {
+  nodeId: "24",
+  familyTokens: ["z-image", "zimage", "z_image"],
+  modelSource: { nodeId: Z_IMAGE_TURBO_IMG2IMG_NODES.diffusionModelLoader, slot: 0 },
+  clipSource: { nodeId: Z_IMAGE_TURBO_IMG2IMG_NODES.clipLoader, slot: 0 },
+  modelConsumers: [{ nodeId: Z_IMAGE_TURBO_IMG2IMG_NODES.modelSampling, inputName: "model" }],
+  clipConsumers: [
+    { nodeId: Z_IMAGE_TURBO_IMG2IMG_NODES.positivePrompt, inputName: "clip" },
+    { nodeId: Z_IMAGE_TURBO_IMG2IMG_NODES.negativePrompt, inputName: "clip" }
+  ]
+} as const;
+
+/**
+ * The three sketch presets share one graph shape by design, so they share this
+ * wiring too -- only the preprocessor and ControlNet differ between them, and
+ * neither touches the model or CLIP path.
+ */
+function createSketchLoraInsertion(nodes: {
+  readonly checkpointLoader: string;
+  readonly sampler: string;
+  readonly positivePrompt: string;
+  readonly negativePrompt: string;
+}) {
+  return {
+    nodeId: "15",
+    familyTokens: ["sd15", "sd1.5", "sd_1.5"],
+    modelSource: { nodeId: nodes.checkpointLoader, slot: 0 },
+    clipSource: { nodeId: nodes.checkpointLoader, slot: 1 },
+    modelConsumers: [{ nodeId: nodes.sampler, inputName: "model" }],
+    clipConsumers: [
+      { nodeId: nodes.positivePrompt, inputName: "clip" },
+      { nodeId: nodes.negativePrompt, inputName: "clip" }
+    ]
+  } as const;
+}
+
 const KREA2_TURBO_TXT2IMG_LORA_INSERTION = {
   nodeId: "23",
   familyTokens: ["krea2", "krea-2", "krea_2"],
@@ -527,6 +578,17 @@ const KREA2_TURBO_IMG2IMG_NODES = {
   sampler: "3",
   decode: "8",
   saveImage: "9"
+} as const;
+const KREA2_TURBO_IMG2IMG_LORA_INSERTION = {
+  nodeId: "23",
+  familyTokens: ["krea2", "krea-2", "krea_2"],
+  modelSource: { nodeId: KREA2_TURBO_IMG2IMG_NODES.diffusionModelLoader, slot: 0 },
+  clipSource: { nodeId: KREA2_TURBO_IMG2IMG_NODES.clipLoader, slot: 0 },
+  modelConsumers: [{ nodeId: KREA2_TURBO_IMG2IMG_NODES.sampler, inputName: "model" }],
+  clipConsumers: [
+    { nodeId: KREA2_TURBO_IMG2IMG_NODES.positivePrompt, inputName: "clip" },
+    { nodeId: KREA2_TURBO_IMG2IMG_NODES.negativePrompt, inputName: "clip" }
+  ]
 } as const;
 
 const PROMPT_FROM_LAYER_FLORENCE2_NODES = {
@@ -1253,6 +1315,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelSource: CHECKPOINT_MODEL_SOURCE,
     capability: IMG2IMG_BASIC_CAPABILITY,
     injections: IMG2IMG_BASIC_INJECTIONS,
+    loraInsertion: IMG2IMG_BASIC_LORA_INSERTION,
     compatibilityNote: "img2img-basic uses the standard CheckpointLoaderSimple, LoadImage, and VAEEncode SD/SDXL workflow.",
     requiredNodes: [
       {
@@ -1387,6 +1450,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelSource: CHECKPOINT_MODEL_SOURCE,
     capability: SKETCH2IMG_LINECN_BASIC_CAPABILITY,
     injections: SKETCH2IMG_LINECN_BASIC_INJECTIONS,
+    loraInsertion: createSketchLoraInsertion(SKETCH2IMG_LINECN_BASIC_NODES),
     compatibilityNote:
       "sketch2img-linecn-basic generates from an empty latent at the sketch size while the SD 1.5 LineArt ControlNet guides structure, so colors render fully instead of inheriting the white sketch paper. Keep denoise at 1 for a full render, or lower it only when blending with a colored source. It uses the AnyLine detector rather than the standard Lineart preprocessor, which returns a blank control image -- and so silently degrades to plain text-to-image -- for light-on-dark art or solid filled shapes.",
     requiredModels: [
@@ -1471,6 +1535,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelSource: CHECKPOINT_MODEL_SOURCE,
     capability: SKETCH2IMG_SCRIBBLE_BASIC_CAPABILITY,
     injections: SKETCH2IMG_SCRIBBLE_BASIC_INJECTIONS,
+    loraInsertion: createSketchLoraInsertion(SKETCH2IMG_SCRIBBLE_BASIC_NODES),
     compatibilityNote:
       "sketch2img-scribble-basic suits loose, gestural strokes: it keeps the sketch's broad shapes and lets the model invent the detail, where the LineArt preset holds the drawn line. Pick Scribble for a rough thumbnail, LineArt for clean inked art. It uses the PiDiNet edge detector rather than the plain Scribble preprocessor, which returns a blank control image -- and so silently degrades to plain text-to-image -- for light-on-dark art or solid filled shapes.",
     requiredModels: [
@@ -1555,6 +1620,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelSource: CHECKPOINT_MODEL_SOURCE,
     capability: SKETCH2IMG_DEPTH_BASIC_CAPABILITY,
     injections: SKETCH2IMG_DEPTH_BASIC_INJECTIONS,
+    loraInsertion: createSketchLoraInsertion(SKETCH2IMG_DEPTH_BASIC_NODES),
     compatibilityNote:
       "sketch2img-depth-basic conditions on estimated scene depth, so it holds perspective and the relative distance of forms while leaving surface detail free -- the preset to reach for when a generated element has to sit inside an existing composite at the right camera angle. LineArt and Scribble hold the drawn stroke instead, and neither carries depth. It works from any shaded image, not only a line drawing, and a flat drawing with no tonal variation gives the estimator little to read. DepthAnythingV2Preprocessor downloads its own estimator weights on first run, the same way the LineArt and Scribble preprocessors do, so the first generation after install is slower than later ones.",
     requiredModels: [
@@ -1956,6 +2022,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelStack: [...Z_IMAGE_TURBO_STACK],
     requiredModels: [...Z_IMAGE_TURBO_STACK],
     injections: Z_IMAGE_TURBO_IMG2IMG_INJECTIONS,
+    loraInsertion: Z_IMAGE_TURBO_IMG2IMG_LORA_INSERTION,
     requiredNodes: [
       {
         id: Z_IMAGE_TURBO_IMG2IMG_NODES.diffusionModelLoader,
@@ -2189,6 +2256,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelStack: [...KREA2_TURBO_STACK],
     requiredModels: [...KREA2_TURBO_STACK],
     injections: KREA2_TURBO_IMG2IMG_INJECTIONS,
+    loraInsertion: KREA2_TURBO_IMG2IMG_LORA_INSERTION,
     requiredNodes: [
       {
         id: KREA2_TURBO_IMG2IMG_NODES.diffusionModelLoader,

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -62,6 +62,17 @@ const DIFFUSION_MODEL_SOURCE = {
   label: "Diffusion model"
 } as const;
 
+// UNETLoader's object_info does not enumerate .gguf files at all (verified live
+// against ComfyUI-GGUF) -- a preset built on UnetLoaderGGUF must ask that loader
+// for its own file list, or every .gguf model is invisible in the Model dropdown
+// no matter where it's placed.
+const DIFFUSION_MODEL_GGUF_SOURCE = {
+  kind: "diffusion-model-stack",
+  objectInfoNode: "UnetLoaderGGUF",
+  inputName: "unet_name",
+  label: "Diffusion model (GGUF)"
+} as const;
+
 const FLORENCE_MODEL_SOURCE = {
   kind: "vision-language",
   objectInfoNode: "Florence2ModelLoader",
@@ -1855,7 +1866,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     recommendedSettings: { steps: 20, cfg: 4 },
     supportedModelFamilies: ["flux2"],
     experimentalModelFamilies: ["unknown"],
-    modelSource: DIFFUSION_MODEL_SOURCE,
+    modelSource: DIFFUSION_MODEL_GGUF_SOURCE,
     capability: FLUX2_DEV_GGUF_TXT2IMG_CAPABILITY,
     modelStack: [...FLUX2_DEV_GGUF_STACK],
     requiredModels: [...FLUX2_DEV_GGUF_STACK],

--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -429,6 +429,30 @@ const KREA2_TURBO_TXT2IMG_NODES = {
   saveImage: "9"
 } as const;
 
+/**
+ * Where an optional LoRA goes in the Krea-2 Turbo graph.
+ *
+ * Both text encodes are listed, not just the positive one. At CFG 1 the
+ * negative encode contributes nothing to the image, but leaving it reading the
+ * bare CLIP would mean two different text encoders in one graph -- harmless
+ * today and a confusing bug the moment this preset is used at a CFG above 1.
+ *
+ * Node id 23 is the next free id after the loaders (20-22); the shipped
+ * workflow stops at 22, and applyLoraSelection refuses to overwrite an
+ * occupied id rather than trusting this comment to stay true.
+ */
+const KREA2_TURBO_TXT2IMG_LORA_INSERTION = {
+  nodeId: "23",
+  familyTokens: ["krea2", "krea-2", "krea_2"],
+  modelSource: { nodeId: KREA2_TURBO_TXT2IMG_NODES.diffusionModelLoader, slot: 0 },
+  clipSource: { nodeId: KREA2_TURBO_TXT2IMG_NODES.clipLoader, slot: 0 },
+  modelConsumers: [{ nodeId: KREA2_TURBO_TXT2IMG_NODES.sampler, inputName: "model" }],
+  clipConsumers: [
+    { nodeId: KREA2_TURBO_TXT2IMG_NODES.positivePrompt, inputName: "clip" },
+    { nodeId: KREA2_TURBO_TXT2IMG_NODES.negativePrompt, inputName: "clip" }
+  ]
+} as const;
+
 const KREA2_TURBO_IMG2IMG_NODES = {
   diffusionModelLoader: "20",
   clipLoader: "21",
@@ -1942,6 +1966,7 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
     modelStack: [...KREA2_TURBO_STACK],
     requiredModels: [...KREA2_TURBO_STACK],
     injections: KREA2_TURBO_TXT2IMG_INJECTIONS,
+    loraInsertion: KREA2_TURBO_TXT2IMG_LORA_INSERTION,
     requiredNodes: [
       {
         id: KREA2_TURBO_TXT2IMG_NODES.diffusionModelLoader,

--- a/src/comfy/setupManifest.ts
+++ b/src/comfy/setupManifest.ts
@@ -27,7 +27,18 @@ import { getModelTargetFolder, getModelTargetPath, getRequiredModelKey, listPres
  * fails that test.
  */
 export const CUSTOM_NODE_PACKAGES: Record<string, { name: string; repoUrl: string }> = {
+  // Kept although no preset ships it any more: it is still a legal node in a
+  // user's own custom workflow, and naming its package is what lets Workflow
+  // Health say which install is missing rather than reporting an absent node.
   LineartStandardPreprocessor: {
+    name: "comfyui_controlnet_aux",
+    repoUrl: "https://github.com/Fannovel16/comfyui_controlnet_aux"
+  },
+  AnyLineArtPreprocessor_aux: {
+    name: "comfyui_controlnet_aux",
+    repoUrl: "https://github.com/Fannovel16/comfyui_controlnet_aux"
+  },
+  Scribble_PiDiNet_Preprocessor: {
     name: "comfyui_controlnet_aux",
     repoUrl: "https://github.com/Fannovel16/comfyui_controlnet_aux"
   },

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -155,6 +155,7 @@ export type BuildImageToImageWorkflowOptions = {
   seed: number;
   denoise: number;
   requiredModelSelections?: Record<string, string>;
+  lora?: WorkflowLoraSelection;
 };
 
 export type BuildSketchToImageWorkflowOptions = BuildImageToImageWorkflowOptions & {

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -10,6 +10,7 @@ export type WorkflowPreset =
   | "prompt-from-layer-florence2"
   | "sketch2img-linecn-basic"
   | "sketch2img-scribble-basic"
+  | "sketch2img-depth-basic"
   | "inpaint-basic"
   | "inpaint-flux-fill-basic"
   | "outpaint-flux-fill-basic"

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -141,6 +141,7 @@ export type BuildWorkflowOptions = {
   steps: number;
   cfg: number;
   seed: number;
+  lora?: WorkflowLoraSelection;
 };
 
 export type BuildImageToImageWorkflowOptions = {
@@ -229,6 +230,53 @@ export type WorkflowInjectionName =
   | "outpaintFeathering";
 
 export type WorkflowInjectionTargetList = WorkflowInputTarget | readonly WorkflowInputTarget[];
+
+/** Where a link starts: a node and one of its output slots. */
+export type WorkflowLinkSource = {
+  nodeId: string;
+  slot: number;
+};
+
+/**
+ * How to splice an optional `LoraLoader` into a preset's graph.
+ *
+ * Every other injection sets a *value* on a node the shipped workflow already
+ * contains. A LoRA cannot work that way: core `LoraLoader` offers no "none"
+ * entry — `lora_name` is a combo of files that exist — so a permanently wired
+ * loader would force every user to own and load a LoRA they may not want. The
+ * node is therefore absent from the shipped workflow and spliced in only when
+ * an artist actually picks one, which is the first and only case where building
+ * a workflow changes its topology rather than its values.
+ *
+ * The wiring is declared here rather than inferred because inferring it means
+ * guessing which MODEL and CLIP edges are the "main" ones, and a wrong guess
+ * silently produces an image with the LoRA applied to nothing.
+ */
+export type WorkflowLoraInsertion = {
+  /** Id the inserted node takes. Must not already exist in the workflow. */
+  nodeId: string;
+  /**
+   * Filename fragments that suggest a LoRA was trained for this preset's model.
+   * Used only to label the dropdown, never to hide an entry -- see
+   * `loraCompatibility.ts` for why nothing stronger is available.
+   */
+  familyTokens?: readonly string[];
+  /** Feeds the loader's `model` input — normally the diffusion model loader. */
+  modelSource: WorkflowLinkSource;
+  /** Feeds the loader's `clip` input — normally the text encoder loader. */
+  clipSource: WorkflowLinkSource;
+  /** Inputs reading the model directly, rewired to the loader's MODEL output. */
+  modelConsumers: readonly WorkflowInputTarget[];
+  /** Inputs reading the CLIP directly, rewired to the loader's CLIP output. */
+  clipConsumers: readonly WorkflowInputTarget[];
+};
+
+/** An artist's LoRA choice. Absent or nameless means "no LoRA". */
+export type WorkflowLoraSelection = {
+  loraName: string;
+  strengthModel: number;
+  strengthClip: number;
+};
 
 export type WorkflowInjectionTargets = Partial<Record<WorkflowInjectionName, WorkflowInjectionTargetList>>;
 
@@ -329,6 +377,8 @@ export type WorkflowPresetDefinition = {
   requiredNodes: WorkflowNodeRequirement[];
   requiredModels?: WorkflowRequiredModel[];
   capability?: WorkflowCapability;
+  /** Present only on presets that can take an optional LoRA. */
+  loraInsertion?: WorkflowLoraInsertion;
   compatibilityNote?: string;
   disabledReason?: string;
 };

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -9,6 +9,7 @@ export type WorkflowPreset =
   | "img2img-krea2-turbo"
   | "prompt-from-layer-florence2"
   | "sketch2img-linecn-basic"
+  | "sketch2img-scribble-basic"
   | "inpaint-basic"
   | "inpaint-flux-fill-basic"
   | "outpaint-flux-fill-basic"

--- a/src/comfy/workflowBuilder.ts
+++ b/src/comfy/workflowBuilder.ts
@@ -112,6 +112,8 @@ export async function buildImg2ImgWorkflow(
   setPresetInput(workflow, preset, "cfg", options.cfg, true);
   setPresetInput(workflow, preset, "denoise", options.denoise, true);
 
+  applyLoraSelection(workflow, preset, options.lora);
+
   validateWorkflowForPreset(workflow, preset);
 
   return {
@@ -147,6 +149,8 @@ export async function buildSketchToImageWorkflow(
   setPresetInput(workflow, preset, "cfg", options.cfg, true);
   setPresetInput(workflow, preset, "denoise", options.denoise, true);
   setPresetInput(workflow, preset, "controlStrength", options.controlStrength, true);
+
+  applyLoraSelection(workflow, preset, options.lora);
 
   validateWorkflowForPreset(workflow, preset);
 

--- a/src/comfy/workflowBuilder.ts
+++ b/src/comfy/workflowBuilder.ts
@@ -23,6 +23,7 @@ import {
   BuildWorkflowOptions,
   BuildWorkflowResult,
   ComfyWorkflow,
+  WorkflowLoraSelection,
   WorkflowPreset,
   WorkflowPresetDefinition,
   WorkflowInjectionTargetList
@@ -72,6 +73,8 @@ export async function buildTxt2ImgWorkflow(options: BuildWorkflowOptions): Promi
   setPresetInput(workflow, preset, "seed", seed, true);
   setPresetInput(workflow, preset, "steps", options.steps, true);
   setPresetInput(workflow, preset, "cfg", options.cfg, true);
+
+  applyLoraSelection(workflow, preset, options.lora);
 
   validateWorkflowForPreset(workflow, preset);
 
@@ -312,6 +315,71 @@ function setPresetInput(
 
 function normalizeTargets(target: WorkflowInjectionTargetList) {
   return Array.isArray(target) ? target : [target];
+}
+
+/**
+ * Splices a `LoraLoader` between a preset's model/CLIP loaders and everything
+ * downstream of them.
+ *
+ * This is the one place a workflow's topology changes at build time, for the
+ * reason spelled out on `WorkflowLoraInsertion`: core `LoraLoader` has no "off"
+ * value, so an optional LoRA cannot be a permanently wired node whose value is
+ * merely injected. No selection leaves the graph exactly as shipped.
+ *
+ * Order matters. This must run after the value injections, because rewiring an
+ * input that a later `setPresetInput` overwrites would silently drop the LoRA
+ * out of the chain while still loading it -- an image that looks untouched with
+ * no error to explain why.
+ */
+function applyLoraSelection(
+  workflow: ComfyWorkflow,
+  preset: WorkflowPresetDefinition,
+  lora: WorkflowLoraSelection | undefined
+) {
+  if (!lora?.loraName) {
+    return;
+  }
+
+  const insertion = preset.loraInsertion;
+
+  if (!insertion) {
+    throw createOpenLayerError(
+      "WORKFLOW_INVALID",
+      `The ${preset.id} preset does not support a LoRA.`,
+      `Add a loraInsertion entry for ${preset.id} in src/comfy/presetRegistry.ts, or clear the LoRA selection.`
+    );
+  }
+
+  // A collision would overwrite a real node and produce a graph that still
+  // validates, because validateWorkflowForPreset only checks that required
+  // nodes are present -- so it has to be caught here or not at all.
+  if (workflow[insertion.nodeId]) {
+    throw createOpenLayerError(
+      "WORKFLOW_INVALID",
+      `The ${preset.id} workflow already uses node ${insertion.nodeId}.`,
+      `Give ${preset.id}'s loraInsertion an unused nodeId in src/comfy/presetRegistry.ts.`
+    );
+  }
+
+  workflow[insertion.nodeId] = {
+    class_type: "LoraLoader",
+    inputs: {
+      lora_name: lora.loraName,
+      strength_model: lora.strengthModel,
+      strength_clip: lora.strengthClip,
+      model: [insertion.modelSource.nodeId, insertion.modelSource.slot],
+      clip: [insertion.clipSource.nodeId, insertion.clipSource.slot]
+    },
+    _meta: { title: "Apply LoRA" }
+  };
+
+  for (const consumer of insertion.modelConsumers) {
+    setInput(workflow, consumer.nodeId, consumer.inputName, [insertion.nodeId, 0]);
+  }
+
+  for (const consumer of insertion.clipConsumers) {
+    setInput(workflow, consumer.nodeId, consumer.inputName, [insertion.nodeId, 1]);
+  }
 }
 
 function applyRequiredModelSelections(

--- a/src/comfy/workflowBuilder.ts
+++ b/src/comfy/workflowBuilder.ts
@@ -1,6 +1,7 @@
 import txt2imgBasicWorkflow from "../workflows/api/txt2img-basic.json";
 import img2imgBasicWorkflow from "../workflows/api/img2img-basic.json";
 import txt2imgFlux1DevFp8Workflow from "../workflows/api/txt2img-flux1-dev-fp8.json";
+import txt2imgFlux2DevGgufWorkflow from "../workflows/api/txt2img-flux2-dev-gguf.json";
 import txt2imgZImageTurboWorkflow from "../workflows/api/txt2img-z-image-turbo.json";
 import img2imgZImageTurboWorkflow from "../workflows/api/img2img-z-image-turbo.json";
 import txt2imgKrea2TurboWorkflow from "../workflows/api/txt2img-krea2-turbo.json";
@@ -37,6 +38,7 @@ const WORKFLOW_TEMPLATES: Partial<Record<WorkflowPreset, ComfyWorkflow>> = {
   "txt2img-basic": txt2imgBasicWorkflow as ComfyWorkflow,
   "img2img-basic": img2imgBasicWorkflow as ComfyWorkflow,
   "txt2img-flux1-dev-fp8": txt2imgFlux1DevFp8Workflow as ComfyWorkflow,
+  "txt2img-flux2-dev-gguf": txt2imgFlux2DevGgufWorkflow as ComfyWorkflow,
   "txt2img-z-image-turbo": txt2imgZImageTurboWorkflow as ComfyWorkflow,
   "img2img-z-image-turbo": img2imgZImageTurboWorkflow as ComfyWorkflow,
   "txt2img-krea2-turbo": txt2imgKrea2TurboWorkflow as ComfyWorkflow,

--- a/src/comfy/workflowBuilder.ts
+++ b/src/comfy/workflowBuilder.ts
@@ -64,7 +64,7 @@ export async function buildTxt2ImgWorkflow(options: BuildWorkflowOptions): Promi
   }
 
   setPresetInput(workflow, preset, "positivePrompt", options.prompt, true);
-  setPresetInput(workflow, preset, "negativePrompt", options.negativePrompt ?? "", true);
+  setPresetInput(workflow, preset, "negativePrompt", options.negativePrompt ?? "");
   setPresetInput(workflow, preset, "width", options.width, true);
   setPresetInput(workflow, preset, "height", options.height, true);
   setPresetInput(workflow, preset, "seed", seed, true);
@@ -99,7 +99,7 @@ export async function buildImg2ImgWorkflow(
 
   setPresetInput(workflow, preset, "sourceImage", options.sourceImageName, true);
   setPresetInput(workflow, preset, "positivePrompt", options.prompt, true);
-  setPresetInput(workflow, preset, "negativePrompt", options.negativePrompt ?? "", true);
+  setPresetInput(workflow, preset, "negativePrompt", options.negativePrompt ?? "");
   setPresetInput(workflow, preset, "seed", seed, true);
   setPresetInput(workflow, preset, "steps", options.steps, true);
   setPresetInput(workflow, preset, "cfg", options.cfg, true);
@@ -132,7 +132,7 @@ export async function buildSketchToImageWorkflow(
 
   setPresetInput(workflow, preset, "sourceImage", options.sourceImageName, true);
   setPresetInput(workflow, preset, "positivePrompt", options.prompt, true);
-  setPresetInput(workflow, preset, "negativePrompt", options.negativePrompt ?? "", true);
+  setPresetInput(workflow, preset, "negativePrompt", options.negativePrompt ?? "");
   setPresetInput(workflow, preset, "width", options.width, true);
   setPresetInput(workflow, preset, "height", options.height, true);
   setPresetInput(workflow, preset, "seed", seed, true);

--- a/src/comfy/workflowBuilder.ts
+++ b/src/comfy/workflowBuilder.ts
@@ -8,6 +8,7 @@ import img2imgKrea2TurboWorkflow from "../workflows/api/img2img-krea2-turbo.json
 import promptFromLayerFlorence2Workflow from "../workflows/api/prompt-from-layer-florence2.json";
 import sketch2imgLinecnBasicWorkflow from "../workflows/api/sketch2img-linecn-basic.json";
 import sketch2imgScribbleBasicWorkflow from "../workflows/api/sketch2img-scribble-basic.json";
+import sketch2imgDepthBasicWorkflow from "../workflows/api/sketch2img-depth-basic.json";
 import inpaintBasicWorkflow from "../workflows/api/inpaint-basic.json";
 import inpaintFluxFillBasicWorkflow from "../workflows/api/inpaint-flux-fill-basic.json";
 import outpaintFluxFillBasicWorkflow from "../workflows/api/outpaint-flux-fill-basic.json";
@@ -42,6 +43,7 @@ const WORKFLOW_TEMPLATES: Partial<Record<WorkflowPreset, ComfyWorkflow>> = {
   "prompt-from-layer-florence2": promptFromLayerFlorence2Workflow as ComfyWorkflow,
   "sketch2img-linecn-basic": sketch2imgLinecnBasicWorkflow as ComfyWorkflow,
   "sketch2img-scribble-basic": sketch2imgScribbleBasicWorkflow as ComfyWorkflow,
+  "sketch2img-depth-basic": sketch2imgDepthBasicWorkflow as ComfyWorkflow,
   "inpaint-basic": inpaintBasicWorkflow as ComfyWorkflow,
   "inpaint-flux-fill-basic": inpaintFluxFillBasicWorkflow as ComfyWorkflow,
   "outpaint-flux-fill-basic": outpaintFluxFillBasicWorkflow as ComfyWorkflow,

--- a/src/comfy/workflowBuilder.ts
+++ b/src/comfy/workflowBuilder.ts
@@ -7,6 +7,7 @@ import txt2imgKrea2TurboWorkflow from "../workflows/api/txt2img-krea2-turbo.json
 import img2imgKrea2TurboWorkflow from "../workflows/api/img2img-krea2-turbo.json";
 import promptFromLayerFlorence2Workflow from "../workflows/api/prompt-from-layer-florence2.json";
 import sketch2imgLinecnBasicWorkflow from "../workflows/api/sketch2img-linecn-basic.json";
+import sketch2imgScribbleBasicWorkflow from "../workflows/api/sketch2img-scribble-basic.json";
 import inpaintBasicWorkflow from "../workflows/api/inpaint-basic.json";
 import inpaintFluxFillBasicWorkflow from "../workflows/api/inpaint-flux-fill-basic.json";
 import outpaintFluxFillBasicWorkflow from "../workflows/api/outpaint-flux-fill-basic.json";
@@ -40,6 +41,7 @@ const WORKFLOW_TEMPLATES: Partial<Record<WorkflowPreset, ComfyWorkflow>> = {
   "img2img-krea2-turbo": img2imgKrea2TurboWorkflow as ComfyWorkflow,
   "prompt-from-layer-florence2": promptFromLayerFlorence2Workflow as ComfyWorkflow,
   "sketch2img-linecn-basic": sketch2imgLinecnBasicWorkflow as ComfyWorkflow,
+  "sketch2img-scribble-basic": sketch2imgScribbleBasicWorkflow as ComfyWorkflow,
   "inpaint-basic": inpaintBasicWorkflow as ComfyWorkflow,
   "inpaint-flux-fill-basic": inpaintFluxFillBasicWorkflow as ComfyWorkflow,
   "outpaint-flux-fill-basic": outpaintFluxFillBasicWorkflow as ComfyWorkflow,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.openlayer.photoshop",
   "name": "OpenLayer",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "main": "index.html",
   "host": [
     {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1620,6 +1620,19 @@ a:hover {
   margin-top: 1px;
 }
 
+/* Margins rather than flex gap: gap is inert in the compact panel widths. */
+.lora-section {
+  display: block;
+}
+
+.lora-section > .field {
+  margin-top: 8px;
+}
+
+.lora-section > .diagnostics-line {
+  margin-top: 6px;
+}
+
 .settings-grid {
   display: flex;
   flex-wrap: wrap;

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -120,7 +120,8 @@ import {
   InstallStep
 } from "./setupInstallModel";
 import type { WorkflowPhotoshopInputAvailability } from "../comfy/workflowCompatibility";
-import { GeneratedImageResult, WorkflowPresetDefinition } from "../comfy/types";
+import { GeneratedImageResult, WorkflowLoraSelection, WorkflowPresetDefinition } from "../comfy/types";
+import { formatLoraHintSuffix, getLoraFamilyHint } from "../comfy/loraCompatibility";
 import {
   ExportedSourceImage,
   SelectedRegionSourceImage,
@@ -268,6 +269,7 @@ import {
   DEFAULT_PROMPT_LAYER_NUM_BEAMS,
   DEFAULT_PROMPT_LAYER_TASK,
   DEFAULT_SERVER_URL,
+  DEFAULT_LORA_STRENGTH,
   DEFAULT_SKETCH_CONTROL_STRENGTH,
   DEFAULT_SKETCH_DENOISE,
   DEFAULT_SKETCH_STEPS,
@@ -1064,10 +1066,15 @@ export function renderApp(rootElement: HTMLElement) {
   elements.workflow.addEventListener("change", () => {
     applyRecommendedPresetSettings(elements.workflow, DEFAULT_WORKFLOW, elements.steps, elements.cfg);
     void refreshTextModelOptionsForSelectedPreset(elements).then(() => updateTextCheckpointCompatibility(elements));
+    void refreshLoraOptionsForSelectedPreset(elements);
   });
 
   elements.checkpoint.addEventListener("change", () => {
     updateTextCheckpointCompatibility(elements);
+  });
+
+  elements.loraName.addEventListener("change", () => {
+    updateLoraStrengthVisibility(elements);
   });
 
   elements.imgWorkflow.addEventListener("change", () => {
@@ -1133,6 +1140,7 @@ export function renderApp(rootElement: HTMLElement) {
       await refreshInpaintModelOptionsForSelectedPreset(elements, client);
       await refreshOutpaintModelOptionsForSelectedPreset(elements, client);
       await refreshUpscaleModelOptionsForSelectedPreset(elements, client);
+      await refreshLoraOptionsForSelectedPreset(elements, client);
       updateImageCheckpointCompatibility(elements, allowExperimentalCheckpoints, imageSource);
       updateSketchCheckpointCompatibility(elements, sketchSource);
       updateInpaintCheckpointCompatibility(elements, inpaintSource);
@@ -1829,7 +1837,8 @@ export function renderApp(rootElement: HTMLElement) {
         height: settings.height,
         steps: settings.steps,
         cfg: settings.cfg,
-        seed: settings.seed
+        seed: settings.seed,
+        lora: readLoraSelection(elements)
       });
 
       const generatedResult = await generation.runPipeline({
@@ -4817,6 +4826,127 @@ function fillSingleCheckpointSelect(select: HTMLSelectElement, checkpoints: stri
   } else {
     select.value = checkpoints[0] ?? "";
   }
+}
+
+/**
+ * Shows the LoRA controls only for presets that declare an insertion point, and
+ * fills the list from ComfyUI.
+ *
+ * The list is deliberately NOT filtered by architecture. ComfyUI exposes only a
+ * LoRA's name, size and timestamps -- `/models/loras` and
+ * `/experiment/models/loras` both stop there -- so nothing reachable over the
+ * wire says which base model a file was trained against. The safetensors
+ * metadata that would say is not served, and is not trustworthy even when read
+ * directly: two LoRAs on the reference machine declare
+ * `ss_base_model_version: sd_1.5` while their tensor keys are plainly Flux.
+ * A filter built on any of that would hide working LoRAs and still admit broken
+ * ones, so the panel lists everything and warns instead.
+ */
+async function refreshLoraOptionsForSelectedPreset(
+  elements: AppElements,
+  client = new ComfyClient(elements.serverUrl.value)
+) {
+  const preset = getWorkflowPreset(readSelectValue(elements.workflow, DEFAULT_WORKFLOW));
+
+  updateLoraFieldVisibility(elements, preset);
+
+  if (!preset.loraInsertion) {
+    return;
+  }
+
+  try {
+    const loraNames = await client.getLoraNames();
+    const preferred = readSelectValue(elements.loraName);
+
+    fillLoraSelect(elements.loraName, loraNames, preset, preferred);
+  } catch {
+    // Keep whatever is listed if ComfyUI is offline; None stays selectable.
+  }
+
+  updateLoraStrengthVisibility(elements);
+}
+
+function updateLoraFieldVisibility(elements: AppElements, preset: WorkflowPresetDefinition) {
+  const supportsLora = Boolean(preset.loraInsertion);
+
+  elements.loraField.hidden = !supportsLora;
+
+  if (!supportsLora) {
+    // Leaving a stale selection behind would silently apply a LoRA the next
+    // time a LoRA-capable preset is chosen.
+    elements.loraName.value = "";
+    updateLoraStrengthVisibility(elements);
+  }
+}
+
+/** Strength only means something once a LoRA is actually selected. */
+function updateLoraStrengthVisibility(elements: AppElements) {
+  const selected = readSelectValue(elements.loraName);
+
+  elements.loraStrengthField.hidden = !selected;
+  elements.loraNote.hidden = !selected;
+
+  if (!selected) {
+    return;
+  }
+
+  const preset = getWorkflowPreset(readSelectValue(elements.workflow, DEFAULT_WORKFLOW));
+  const hint = getLoraFamilyHint(selected, preset);
+
+  elements.loraNote.textContent = hint === "foreign"
+    ? "This LoRA's name suggests it was trained for a different model. A mismatched LoRA loads without any error and then does nothing, so an unchanged image is the symptom to expect."
+    : "ComfyUI reports only a LoRA's name, never which model it was trained for. A mismatched LoRA loads without error and quietly does nothing, so if the image looks unchanged, check the LoRA suits this workflow's model.";
+}
+
+function fillLoraSelect(
+  select: HTMLSelectElement,
+  loraNames: string[],
+  preset: WorkflowPresetDefinition,
+  preferredValue?: string
+) {
+  select.innerHTML = "";
+
+  const none = document.createElement("option");
+  none.value = "";
+  none.textContent = "None";
+  select.append(none);
+
+  // Likely matches first, then unlabelled, then the ones whose names point at
+  // another model -- so the entry most likely to work is nearest the top
+  // without any of them being hidden.
+  const order: Record<string, number> = { matches: 0, unknown: 1, foreign: 2 };
+  const sorted = [...loraNames].sort((left, right) => (
+    order[getLoraFamilyHint(left, preset)] - order[getLoraFamilyHint(right, preset)]
+  ));
+
+  for (const loraName of sorted) {
+    const option = document.createElement("option");
+    option.value = loraName;
+    option.textContent = `${loraName}${formatLoraHintSuffix(getLoraFamilyHint(loraName, preset))}`;
+    select.append(option);
+  }
+
+  select.value = preferredValue && loraNames.includes(preferredValue) ? preferredValue : "";
+}
+
+/** The artist's LoRA choice, or undefined when None is selected. */
+function readLoraSelection(elements: AppElements): WorkflowLoraSelection | undefined {
+  const loraName = readSelectValue(elements.loraName);
+
+  if (!loraName) {
+    return undefined;
+  }
+
+  const parsed = Number.parseFloat(elements.loraStrength.value);
+  // One control drives both strengths; a blank or junk value falls back to the
+  // default rather than sending NaN to ComfyUI.
+  const strength = Number.isFinite(parsed) ? parsed : Number.parseFloat(DEFAULT_LORA_STRENGTH);
+
+  return {
+    loraName,
+    strengthModel: strength,
+    strengthClip: strength
+  };
 }
 
 function ensureCoreSelectDefaults(elements: AppElements) {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -1072,7 +1072,7 @@ export function renderApp(rootElement: HTMLElement) {
   elements.workflow.addEventListener("change", () => {
     applyRecommendedPresetSettings(elements.workflow, DEFAULT_WORKFLOW, elements.steps, elements.cfg);
     void refreshTextModelOptionsForSelectedPreset(elements).then(() => updateTextCheckpointCompatibility(elements));
-    void refreshLoraOptionsForSelectedPreset(elements);
+    void refreshLoraOptions(getTextLoraControls(elements), elements);
   });
 
   elements.checkpoint.addEventListener("change", () => {
@@ -1080,7 +1080,15 @@ export function renderApp(rootElement: HTMLElement) {
   });
 
   elements.loraName.addEventListener("change", () => {
-    updateLoraStrengthVisibility(elements);
+    updateLoraStrengthVisibility(getTextLoraControls(elements));
+  });
+
+  elements.imgLoraName.addEventListener("change", () => {
+    updateLoraStrengthVisibility(getImageLoraControls(elements));
+  });
+
+  elements.sketchLoraName.addEventListener("change", () => {
+    updateLoraStrengthVisibility(getSketchLoraControls(elements));
   });
 
   elements.imgWorkflow.addEventListener("change", () => {
@@ -1088,6 +1096,7 @@ export function renderApp(rootElement: HTMLElement) {
     void refreshImageModelOptionsForSelectedPreset(elements).then(() => (
       updateImageCheckpointCompatibility(elements, allowExperimentalCheckpoints, imageSource)
     ));
+    void refreshLoraOptions(getImageLoraControls(elements), elements);
   });
 
   elements.imgCheckpoint.addEventListener("change", () => {
@@ -1097,6 +1106,7 @@ export function renderApp(rootElement: HTMLElement) {
   elements.sketchWorkflow.addEventListener("change", () => {
     applyRecommendedPresetSettings(elements.sketchWorkflow, DEFAULT_SKETCH_WORKFLOW, elements.sketchSteps, elements.sketchCfg);
     updateSketchCheckpointCompatibility(elements, sketchSource);
+    void refreshLoraOptions(getSketchLoraControls(elements), elements);
   });
 
   elements.sketchCheckpoint.addEventListener("change", () => {
@@ -1146,7 +1156,7 @@ export function renderApp(rootElement: HTMLElement) {
       await refreshInpaintModelOptionsForSelectedPreset(elements, client);
       await refreshOutpaintModelOptionsForSelectedPreset(elements, client);
       await refreshUpscaleModelOptionsForSelectedPreset(elements, client);
-      await refreshLoraOptionsForSelectedPreset(elements, client);
+      await refreshAllLoraOptions(elements, client);
       updateImageCheckpointCompatibility(elements, allowExperimentalCheckpoints, imageSource);
       updateSketchCheckpointCompatibility(elements, sketchSource);
       updateInpaintCheckpointCompatibility(elements, inpaintSource);
@@ -1844,7 +1854,7 @@ export function renderApp(rootElement: HTMLElement) {
         steps: settings.steps,
         cfg: settings.cfg,
         seed: settings.seed,
-        lora: readLoraSelection(elements)
+        lora: readLoraSelection(getTextLoraControls(elements))
       });
 
       const generatedResult = await generation.runPipeline({
@@ -2257,7 +2267,8 @@ export function renderApp(rootElement: HTMLElement) {
         steps: settings.steps,
         cfg: settings.cfg,
         seed: settings.seed,
-        denoise: settings.denoise
+        denoise: settings.denoise,
+        lora: readLoraSelection(getImageLoraControls(elements))
       });
 
       // The commit closure runs after awaits; a const keeps the null-checked
@@ -3187,7 +3198,8 @@ export function renderApp(rootElement: HTMLElement) {
         cfg: settings.cfg,
         seed: settings.seed,
         denoise: settings.denoise,
-        controlStrength: settings.controlStrength
+        controlStrength: settings.controlStrength,
+        lora: readLoraSelection(getSketchLoraControls(elements))
       });
 
       // The commit closure runs after awaits; a const keeps the null-checked
@@ -4835,6 +4847,59 @@ function fillSingleCheckpointSelect(select: HTMLSelectElement, checkpoints: stri
 }
 
 /**
+ * The LoRA controls for one tool card.
+ *
+ * Grouped rather than passed individually because three tools now carry the
+ * same row, and the alternative is the same six-element signature repeated at
+ * every call site.
+ */
+type LoraControls = {
+  workflowSelect: HTMLSelectElement;
+  defaultPresetId: string;
+  field: HTMLElement;
+  name: HTMLSelectElement;
+  strengthField: HTMLElement;
+  strength: HTMLInputElement;
+  note: HTMLElement;
+};
+
+function getTextLoraControls(elements: AppElements): LoraControls {
+  return {
+    workflowSelect: elements.workflow,
+    defaultPresetId: DEFAULT_WORKFLOW,
+    field: elements.loraField,
+    name: elements.loraName,
+    strengthField: elements.loraStrengthField,
+    strength: elements.loraStrength,
+    note: elements.loraNote
+  };
+}
+
+function getImageLoraControls(elements: AppElements): LoraControls {
+  return {
+    workflowSelect: elements.imgWorkflow,
+    defaultPresetId: DEFAULT_IMAGE_WORKFLOW,
+    field: elements.imgLoraField,
+    name: elements.imgLoraName,
+    strengthField: elements.imgLoraStrengthField,
+    strength: elements.imgLoraStrength,
+    note: elements.imgLoraNote
+  };
+}
+
+function getSketchLoraControls(elements: AppElements): LoraControls {
+  return {
+    workflowSelect: elements.sketchWorkflow,
+    defaultPresetId: DEFAULT_SKETCH_WORKFLOW,
+    field: elements.sketchLoraField,
+    name: elements.sketchLoraName,
+    strengthField: elements.sketchLoraStrengthField,
+    strength: elements.sketchLoraStrength,
+    note: elements.sketchLoraNote
+  };
+}
+
+/**
  * Shows the LoRA controls only for presets that declare an insertion point, and
  * fills the list from ComfyUI.
  *
@@ -4848,13 +4913,14 @@ function fillSingleCheckpointSelect(select: HTMLSelectElement, checkpoints: stri
  * A filter built on any of that would hide working LoRAs and still admit broken
  * ones, so the panel lists everything and warns instead.
  */
-async function refreshLoraOptionsForSelectedPreset(
+async function refreshLoraOptions(
+  controls: LoraControls,
   elements: AppElements,
   client = new ComfyClient(elements.serverUrl.value)
 ) {
-  const preset = getWorkflowPreset(readSelectValue(elements.workflow, DEFAULT_WORKFLOW));
+  const preset = getWorkflowPreset(readSelectValue(controls.workflowSelect, controls.defaultPresetId));
 
-  updateLoraFieldVisibility(elements, preset);
+  updateLoraFieldVisibility(controls, preset);
 
   if (!preset.loraInsertion) {
     return;
@@ -4862,45 +4928,51 @@ async function refreshLoraOptionsForSelectedPreset(
 
   try {
     const loraNames = await client.getLoraNames();
-    const preferred = readSelectValue(elements.loraName);
 
-    fillLoraSelect(elements.loraName, loraNames, preset, preferred);
+    fillLoraSelect(controls.name, loraNames, preset, readSelectValue(controls.name));
   } catch {
     // Keep whatever is listed if ComfyUI is offline; None stays selectable.
   }
 
-  updateLoraStrengthVisibility(elements);
+  updateLoraStrengthVisibility(controls);
 }
 
-function updateLoraFieldVisibility(elements: AppElements, preset: WorkflowPresetDefinition) {
+/** Refreshes every tool's LoRA row. */
+async function refreshAllLoraOptions(elements: AppElements, client = new ComfyClient(elements.serverUrl.value)) {
+  await refreshLoraOptions(getTextLoraControls(elements), elements, client);
+  await refreshLoraOptions(getImageLoraControls(elements), elements, client);
+  await refreshLoraOptions(getSketchLoraControls(elements), elements, client);
+}
+
+function updateLoraFieldVisibility(controls: LoraControls, preset: WorkflowPresetDefinition) {
   const supportsLora = Boolean(preset.loraInsertion);
 
-  elements.loraField.hidden = !supportsLora;
+  controls.field.hidden = !supportsLora;
 
   if (!supportsLora) {
     // Leaving a stale selection behind would silently apply a LoRA the next
     // time a LoRA-capable preset is chosen.
-    elements.loraName.value = NO_LORA_VALUE;
-    updateLoraStrengthVisibility(elements);
+    controls.name.value = NO_LORA_VALUE;
+    updateLoraStrengthVisibility(controls);
   }
 }
 
 /** Strength only means something once a LoRA is actually selected. */
-function updateLoraStrengthVisibility(elements: AppElements) {
-  const selected = readSelectValue(elements.loraName);
+function updateLoraStrengthVisibility(controls: LoraControls) {
+  const selected = readSelectValue(controls.name);
   const hasLora = isLoraSelected(selected);
 
-  elements.loraStrengthField.hidden = !hasLora;
-  elements.loraNote.hidden = !hasLora;
+  controls.strengthField.hidden = !hasLora;
+  controls.note.hidden = !hasLora;
 
   if (!hasLora) {
     return;
   }
 
-  const preset = getWorkflowPreset(readSelectValue(elements.workflow, DEFAULT_WORKFLOW));
+  const preset = getWorkflowPreset(readSelectValue(controls.workflowSelect, controls.defaultPresetId));
   const hint = getLoraFamilyHint(selected, preset);
 
-  elements.loraNote.textContent = hint === "foreign"
+  controls.note.textContent = hint === "foreign"
     ? "This LoRA's name suggests it was trained for a different model. A mismatched LoRA loads without any error and then does nothing, so an unchanged image is the symptom to expect."
     : "ComfyUI reports only a LoRA's name, never which model it was trained for. A mismatched LoRA loads without error and quietly does nothing, so if the image looks unchanged, check the LoRA suits this workflow's model.";
 }
@@ -4929,7 +5001,7 @@ function fillLoraSelect(
   for (const loraName of sorted) {
     const option = document.createElement("option");
     option.value = loraName;
-    option.textContent = `${loraName}${formatLoraHintSuffix(getLoraFamilyHint(loraName, preset))}`;
+    option.textContent = loraName + formatLoraHintSuffix(getLoraFamilyHint(loraName, preset));
     select.append(option);
   }
 
@@ -4937,10 +5009,10 @@ function fillLoraSelect(
 }
 
 /** The artist's LoRA choice, or undefined when None is selected. */
-function readLoraSelection(elements: AppElements): WorkflowLoraSelection | undefined {
+function readLoraSelection(controls: LoraControls): WorkflowLoraSelection | undefined {
   return resolveLoraSelection(
-    readSelectValue(elements.loraName),
-    elements.loraStrength.value,
+    readSelectValue(controls.name),
+    controls.strength.value,
     Number.parseFloat(DEFAULT_LORA_STRENGTH)
   );
 }

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -121,7 +121,13 @@ import {
 } from "./setupInstallModel";
 import type { WorkflowPhotoshopInputAvailability } from "../comfy/workflowCompatibility";
 import { GeneratedImageResult, WorkflowLoraSelection, WorkflowPresetDefinition } from "../comfy/types";
-import { formatLoraHintSuffix, getLoraFamilyHint } from "../comfy/loraCompatibility";
+import {
+  NO_LORA_VALUE,
+  formatLoraHintSuffix,
+  getLoraFamilyHint,
+  isLoraSelected,
+  resolveLoraSelection
+} from "../comfy/loraCompatibility";
 import {
   ExportedSourceImage,
   SelectedRegionSourceImage,
@@ -4874,7 +4880,7 @@ function updateLoraFieldVisibility(elements: AppElements, preset: WorkflowPreset
   if (!supportsLora) {
     // Leaving a stale selection behind would silently apply a LoRA the next
     // time a LoRA-capable preset is chosen.
-    elements.loraName.value = "";
+    elements.loraName.value = NO_LORA_VALUE;
     updateLoraStrengthVisibility(elements);
   }
 }
@@ -4882,11 +4888,12 @@ function updateLoraFieldVisibility(elements: AppElements, preset: WorkflowPreset
 /** Strength only means something once a LoRA is actually selected. */
 function updateLoraStrengthVisibility(elements: AppElements) {
   const selected = readSelectValue(elements.loraName);
+  const hasLora = isLoraSelected(selected);
 
-  elements.loraStrengthField.hidden = !selected;
-  elements.loraNote.hidden = !selected;
+  elements.loraStrengthField.hidden = !hasLora;
+  elements.loraNote.hidden = !hasLora;
 
-  if (!selected) {
+  if (!hasLora) {
     return;
   }
 
@@ -4907,7 +4914,7 @@ function fillLoraSelect(
   select.innerHTML = "";
 
   const none = document.createElement("option");
-  none.value = "";
+  none.value = NO_LORA_VALUE;
   none.textContent = "None";
   select.append(none);
 
@@ -4926,27 +4933,16 @@ function fillLoraSelect(
     select.append(option);
   }
 
-  select.value = preferredValue && loraNames.includes(preferredValue) ? preferredValue : "";
+  select.value = preferredValue && loraNames.includes(preferredValue) ? preferredValue : NO_LORA_VALUE;
 }
 
 /** The artist's LoRA choice, or undefined when None is selected. */
 function readLoraSelection(elements: AppElements): WorkflowLoraSelection | undefined {
-  const loraName = readSelectValue(elements.loraName);
-
-  if (!loraName) {
-    return undefined;
-  }
-
-  const parsed = Number.parseFloat(elements.loraStrength.value);
-  // One control drives both strengths; a blank or junk value falls back to the
-  // default rather than sending NaN to ComfyUI.
-  const strength = Number.isFinite(parsed) ? parsed : Number.parseFloat(DEFAULT_LORA_STRENGTH);
-
-  return {
-    loraName,
-    strengthModel: strength,
-    strengthClip: strength
-  };
+  return resolveLoraSelection(
+    readSelectValue(elements.loraName),
+    elements.loraStrength.value,
+    Number.parseFloat(DEFAULT_LORA_STRENGTH)
+  );
 }
 
 function ensureCoreSelectDefaults(elements: AppElements) {

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -1,7 +1,7 @@
 import { OpenLayerTheme } from "../utils/preferences";
 
 export const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-export const APP_VERSION = "0.12.0";
+export const APP_VERSION = "0.13.0";
 export const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 export const HISTORY_LIMIT = 5;
 export const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -23,6 +23,8 @@ export const DEFAULT_IMG2IMG_DENOISE = "0.55";
 export const DEFAULT_SKETCH_STEPS = "20";
 export const DEFAULT_SKETCH_DENOISE = "1";
 export const DEFAULT_SKETCH_CONTROL_STRENGTH = "0.8";
+/** One control drives both strength_model and strength_clip; 0.8 is the usual starting point. */
+export const DEFAULT_LORA_STRENGTH = "0.8";
 export const DEFAULT_INPAINT_STEPS = "16";
 export const DEFAULT_INPAINT_DENOISE = "0.75";
 export const DEFAULT_OUTPAINT_STEPS = "20";

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -80,6 +80,16 @@ export type AppElements = {
   loraStrengthField: HTMLElement;
   loraStrength: HTMLInputElement;
   loraNote: HTMLElement;
+  imgLoraField: HTMLElement;
+  imgLoraName: HTMLSelectElement;
+  imgLoraStrengthField: HTMLElement;
+  imgLoraStrength: HTMLInputElement;
+  imgLoraNote: HTMLElement;
+  sketchLoraField: HTMLElement;
+  sketchLoraName: HTMLSelectElement;
+  sketchLoraStrengthField: HTMLElement;
+  sketchLoraStrength: HTMLInputElement;
+  sketchLoraNote: HTMLElement;
   width: HTMLInputElement;
   height: HTMLInputElement;
   steps: HTMLInputElement;
@@ -695,6 +705,19 @@ export function createAppMarkup() {
             </select>
             ${createInfoPanelMarkup("img-compatibility-note", "img2img-basic is safest with SD 1.x and SDXL checkpoints. SD3 and Flux may need dedicated presets.")}
           </div>
+          <section class="lora-section" id="img-lora-field" aria-label="LoRA" hidden>
+            <label class="field">
+              <span class="label">LoRA (optional)</span>
+              <select class="select" id="img-lora-name">
+                <option value="${NO_LORA_VALUE}">None</option>
+              </select>
+            </label>
+            <label class="field" id="img-lora-strength-field" hidden>
+              <span class="label">LoRA strength</span>
+              <input class="input input-compact" id="img-lora-strength" type="number" min="0" max="2" step="0.05" value="${DEFAULT_LORA_STRENGTH}" />
+            </label>
+            <div class="diagnostics-line" id="img-lora-note" hidden></div>
+          </section>
           <button class="button experimental-toggle action-control" id="experimental-checkpoint-toggle" data-openlayer-action="toggleExperimentalCheckpoints" type="button" aria-pressed="false">Experimental Checkpoints Off</button>
           <div class="settings-grid img2img-settings-grid" aria-label="Image to Image settings">
             <div class="field ol-setting-row">
@@ -802,6 +825,19 @@ export function createAppMarkup() {
             </select>
             ${createInfoPanelMarkup("sketch-compatibility-note", "Recommended: epicrealism_naturalSinRC1VAE.safetensors with an SD 1.5 LineArt ControlNet workflow.")}
           </div>
+          <section class="lora-section" id="sketch-lora-field" aria-label="LoRA" hidden>
+            <label class="field">
+              <span class="label">LoRA (optional)</span>
+              <select class="select" id="sketch-lora-name">
+                <option value="${NO_LORA_VALUE}">None</option>
+              </select>
+            </label>
+            <label class="field" id="sketch-lora-strength-field" hidden>
+              <span class="label">LoRA strength</span>
+              <input class="input input-compact" id="sketch-lora-strength" type="number" min="0" max="2" step="0.05" value="${DEFAULT_LORA_STRENGTH}" />
+            </label>
+            <div class="diagnostics-line" id="sketch-lora-note" hidden></div>
+          </section>
           <div class="settings-grid img2img-settings-grid" aria-label="Sketch to Image settings">
             <div class="field">
               <span class="label">Steps</span>
@@ -1461,6 +1497,16 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     loraStrengthField: getElement<HTMLElement>(rootElement, "lora-strength-field"),
     loraStrength: getElement<HTMLInputElement>(rootElement, "lora-strength"),
     loraNote: getElement<HTMLElement>(rootElement, "lora-note"),
+    imgLoraField: getElement<HTMLElement>(rootElement, "img-lora-field"),
+    imgLoraName: getElement<HTMLSelectElement>(rootElement, "img-lora-name"),
+    imgLoraStrengthField: getElement<HTMLElement>(rootElement, "img-lora-strength-field"),
+    imgLoraStrength: getElement<HTMLInputElement>(rootElement, "img-lora-strength"),
+    imgLoraNote: getElement<HTMLElement>(rootElement, "img-lora-note"),
+    sketchLoraField: getElement<HTMLElement>(rootElement, "sketch-lora-field"),
+    sketchLoraName: getElement<HTMLSelectElement>(rootElement, "sketch-lora-name"),
+    sketchLoraStrengthField: getElement<HTMLElement>(rootElement, "sketch-lora-strength-field"),
+    sketchLoraStrength: getElement<HTMLInputElement>(rootElement, "sketch-lora-strength"),
+    sketchLoraNote: getElement<HTMLElement>(rootElement, "sketch-lora-note"),
     width: getElement<HTMLInputElement>(rootElement, "width"),
     height: getElement<HTMLInputElement>(rootElement, "height"),
     steps: getElement<HTMLInputElement>(rootElement, "steps"),

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_IMG2IMG_STEPS,
   DEFAULT_INPAINT_DENOISE,
   DEFAULT_INPAINT_STEPS,
+  DEFAULT_LORA_STRENGTH,
   DEFAULT_OUTPAINT_BOTTOM,
   DEFAULT_OUTPAINT_DENOISE,
   DEFAULT_OUTPAINT_FEATHERING,
@@ -73,6 +74,11 @@ export type AppElements = {
   negativePrompt: HTMLTextAreaElement;
   workflow: HTMLSelectElement;
   checkpoint: HTMLSelectElement;
+  loraField: HTMLElement;
+  loraName: HTMLSelectElement;
+  loraStrengthField: HTMLElement;
+  loraStrength: HTMLInputElement;
+  loraNote: HTMLElement;
   width: HTMLInputElement;
   height: HTMLInputElement;
   steps: HTMLInputElement;
@@ -565,6 +571,19 @@ export function createAppMarkup() {
               ${FALLBACK_CHECKPOINTS.map((checkpoint) => `<option value="${checkpoint}">${checkpoint}</option>`).join("")}
             </select>
           </label>
+          <section class="lora-section" id="lora-field" aria-label="LoRA" hidden>
+            <label class="field">
+              <span class="label">LoRA (optional)</span>
+              <select class="select" id="lora-name">
+                <option value="">None</option>
+              </select>
+            </label>
+            <label class="field" id="lora-strength-field" hidden>
+              <span class="label">LoRA strength</span>
+              <input class="input input-compact" id="lora-strength" type="number" min="0" max="2" step="0.05" value="${DEFAULT_LORA_STRENGTH}" />
+            </label>
+            <div class="diagnostics-line" id="lora-note" hidden></div>
+          </section>
           <div class="settings-grid" aria-label="Generation settings">
             <label class="field">
               <span class="label">Width</span>
@@ -1436,6 +1455,11 @@ export function getAppElements(rootElement: HTMLElement): AppElements {
     negativePrompt: getElement<HTMLTextAreaElement>(rootElement, "negative-prompt"),
     workflow: getElement<HTMLSelectElement>(rootElement, "workflow"),
     checkpoint: getElement<HTMLSelectElement>(rootElement, "checkpoint"),
+    loraField: getElement<HTMLElement>(rootElement, "lora-field"),
+    loraName: getElement<HTMLSelectElement>(rootElement, "lora-name"),
+    loraStrengthField: getElement<HTMLElement>(rootElement, "lora-strength-field"),
+    loraStrength: getElement<HTMLInputElement>(rootElement, "lora-strength"),
+    loraNote: getElement<HTMLElement>(rootElement, "lora-note"),
     width: getElement<HTMLInputElement>(rootElement, "width"),
     height: getElement<HTMLInputElement>(rootElement, "height"),
     steps: getElement<HTMLInputElement>(rootElement, "steps"),

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -1,4 +1,5 @@
 import { listRunnableWorkflowPresets, listWorkflowPresets } from "../comfy/presetRegistry";
+import { NO_LORA_VALUE } from "../comfy/loraCompatibility";
 import {
   APP_VERSION,
   DEFAULT_CFG,
@@ -575,7 +576,7 @@ export function createAppMarkup() {
             <label class="field">
               <span class="label">LoRA (optional)</span>
               <select class="select" id="lora-name">
-                <option value="">None</option>
+                <option value="${NO_LORA_VALUE}">None</option>
               </select>
             </label>
             <label class="field" id="lora-strength-field" hidden>

--- a/src/workflows/api/sketch2img-depth-basic.json
+++ b/src/workflows/api/sketch2img-depth-basic.json
@@ -1,0 +1,166 @@
+{
+  "4": {
+    "inputs": {
+      "ckpt_name": "epicrealism_naturalSinRC1VAE.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load SD1 Checkpoint"
+    }
+  },
+  "10": {
+    "inputs": {
+      "image": "openlayer-sketch-source.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Sketch Source"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "a finished illustration matching the depth and perspective of the source",
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "Positive Prompt"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "4",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "Negative Prompt"
+    }
+  },
+  "12": {
+    "inputs": {
+      "ckpt_name": "depth_anything_v2_vitl.pth",
+      "resolution": 512,
+      "image": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "DepthAnythingV2Preprocessor",
+    "_meta": {
+      "title": "Depth Anything V2 Preprocessor"
+    }
+  },
+  "13": {
+    "inputs": {
+      "control_net_name": "control_v11f1p_sd15_depth_fp16.safetensors"
+    },
+    "class_type": "ControlNetLoader",
+    "_meta": {
+      "title": "Load Depth ControlNet"
+    }
+  },
+  "14": {
+    "inputs": {
+      "strength": 0.8,
+      "start_percent": 0,
+      "end_percent": 1,
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "control_net": [
+        "13",
+        0
+      ],
+      "image": [
+        "12",
+        0
+      ]
+    },
+    "class_type": "ControlNetApplyAdvanced",
+    "_meta": {
+      "title": "Apply Depth ControlNet"
+    }
+  },
+  "5": {
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent At Sketch Size"
+    }
+  },
+  "3": {
+    "inputs": {
+      "seed": 1,
+      "steps": 20,
+      "cfg": 7,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "4",
+        0
+      ],
+      "positive": [
+        "14",
+        0
+      ],
+      "negative": [
+        "14",
+        1
+      ],
+      "latent_image": [
+        "5",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "Sampler"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "4",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "OpenLayer_Sketch",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/src/workflows/api/sketch2img-scribble-basic.json
+++ b/src/workflows/api/sketch2img-scribble-basic.json
@@ -19,7 +19,7 @@
   },
   "6": {
     "inputs": {
-      "text": "a refined image guided by clean lineart",
+      "text": "a finished illustration guided by a rough scribble",
       "clip": [
         "4",
         1
@@ -45,25 +45,21 @@
   },
   "12": {
     "inputs": {
-      "merge_with_lineart": "lineart_standard",
+      "safe": "enable",
       "resolution": 1024,
-      "lineart_lower_bound": 0,
-      "lineart_upper_bound": 1,
-      "object_min_size": 36,
-      "object_connectivity": 1,
       "image": [
         "10",
         0
       ]
     },
-    "class_type": "AnyLineArtPreprocessor_aux",
+    "class_type": "Scribble_PiDiNet_Preprocessor",
     "_meta": {
       "title": "Standard Lineart Preprocessor"
     }
   },
   "13": {
     "inputs": {
-      "control_net_name": "control_v11p_sd15_lineart_fp16.safetensors"
+      "control_net_name": "control_v11p_sd15_scribble_fp16.safetensors"
     },
     "class_type": "ControlNetLoader",
     "_meta": {

--- a/src/workflows/source/sketch2img-depth-basic.workflow.json
+++ b/src/workflows/source/sketch2img-depth-basic.workflow.json
@@ -1,0 +1,691 @@
+{
+  "id": "5f2a91c4-7b3e-4d16-9c48-2ae70b5d8f31",
+  "revision": 0,
+  "last_node_id": 14,
+  "last_link_id": 28,
+  "nodes": [
+    {
+      "id": 7,
+      "type": "CLIPTextEncode",
+      "pos": [
+        482.798828125,
+        460
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 20
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            26
+          ]
+        }
+      ],
+      "title": "Negative Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 8,
+      "type": "VAEDecode",
+      "pos": [
+        1722.798828125,
+        130
+      ],
+      "size": [
+        140,
+        46
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 21
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 22
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            23
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "VAEDecode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 14,
+      "type": "ControlNetApplyAdvanced",
+      "pos": [
+        982.798828125,
+        130
+      ],
+      "size": [
+        270,
+        186
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 25
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 26
+        },
+        {
+          "name": "control_net",
+          "type": "CONTROL_NET",
+          "link": 27
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 28
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            16
+          ]
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "links": [
+            17
+          ]
+        }
+      ],
+      "title": "Apply Depth ControlNet",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "ControlNetApplyAdvanced",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        0.8,
+        0,
+        1
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        100,
+        130
+      ],
+      "size": [
+        270,
+        98
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            15
+          ]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            19,
+            20
+          ]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            22
+          ]
+        }
+      ],
+      "title": "Load SD1 Checkpoint",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "CheckpointLoaderSimple",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "epicrealism_naturalSinRC1VAE.safetensors"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "CLIPTextEncode",
+      "pos": [
+        482.798828125,
+        130
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 19
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            25
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "a finished illustration matching the depth and perspective of the source"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "DepthAnythingV2Preprocessor",
+      "pos": [
+        482.798828125,
+        790
+      ],
+      "size": [
+        270,
+        82
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 24
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            28
+          ]
+        }
+      ],
+      "title": "Depth Anything V2 - Relative",
+      "properties": {
+        "cnr_id": "comfyui_controlnet_aux",
+        "ver": "e8b689a513c3e6b63edc44066560ca5919c0576e",
+        "Node name for S&R": "DepthAnythingV2Preprocessor",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "depth_anything_v2_vitl.pth",
+        512
+      ]
+    },
+    {
+      "id": 13,
+      "type": "ControlNetLoader",
+      "pos": [
+        98.70262257668115,
+        855.8390373677852
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONTROL_NET",
+          "type": "CONTROL_NET",
+          "links": [
+            27
+          ]
+        }
+      ],
+      "title": "Load Depth ControlNet",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "ControlNetLoader",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "control_v11f1p_sd15_depth_fp16.safetensors"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [
+        108.54752513930123,
+        287.7204535163998
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            18
+          ]
+        }
+      ],
+      "title": "Empty Latent At Sketch Size",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "EmptyLatentImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        512,
+        512,
+        1
+      ]
+    },
+    {
+      "id": 10,
+      "type": "LoadImage",
+      "pos": [
+        99.23656618600262,
+        478.3031831162233
+      ],
+      "size": [
+        282.798828125,
+        314.00000000000006
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            24
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "title": "Load Sketch Source",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "LoadImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        },
+        "#sdppp_variant": "default",
+        "#sdppp_simple_content": "canvas",
+        "#sdppp_simple_mask": "canvas",
+        "#sdppp_simple_boundary": "canvas",
+        "#sdppp_label": ""
+      },
+      "widgets_values": [
+        "z-image_01484_.png",
+        "image"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "KSampler",
+      "pos": [
+        1352.798828125,
+        130
+      ],
+      "size": [
+        270,
+        474
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 15
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 16
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 17
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 18
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            21
+          ]
+        }
+      ],
+      "title": "Sampler",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "KSampler",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        799774906435439,
+        "randomize",
+        20,
+        7,
+        "euler",
+        "normal",
+        1
+      ]
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        1962.798828125,
+        130
+      ],
+      "size": [
+        270,
+        270
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 23
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.1",
+        "Node name for S&R": "SaveImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "OpenLayer_Sketch"
+      ]
+    }
+  ],
+  "links": [
+    [
+      15,
+      4,
+      0,
+      3,
+      0,
+      "MODEL"
+    ],
+    [
+      16,
+      14,
+      0,
+      3,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      17,
+      14,
+      1,
+      3,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      18,
+      5,
+      0,
+      3,
+      3,
+      "LATENT"
+    ],
+    [
+      19,
+      4,
+      1,
+      6,
+      0,
+      "CLIP"
+    ],
+    [
+      20,
+      4,
+      1,
+      7,
+      0,
+      "CLIP"
+    ],
+    [
+      21,
+      3,
+      0,
+      8,
+      0,
+      "LATENT"
+    ],
+    [
+      22,
+      4,
+      2,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      23,
+      8,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ],
+    [
+      24,
+      10,
+      0,
+      12,
+      0,
+      "IMAGE"
+    ],
+    [
+      25,
+      6,
+      0,
+      14,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      26,
+      7,
+      0,
+      14,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      27,
+      13,
+      0,
+      14,
+      2,
+      "CONTROL_NET"
+    ],
+    [
+      28,
+      12,
+      0,
+      14,
+      3,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ue_links": [],
+    "links_added_by_ue": [],
+    "ds": {
+      "scale": 0.7657731958762918,
+      "offset": [
+        1.502953707290921,
+        176.13778347079736
+      ]
+    },
+    "frontendVersion": "1.45.20",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/src/workflows/source/sketch2img-scribble-basic.workflow.json
+++ b/src/workflows/source/sketch2img-scribble-basic.workflow.json
@@ -1,5 +1,5 @@
 {
-  "id": "26d610c6-0420-4ac5-a99f-1da6e85f924f",
+  "id": "5f2a91c4-7b3e-4d16-9c48-2ae70b5d8f31",
   "revision": 0,
   "last_node_id": 14,
   "last_link_id": 28,
@@ -154,7 +154,7 @@
           ]
         }
       ],
-      "title": "Apply LineArt ControlNet",
+      "title": "Apply Scribble ControlNet",
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.27.1",
@@ -267,19 +267,19 @@
         }
       },
       "widgets_values": [
-        "a refined image guided by clean lineart"
+        "a finished illustration guided by a rough scribble"
       ]
     },
     {
       "id": 12,
-      "type": "AnyLineArtPreprocessor_aux",
+      "type": "Scribble_PiDiNet_Preprocessor",
       "pos": [
         482.798828125,
         790
       ],
       "size": [
         270,
-        154
+        82
       ],
       "flags": {},
       "order": 6,
@@ -300,11 +300,11 @@
           ]
         }
       ],
-      "title": "AnyLine Lineart Preprocessor",
+      "title": "Scribble (PiDiNet) Preprocessor",
       "properties": {
         "cnr_id": "comfyui_controlnet_aux",
         "ver": "e8b689a513c3e6b63edc44066560ca5919c0576e",
-        "Node name for S&R": "AnyLineArtPreprocessor_aux",
+        "Node name for S&R": "Scribble_PiDiNet_Preprocessor",
         "ue_properties": {
           "widget_ue_connectable": {},
           "input_ue_unconnectable": {},
@@ -312,12 +312,8 @@
         }
       },
       "widgets_values": [
-        "lineart_standard",
-        1024,
-        0,
-        1,
-        36,
-        1
+        "enable",
+        1024
       ]
     },
     {
@@ -344,7 +340,7 @@
           ]
         }
       ],
-      "title": "Load LineArt ControlNet",
+      "title": "Load Scribble ControlNet",
       "properties": {
         "cnr_id": "comfy-core",
         "ver": "0.27.1",
@@ -356,7 +352,7 @@
         }
       },
       "widgets_values": [
-        "control_v11p_sd15_lineart_fp16.safetensors"
+        "control_v11p_sd15_scribble_fp16.safetensors"
       ]
     },
     {

--- a/tests/comfy/loraCompatibility.test.ts
+++ b/tests/comfy/loraCompatibility.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { formatLoraHintSuffix, getLoraFamilyHint } from "../../src/comfy/loraCompatibility";
+import { getWorkflowPreset } from "../../src/comfy/presetRegistry";
+
+const KREA2 = getWorkflowPreset("txt2img-krea2-turbo");
+const NO_LORA_PRESET = getWorkflowPreset("txt2img-basic");
+
+/**
+ * The real contents of the reference machine's loras folder, with the
+ * architecture each file actually is -- read from its safetensors tensor keys,
+ * not from its name and not from its metadata.
+ *
+ * Two of these (`illustration`, `meat_v1`) declare `ss_base_model_version:
+ * sd_1.5` in metadata while their keys are Flux, which is exactly why the hint
+ * is filename-based and advisory rather than authoritative.
+ */
+const REAL_LORAS = [
+  { name: "krea2_darkbrush.safetensors", actual: "krea2" },
+  { name: "aidmaMJ6.1-FLUX-v0.5.safetensors", actual: "flux" },
+  { name: "flux_realism_lora.safetensors", actual: "flux" },
+  { name: "lcm\\SD1.5\\pytorch_lora_weights.safetensors", actual: "sd1.5" },
+  { name: "qinglong_detailedeye_z-imageV2(comfy).safetensors", actual: "zimage" },
+  { name: "Martin_French.safetensors", actual: "flux" },
+  { name: "Memoria_xyzVntg.safetensors", actual: "sd1.5" },
+  { name: "add_detail.safetensors", actual: "sd1.5" },
+  { name: "illustration.safetensors", actual: "flux" },
+  { name: "lora.safetensors", actual: "flux" },
+  { name: "meat_v1.safetensors", actual: "flux" }
+] as const;
+
+describe("LoRA family hints", () => {
+  it("never claims a match for a LoRA that is not actually this preset's family", () => {
+    // The one error that would genuinely mislead. A missed mismatch costs a
+    // wasted generation; a false "matches" sends the artist looking for a bug
+    // in the wrong place.
+    for (const lora of REAL_LORAS) {
+      if (getLoraFamilyHint(lora.name, KREA2) === "matches") {
+        expect(lora.actual, `${lora.name} was labelled a match`).toBe("krea2");
+      }
+    }
+  });
+
+  it("recognises the one genuinely compatible LoRA on the reference machine", () => {
+    expect(getLoraFamilyHint("krea2_darkbrush.safetensors", KREA2)).toBe("matches");
+  });
+
+  it("flags the foreign LoRAs whose names say so", () => {
+    expect(getLoraFamilyHint("aidmaMJ6.1-FLUX-v0.5.safetensors", KREA2)).toBe("foreign");
+    expect(getLoraFamilyHint("flux_realism_lora.safetensors", KREA2)).toBe("foreign");
+    expect(getLoraFamilyHint("lcm\\SD1.5\\pytorch_lora_weights.safetensors", KREA2)).toBe("foreign");
+    expect(getLoraFamilyHint("qinglong_detailedeye_z-imageV2(comfy).safetensors", KREA2)).toBe("foreign");
+  });
+
+  it("admits it does not know for names that carry no signal", () => {
+    // These really are incompatible, but nothing in the filename says so, and
+    // guessing would be dishonest.
+    for (const name of ["Martin_French.safetensors", "add_detail.safetensors", "lora.safetensors"]) {
+      expect(getLoraFamilyHint(name, KREA2)).toBe("unknown");
+    }
+  });
+
+  it("treats a preset with no LoRA support as having no positive tokens", () => {
+    expect(getLoraFamilyHint("krea2_darkbrush.safetensors", NO_LORA_PRESET)).toBe("unknown");
+    expect(getLoraFamilyHint("flux_realism_lora.safetensors", NO_LORA_PRESET)).toBe("foreign");
+  });
+
+  it("is case- and separator-insensitive", () => {
+    expect(getLoraFamilyHint("KREA2_Bold.safetensors", KREA2)).toBe("matches");
+    expect(getLoraFamilyHint("krea-2-bold.safetensors", KREA2)).toBe("matches");
+    expect(getLoraFamilyHint("sub/dir/FLUX_thing.safetensors", KREA2)).toBe("foreign");
+  });
+
+  it("labels only what is worth saying", () => {
+    expect(formatLoraHintSuffix("matches")).toContain("matches this model");
+    expect(formatLoraHintSuffix("foreign")).toContain("another model");
+    expect(formatLoraHintSuffix("unknown")).toBe("");
+  });
+});

--- a/tests/comfy/loraCompatibility.test.ts
+++ b/tests/comfy/loraCompatibility.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { formatLoraHintSuffix, getLoraFamilyHint } from "../../src/comfy/loraCompatibility";
+import {
+  NO_LORA_VALUE,
+  formatLoraHintSuffix,
+  getLoraFamilyHint,
+  isLoraSelected,
+  resolveLoraSelection
+} from "../../src/comfy/loraCompatibility";
 import { getWorkflowPreset } from "../../src/comfy/presetRegistry";
 
 const KREA2 = getWorkflowPreset("txt2img-krea2-turbo");
@@ -74,5 +80,47 @@ describe("LoRA family hints", () => {
     expect(formatLoraHintSuffix("matches")).toContain("matches this model");
     expect(formatLoraHintSuffix("foreign")).toContain("another model");
     expect(formatLoraHintSuffix("unknown")).toBe("");
+  });
+});
+
+describe("resolving the LoRA controls", () => {
+  const DEFAULT_STRENGTH = 0.8;
+
+  it("treats the None sentinel as no LoRA", () => {
+    expect(isLoraSelected(NO_LORA_VALUE)).toBe(false);
+    expect(resolveLoraSelection(NO_LORA_VALUE, "0.8", DEFAULT_STRENGTH)).toBeUndefined();
+  });
+
+  it("treats the literal label None as no LoRA", () => {
+    // The defect this pins: readSelectValue falls back to an option's LABEL
+    // when its value is empty, because UXP selects do not always report
+    // `.value`. An empty-valued "None" therefore came back as the string
+    // "None", which read as a real choice -- the strength field appeared and
+    // ComfyUI rejected the prompt, since no file is called None.
+    expect(isLoraSelected("None")).toBe(false);
+    expect(resolveLoraSelection("None", "0.8", DEFAULT_STRENGTH)).toBeUndefined();
+  });
+
+  it("treats an empty or whitespace value as no LoRA", () => {
+    expect(resolveLoraSelection("", "0.8", DEFAULT_STRENGTH)).toBeUndefined();
+    expect(resolveLoraSelection("   ", "0.8", DEFAULT_STRENGTH)).toBeUndefined();
+  });
+
+  it("resolves a real selection and drives both strengths from one control", () => {
+    expect(resolveLoraSelection("krea2_darkbrush.safetensors", "1.2", DEFAULT_STRENGTH)).toEqual({
+      loraName: "krea2_darkbrush.safetensors",
+      strengthModel: 1.2,
+      strengthClip: 1.2
+    });
+  });
+
+  it("falls back rather than sending NaN to ComfyUI", () => {
+    expect(resolveLoraSelection("krea2_darkbrush.safetensors", "", DEFAULT_STRENGTH)?.strengthModel).toBe(0.8);
+    expect(resolveLoraSelection("krea2_darkbrush.safetensors", "abc", DEFAULT_STRENGTH)?.strengthClip).toBe(0.8);
+  });
+
+  it("keeps a strength of zero rather than treating it as missing", () => {
+    // 0 is falsy but meaningful: it is a deliberate no-op the artist asked for.
+    expect(resolveLoraSelection("krea2_darkbrush.safetensors", "0", DEFAULT_STRENGTH)?.strengthModel).toBe(0);
   });
 });

--- a/tests/comfy/modelFolders.test.ts
+++ b/tests/comfy/modelFolders.test.ts
@@ -120,6 +120,7 @@ describe("required model inventory", () => {
         "LLM/Florence-2-base-PromptGen-v2.0",
         "checkpoints/flux1-dev-fp8.safetensors",
         "controlnet/control_v11p_sd15_lineart_fp16.safetensors",
+        "controlnet/control_v11p_sd15_scribble_fp16.safetensors",
         "diffusion_models/flux1-fill-dev.safetensors",
         "diffusion_models/flux2-dev-Q4_K_M.gguf",
         "diffusion_models/krea2_turbo_fp8_scaled.safetensors",

--- a/tests/comfy/modelFolders.test.ts
+++ b/tests/comfy/modelFolders.test.ts
@@ -119,6 +119,7 @@ describe("required model inventory", () => {
       [
         "LLM/Florence-2-base-PromptGen-v2.0",
         "checkpoints/flux1-dev-fp8.safetensors",
+        "controlnet/control_v11f1p_sd15_depth_fp16.safetensors",
         "controlnet/control_v11p_sd15_lineart_fp16.safetensors",
         "controlnet/control_v11p_sd15_scribble_fp16.safetensors",
         "diffusion_models/flux1-fill-dev.safetensors",

--- a/tests/comfy/workflowCompatibility.test.ts
+++ b/tests/comfy/workflowCompatibility.test.ts
@@ -76,7 +76,7 @@ describe("workflow compatibility", () => {
   it("reports missing ComfyUI node classes without touching ComfyUI", () => {
     const preset = getWorkflowPreset("sketch2img-linecn-basic");
     const availableNodes = createAvailableNodes(preset);
-    delete availableNodes.LineartStandardPreprocessor;
+    delete availableNodes.AnyLineArtPreprocessor_aux;
 
     const result = evaluateWorkflowCompatibility(preset, {
       selectedModelName: "epicrealism_naturalSinRC1VAE.safetensors",

--- a/tests/comfy/workflowDiagnostics.test.ts
+++ b/tests/comfy/workflowDiagnostics.test.ts
@@ -36,7 +36,7 @@ describe("workflow diagnostics", () => {
   it("explains missing ComfyUI setup as setup-required", () => {
     const preset = getWorkflowPreset("sketch2img-linecn-basic");
     const availableNodes = createAvailableNodes(preset);
-    delete availableNodes.LineartStandardPreprocessor;
+    delete availableNodes.AnyLineArtPreprocessor_aux;
 
     const message = createWorkflowDiagnosticMessage(preset, {
       selectedModelName: "epicrealism_naturalSinRC1VAE.safetensors",
@@ -46,7 +46,7 @@ describe("workflow diagnostics", () => {
 
     expect(message.isWarning).toBe(true);
     expect(message.summary).toContain("needs setup");
-    expect(message.detail).toContain("LineartStandardPreprocessor");
+    expect(message.detail).toContain("AnyLineArtPreprocessor_aux");
   });
 
   it("explains missing required model files", () => {

--- a/tests/comfy/workflowFiles.test.ts
+++ b/tests/comfy/workflowFiles.test.ts
@@ -27,9 +27,13 @@ function loadApiWorkflow(preset: WorkflowPresetDefinition): ComfyWorkflow {
  * registered there would be silently reported as core, and this fails first.
  */
 const EXPECTED_CUSTOM_NODE_CLASSES = [
+  // Both sketch presets use a learned edge detector rather than the naive
+  // Lineart/Scribble preprocessors, which return a blank control image for
+  // light-on-dark art and so silently degrade the preset to text-to-image.
+  "AnyLineArtPreprocessor_aux",
   "Florence2ModelLoader",
   "Florence2Run",
-  "LineartStandardPreprocessor",
+  "Scribble_PiDiNet_Preprocessor",
   // Flux.2's quantised model. Note only the UNET loader appears: its text
   // encoder is a safetensors file read by core CLIPLoader, so CLIPLoaderGGUF is
   // mapped in the registry but not required by any shipped preset.

--- a/tests/comfy/workflowHealth.test.ts
+++ b/tests/comfy/workflowHealth.test.ts
@@ -117,7 +117,7 @@ describe("workflow health", () => {
   it("reports missing ComfyUI node classes", () => {
     const preset = getWorkflowPreset("sketch2img-linecn-basic");
     const availableNodes = createAvailableNodes(preset);
-    delete availableNodes.LineartStandardPreprocessor;
+    delete availableNodes.AnyLineArtPreprocessor_aux;
 
     const item = createWorkflowHealthItem(preset, {
       availableNodes,
@@ -127,7 +127,7 @@ describe("workflow health", () => {
     });
 
     expect(item.state).toBe("missing-node");
-    expect(item.summary).toContain("LineartStandardPreprocessor");
+    expect(item.summary).toContain("AnyLineArtPreprocessor_aux");
   });
 
   it("keeps enriched setup issues routed to missing-model and missing-node states", () => {

--- a/tests/comfy/workflowLoraInsertion.test.ts
+++ b/tests/comfy/workflowLoraInsertion.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildTxt2ImgWorkflow } from "../../src/comfy/workflowBuilder";
-import { getWorkflowPreset } from "../../src/comfy/presetRegistry";
-import { getTechnicalErrorDetails } from "../../src/utils/errors";
+import { WORKFLOW_PRESETS, getWorkflowPreset } from "../../src/comfy/presetRegistry";
 
 const BASE = {
   presetId: "txt2img-krea2-turbo",
@@ -81,17 +80,15 @@ describe("optional LoRA insertion", () => {
     }
   });
 
-  it("refuses a LoRA on a preset that declares no insertion point", async () => {
-    let thrown: unknown;
-
-    try {
-      await buildTxt2ImgWorkflow({ ...BASE, presetId: "txt2img-basic", lora: LORA });
-    } catch (error) {
-      thrown = error;
+  it("leaves presets that should not take a LoRA without an insertion point", () => {
+    // The builder's guard throws for a preset with no insertion point, but
+    // every txt2img preset now declares one, so that path is unreachable from
+    // buildTxt2ImgWorkflow and cannot honestly be exercised here. What is still
+    // worth pinning is that tools which never offer a LoRA have not quietly
+    // acquired one.
+    for (const id of ["inpaint-basic", "outpaint-flux-fill-basic", "upscale-basic"] as const) {
+      expect(getWorkflowPreset(id).loraInsertion).toBeUndefined();
     }
-
-    expect(thrown).toBeDefined();
-    expect(getTechnicalErrorDetails(thrown)).toContain("loraInsertion");
   });
 
   it("still passes the preset's own workflow validation after surgery", async () => {
@@ -99,4 +96,103 @@ describe("optional LoRA insertion", () => {
     // builder validates again after the splice.
     await expect(buildTxt2ImgWorkflow({ ...BASE, lora: LORA })).resolves.toBeDefined();
   });
+});
+
+describe("every declared LoRA insertion point", () => {
+  const withLora = WORKFLOW_PRESETS.filter((preset) => preset.loraInsertion);
+
+  it("covers the presets that are meant to have one", () => {
+    expect(withLora.map((preset) => preset.id).sort()).toEqual([
+      "txt2img-basic",
+      "txt2img-flux1-dev-fp8",
+      "txt2img-flux2-dev-gguf",
+      "txt2img-krea2-turbo",
+      "txt2img-z-image-turbo"
+    ]);
+  });
+
+  for (const preset of withLora) {
+    describe(preset.id, () => {
+      const insertion = preset.loraInsertion!;
+
+      it("takes a node id its workflow does not already use", async () => {
+        const built = await buildTxt2ImgWorkflow({
+          presetId: preset.id,
+          prompt: "a test",
+          width: 512,
+          height: 512,
+          steps: 4,
+          cfg: 1,
+          seed: 1
+        });
+
+        // Without this the splice would overwrite a real node and still pass
+        // validation, because validateWorkflowForPreset only checks that the
+        // required nodes are present.
+        expect(built.workflow[insertion.nodeId]).toBeUndefined();
+      });
+
+      it("names sources and consumers that exist, and rewires all of them", async () => {
+        const built = await buildTxt2ImgWorkflow({
+          presetId: preset.id,
+          prompt: "a test",
+          width: 512,
+          height: 512,
+          steps: 4,
+          cfg: 1,
+          seed: 1,
+          lora: LORA
+        });
+
+        expect(built.workflow[insertion.modelSource.nodeId]).toBeDefined();
+        expect(built.workflow[insertion.clipSource.nodeId]).toBeDefined();
+
+        for (const consumer of insertion.modelConsumers) {
+          expect(built.workflow[consumer.nodeId]?.inputs[consumer.inputName]).toEqual([insertion.nodeId, 0]);
+        }
+
+        for (const consumer of insertion.clipConsumers) {
+          expect(built.workflow[consumer.nodeId]?.inputs[consumer.inputName]).toEqual([insertion.nodeId, 1]);
+        }
+      });
+
+      it("leaves nothing downstream still reading the bare model or CLIP", async () => {
+        const built = await buildTxt2ImgWorkflow({
+          presetId: preset.id,
+          prompt: "a test",
+          width: 512,
+          height: 512,
+          steps: 4,
+          cfg: 1,
+          seed: 1,
+          lora: LORA
+        });
+
+        // The failure this guards against is silent: a consumer left on the
+        // original loader means the LoRA loads and then applies to nothing.
+        for (const [id, node] of Object.entries(built.workflow)) {
+          if (id === insertion.nodeId) {
+            continue;
+          }
+
+          for (const [inputName, value] of Object.entries(node.inputs)) {
+            if (!Array.isArray(value) || value.length < 2) {
+              continue;
+            }
+
+            const readsModel = String(value[0]) === insertion.modelSource.nodeId && value[1] === insertion.modelSource.slot;
+            const readsClip = String(value[0]) === insertion.clipSource.nodeId && value[1] === insertion.clipSource.slot;
+
+            if (readsModel && inputName === "model") {
+              throw new Error(`${preset.id}: node ${id}.${inputName} still reads the bare model`);
+            }
+
+            if (readsClip && inputName === "clip") {
+              throw new Error(`${preset.id}: node ${id}.${inputName} still reads the bare CLIP`);
+            }
+          }
+        }
+      });
+    });
+  }
 });

--- a/tests/comfy/workflowLoraInsertion.test.ts
+++ b/tests/comfy/workflowLoraInsertion.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { buildTxt2ImgWorkflow } from "../../src/comfy/workflowBuilder";
+import { getWorkflowPreset } from "../../src/comfy/presetRegistry";
+import { getTechnicalErrorDetails } from "../../src/utils/errors";
+
+const BASE = {
+  presetId: "txt2img-krea2-turbo",
+  prompt: "a cinematic scene",
+  checkpointName: "krea2_turbo_fp8_scaled.safetensors",
+  width: 1024,
+  height: 1024,
+  steps: 8,
+  cfg: 1,
+  seed: 42
+};
+
+const LORA = {
+  loraName: "krea2_darkbrush.safetensors",
+  strengthModel: 0.8,
+  strengthClip: 0.8
+};
+
+describe("optional LoRA insertion", () => {
+  it("leaves the graph exactly as shipped when no LoRA is chosen", async () => {
+    const withoutLora = await buildTxt2ImgWorkflow(BASE);
+    const insertion = getWorkflowPreset("txt2img-krea2-turbo").loraInsertion;
+
+    expect(insertion).toBeDefined();
+    expect(withoutLora.workflow[insertion!.nodeId]).toBeUndefined();
+
+    // The sampler still reads the diffusion model loader directly.
+    expect(withoutLora.workflow["3"].inputs.model).toEqual(["20", 0]);
+    expect(withoutLora.workflow["6"].inputs.clip).toEqual(["21", 0]);
+  });
+
+  it("treats an empty lora name as no LoRA rather than inserting a broken node", async () => {
+    const built = await buildTxt2ImgWorkflow({
+      ...BASE,
+      lora: { loraName: "", strengthModel: 1, strengthClip: 1 }
+    });
+
+    expect(built.workflow["23"]).toBeUndefined();
+    expect(built.workflow["3"].inputs.model).toEqual(["20", 0]);
+  });
+
+  it("splices the loader in and rewires every consumer when a LoRA is chosen", async () => {
+    const built = await buildTxt2ImgWorkflow({ ...BASE, lora: LORA });
+    const node = built.workflow["23"];
+
+    expect(node.class_type).toBe("LoraLoader");
+    expect(node.inputs.lora_name).toBe("krea2_darkbrush.safetensors");
+    expect(node.inputs.strength_model).toBe(0.8);
+    expect(node.inputs.strength_clip).toBe(0.8);
+
+    // Reads from the original loaders...
+    expect(node.inputs.model).toEqual(["20", 0]);
+    expect(node.inputs.clip).toEqual(["21", 0]);
+
+    // ...and everything downstream now reads from it instead.
+    expect(built.workflow["3"].inputs.model).toEqual(["23", 0]);
+    expect(built.workflow["6"].inputs.clip).toEqual(["23", 1]);
+    expect(built.workflow["7"].inputs.clip).toEqual(["23", 1]);
+  });
+
+  it("leaves no consumer still reading the bare model or CLIP", async () => {
+    const built = await buildTxt2ImgWorkflow({ ...BASE, lora: LORA });
+
+    // The whole point of the rewire: nothing except the LoRA node itself may
+    // still take a link straight from the diffusion or CLIP loader, or the
+    // LoRA would load and then apply to nothing.
+    for (const [id, node] of Object.entries(built.workflow)) {
+      if (id === "23") {
+        continue;
+      }
+
+      for (const value of Object.values(node.inputs)) {
+        if (Array.isArray(value) && (value[0] === "20" || value[0] === "21")) {
+          throw new Error(`node ${id} still reads directly from loader ${String(value[0])}`);
+        }
+      }
+    }
+  });
+
+  it("refuses a LoRA on a preset that declares no insertion point", async () => {
+    let thrown: unknown;
+
+    try {
+      await buildTxt2ImgWorkflow({ ...BASE, presetId: "txt2img-basic", lora: LORA });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(getTechnicalErrorDetails(thrown)).toContain("loraInsertion");
+  });
+
+  it("still passes the preset's own workflow validation after surgery", async () => {
+    // A rewire that broke a required input would surface here, because the
+    // builder validates again after the splice.
+    await expect(buildTxt2ImgWorkflow({ ...BASE, lora: LORA })).resolves.toBeDefined();
+  });
+});

--- a/tests/comfy/workflowLoraInsertion.test.ts
+++ b/tests/comfy/workflowLoraInsertion.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildTxt2ImgWorkflow } from "../../src/comfy/workflowBuilder";
+import {
+  buildImg2ImgWorkflow,
+  buildSketchToImageWorkflow,
+  buildTxt2ImgWorkflow
+} from "../../src/comfy/workflowBuilder";
 import { WORKFLOW_PRESETS, getWorkflowPreset } from "../../src/comfy/presetRegistry";
+import { WorkflowPresetDefinition } from "../../src/comfy/types";
 
 const BASE = {
   presetId: "txt2img-krea2-turbo",
@@ -98,11 +103,47 @@ describe("optional LoRA insertion", () => {
   });
 });
 
+/** Builds a preset through whichever builder its mode belongs to. */
+async function buildForMode(preset: WorkflowPresetDefinition, lora?: typeof LORA) {
+  const shared = {
+    presetId: preset.id,
+    prompt: "a test",
+    width: 512,
+    height: 512,
+    steps: 4,
+    cfg: 1,
+    seed: 1,
+    lora
+  };
+
+  if (preset.mode === "txt2img") {
+    return buildTxt2ImgWorkflow(shared);
+  }
+
+  const imageShared = { ...shared, sourceImageName: "source.png", denoise: 0.6 };
+
+  if (preset.mode === "img2img") {
+    return buildImg2ImgWorkflow(imageShared);
+  }
+
+  if (preset.mode === "sketch2img") {
+    return buildSketchToImageWorkflow({ ...imageShared, controlStrength: 0.8 });
+  }
+
+  throw new Error(`no builder wired for mode ${preset.mode}`);
+}
+
 describe("every declared LoRA insertion point", () => {
   const withLora = WORKFLOW_PRESETS.filter((preset) => preset.loraInsertion);
 
   it("covers the presets that are meant to have one", () => {
     expect(withLora.map((preset) => preset.id).sort()).toEqual([
+      "img2img-basic",
+      "img2img-krea2-turbo",
+      "img2img-z-image-turbo",
+      "sketch2img-depth-basic",
+      "sketch2img-linecn-basic",
+      "sketch2img-scribble-basic",
       "txt2img-basic",
       "txt2img-flux1-dev-fp8",
       "txt2img-flux2-dev-gguf",
@@ -116,15 +157,7 @@ describe("every declared LoRA insertion point", () => {
       const insertion = preset.loraInsertion!;
 
       it("takes a node id its workflow does not already use", async () => {
-        const built = await buildTxt2ImgWorkflow({
-          presetId: preset.id,
-          prompt: "a test",
-          width: 512,
-          height: 512,
-          steps: 4,
-          cfg: 1,
-          seed: 1
-        });
+        const built = await buildForMode(preset);
 
         // Without this the splice would overwrite a real node and still pass
         // validation, because validateWorkflowForPreset only checks that the
@@ -133,16 +166,7 @@ describe("every declared LoRA insertion point", () => {
       });
 
       it("names sources and consumers that exist, and rewires all of them", async () => {
-        const built = await buildTxt2ImgWorkflow({
-          presetId: preset.id,
-          prompt: "a test",
-          width: 512,
-          height: 512,
-          steps: 4,
-          cfg: 1,
-          seed: 1,
-          lora: LORA
-        });
+        const built = await buildForMode(preset, LORA);
 
         expect(built.workflow[insertion.modelSource.nodeId]).toBeDefined();
         expect(built.workflow[insertion.clipSource.nodeId]).toBeDefined();
@@ -157,16 +181,7 @@ describe("every declared LoRA insertion point", () => {
       });
 
       it("leaves nothing downstream still reading the bare model or CLIP", async () => {
-        const built = await buildTxt2ImgWorkflow({
-          presetId: preset.id,
-          prompt: "a test",
-          width: 512,
-          height: 512,
-          steps: 4,
-          cfg: 1,
-          seed: 1,
-          lora: LORA
-        });
+        const built = await buildForMode(preset, LORA);
 
         // The failure this guards against is silent: a consumer left on the
         // original loader means the LoRA loads and then applies to nothing.


### PR DESCRIPTION
Ships optional LoRA support, a Depth ControlNet sketch preset, and fixes for two presets that were quietly broken in v0.12.0.

## What's in it

**Optional LoRA on eleven presets** — every preset that loads a model and a text encoder, across Text to Image, Image to Image and Sketch to Image. Choosing nothing leaves the shipped workflow byte-identical, because ComfyUI's `LoraLoader` has no "none" entry: the node is spliced into the graph only when a LoRA is actually picked, and the model and text-encode inputs downstream are rewired to it. This is the first time building a workflow changes its shape rather than its values, so each preset declares its own wiring rather than having it inferred. Three genuinely different shapes turned up among the eleven, including Z-Image, where the LoRA must be applied before `ModelSamplingAuraFlow` rather than at the sampler — rewiring the sampler there would have bypassed the wrapper and changed how the model is sampled, with no error.

**A Depth ControlNet sketch preset**, holding scene perspective where LineArt and Scribble hold the drawn stroke. Needs one new ControlNet weight; no new node package, since the depth estimator comes from `comfyui_controlnet_aux` which the sketch presets already required.

**Two fixes for presets that failed silently.** Sketch to Image fed ControlNet a blank control image for light-on-dark art, so the sketch was ignored with nothing reported. The Flux.2 dev (GGUF) preset that headlined v0.12.0 could not be run at all: its Model dropdown asked core `UNETLoader` for the file list, and that loader does not enumerate `.gguf` files, and pressing Generate then failed because the builder required a negative-prompt target on a preset that deliberately has none.

## Verification

- 669 tests, typecheck and build pass.
- All eleven LoRA-spliced graphs were submitted to a live ComfyUI and confirmed valid, with a real uploaded source image so the six image-input presets exercised their `LoadImage` node rather than a placeholder.
- Manually smoke-tested in Photoshop against ComfyUI 0.30.0 on an RTX 4070 Ti: LoRA on and off per tool, per-tool independence, strength changes, the Z-Image wrapper case, and the depth preset.

## Notes for review

- `1105811` (the sketch preprocessor fix and the Scribble preset) predates this branch's release work but had never been released, so it is included in the v0.13.0 notes rather than assumed shipped.
- The "None" LoRA defect was introduced and fixed within this branch, so it is deliberately absent from the changelog — no released build ever had it.
- `docs/BATCH_GENERATION.md` is a design note only. No batch code is in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
