### PR TITLE
Unflatten phase one: answer Q5 and Q8 before any UI work

### DIFF
--- a/.claude/agents/WFL.md
+++ b/.claude/agents/WFL.md
@@ -27,7 +27,7 @@ Read `docs/ORCHESTRATION.md` first, every time. It is the durable source of trut
 Judge everything against these. A suggestion that ignores them wastes the developer's time.
 
 **Hardware ceiling.** The only verified machine is an **RTX 4070 Ti, 12 GB VRAM**, 31.7 GB system
-RAM, Windows 11. ComfyUI 0.30.0, Python 3.10.11, PyTorch 2.6.0+cu124. Anything you recommend must run
+RAM, Windows 11. ComfyUI 0.30.0, Python 3.10.11, PyTorch 2.13.0+cu130. Anything you recommend must run
 in 12 GB, and you must say how — fp8, GGUF quant, tiled VAE, sequential offload — with a measured or
 sourced figure, not a guess. For reference, Krea-2 Turbo at 1024² 8 steps takes ~38-48 s on this card
 with offloading; SD 1.5 + LCM at 512² 5 steps is ~0.5-0.7 s. If a model cannot beat those on quality

--- a/docs/unflatten-gate-findings.md
+++ b/docs/unflatten-gate-findings.md
@@ -1,0 +1,293 @@
+# Unflatten: Gate Findings
+
+Live results for the questions [`unflatten-v0.20.0.md`](unflatten-v0.20.0.md) put in front
+of the UI work. Run from 2026-08-30 against ComfyUI 0.30.0 on 127.0.0.1:8190, RTX 4070 Ti
+12 GB, PyTorch 2.13.0+cu130, Python 3.10.11.
+
+**This document is incomplete and says so.** Two questions are answered, six are open. The
+answered pair is recorded now rather than at the end because both already change the build
+plan, and one of them -- Q8 -- was not in the original gate at all.
+
+**A failed gate remains an acceptable outcome.** Nothing below commits the release to
+shipping a tool.
+
+---
+
+## Environment
+
+All three model files are on disk and the graph runs:
+
+| File | Folder | Present |
+| --- | --- | --- |
+| `qwen_image_layered_fp8mixed.safetensors` | `diffusion_models` | yes |
+| `qwen_2.5_vl_7b_fp8_scaled.safetensors` | `text_encoders` | yes |
+| `qwen_image_layered_vae.safetensors` | `vae` | yes |
+
+`EmptyQwenImageLayeredLatentImage`, `LatentCutToBatch` and `ImageScaleToMaxDimension` are
+all registered on this build (2846 classes), so no ComfyUI upgrade is needed. The naming
+trap the plan warned about is real and worth repeating: `qwen_image_layered_vae` sits in
+the same folder as `qwen_image_vae`, which is Krea-2's, and the wrong one loads far enough
+to fail confusingly rather than obviously.
+
+The only download still outstanding anywhere in this plan is the Q4_K_M GGUF for Q6, which
+is conditional and last -- it can shrink the setup story but cannot decide go/no-go.
+
+**Verified working settings**, read back from the run history rather than transcribed:
+20 steps, CFG 2.5, `euler`/`simple`, denoise 1.0, `ModelSamplingAuraFlow` shift 1.0,
+`ImageScaleToMaxDimension` at `largest_size: 640` with lanczos, prompt encoded once for
+positive and once empty for negative, both through `ReferenceLatent` off a `VAEEncode` of
+the scaled source.
+
+### A note on sources
+
+The two runs behind Q8 used a source image that cannot be published: it is watermarked
+commercial stock. Their numbers are reproduced here because the finding is structural and
+holds regardless of subject, but the imagery is not, and those runs do not count toward
+Q1. Every run from here uses licensed sources (Wikimedia / CC0) recorded in a manifest, as
+v0.19 did -- this document is public and the release recording is public with it.
+
+---
+
+## Q5 -- Does the alpha survive the trip into Photoshop?
+
+**Answer: yes, and it was never the risk. The risk is that Photoshop silently resizes the
+layer, and nothing in the current import path corrects it.**
+
+This ran first, before any GPU time, because it is the only question that needed no model
+and the only one whose failure is unconditional: every other question grades how good the
+decomposition is, this one decides whether the product can exist.
+
+### The byte path was already safe, by reading
+
+Nothing between ComfyUI and Photoshop decodes or re-encodes the image:
+
+- `retrieveFirstOutputImage` takes the bytes straight from `fetch().blob()`.
+- `saveBlobToTemporaryFile` writes the arrayBuffer with `formats.binary`.
+- `placeFileAsLayer` hands that file to `placeEvent`.
+
+There is no canvas, no `toBlob`, no pixel round-trip anywhere on that path. The plan's
+"nothing in this codebase has ever moved an alpha channel" is true as history but
+overstates the code risk: all seven `applyAlpha: false` sites in `photoshopAdapter.ts` are
+`imaging.getPixels` calls, which is the **capture** direction. Import never touches an
+alpha option because it never touches pixels.
+
+So the open question was host behaviour, not fidelity.
+
+### The test
+
+Four hand-made RGBA PNGs, every one exactly 1024 x 1024, placed with `File > Place
+Embedded` into a document with a saturated green background layer -- green rather than
+white specifically because the failure mode *is* white, and white on white is invisible.
+
+| File | Content | What it isolates |
+| --- | --- | --- |
+| A1 | Opaque square, bottom-left, touching no edge | Binary alpha, and bounds |
+| A3 | Opaque square, top-right | Two layers with different opaque regions must register to the same canvas |
+| A2 | Full-canvas horizontal alpha ramp, 255 -> 0 | Gradient alpha -- the hair-matte case |
+| A4 | 40px fully clear border, feathered interior edge | The realistic layer shape |
+
+A1 and A3 are the pair that matters. If Photoshop trimmed a placed layer to its visible
+pixels, the two squares would land in the same place instead of staying diagonal, and a
+decomposed stack would come apart layer by layer -- each layer's opaque region is
+different, so each would be trimmed differently.
+
+### Results
+
+- **Bounds are preserved.** A1 stayed bottom-left, A3 stayed top-right. No trimming.
+  Confirmed twice, in two separate documents.
+- **Transparency is real transparency.** The green background shows through everywhere it
+  should; the Layers panel thumbnails carry the checkerboard.
+- **Gradient alpha holds.** A2's ramp is smooth and A4's feathered edge survived, so this
+  is not a binary-cutout-only result.
+- **16-bit behaves identically.** Repeated in a 16-bit RGB document with no difference,
+  which matters because that is the mode a photographer actually opens.
+
+### The negative result, which is the useful half
+
+The options bar during placement read **`W: 97.66%`**. The document was 1000px tall and the
+file is 1024px tall, and 1000 / 1024 = 0.9766 exactly. `placeEvent` **auto-fits an oversized
+image down to the canvas**, unasked.
+
+Placing the same file into a 2000 x 2000 document read `W: 100.00%`. So the behaviour is
+one-directional: **Place shrinks to fit and never enlarges.**
+
+`alignActiveLayerToBounds` cannot rescue this. It reads the layer bounds, computes an
+offset and calls `moveActiveLayerBy` -- it translates, and never scales. Neither does
+`centerActiveLayerOnCanvas`.
+
+That is acute for this feature specifically. `ImageScaleToMaxDimension` caps the graph's
+output at 640px on the long side, so a layer captured from a 4000px document comes back at
+roughly one sixth of the size it has to occupy. Place will not grow it and the aligner will
+not either.
+
+**Consequence for task 3: the import must carry an explicit scale-to-target-bounds step.**
+Only the enlarging direction needs handling, because the output is always small -- which is
+the easier version of this problem, but it does not solve itself.
+
+### What this does not prove
+
+The test exercised Photoshop's `Place Embedded`, which issues the same `placeEvent` command
+OpenLayer issues, but it did not go through `importGeneratedImageAsLayer` -- the session
+token, the `executeAsModal` wrapper and `alignActiveLayerToBounds` are still untested
+against a transparent layer. The byte path is proven by reading and the host behaviour is
+proven by this test; the seam between them is not.
+
+Separately: the first attempt used an **artboard** document by accident and was re-run on a
+plain one. Whether OpenLayer imports correctly into artboard documents is untested and
+unrelated to alpha, but it is now a known gap.
+
+---
+
+## Q8 -- How many images come back, and what order are they in?
+
+**Answer: `layers: N` returns N+1 images. Index 0 is the flattened composite, not a layer.
+The layers run back-to-front from index 1.**
+
+This question was not in the plan. It should have been: task 3's acceptance criteria say
+"in stacking order" and task 2's say "a run returning N images yields N results in order",
+and both sentences assume a mapping nobody had checked.
+
+Measured on the two `layers: 2` runs, which returned **three** images each:
+
+| Output | Fully transparent | Opaque | What it is |
+| --- | --- | --- | --- |
+| index 0 | 0.0% | 39.7% (rest 251-254) | The flattened composite |
+| index 1 | 0.0% | 18.2% (rest 251-254, min 176) | Background -- effectively opaque |
+| index 2 | 48.5% | 29.9% | Subject -- real alpha, with a genuine soft gradient |
+
+Compositing index 2 over index 1 reproduces index 0 to a **mean absolute error of 2.87/255**
+(p95 = 8). That is VAE round-trip noise. The decomposition is sound, and the identity
+confirms which output is the composite rather than leaving it to inspection.
+
+Two things follow:
+
+- **Task 3 must skip index 0.** Importing all N+1 outputs would stack a flat copy of the
+  entire picture on top of the group, which would read as an import bug rather than a
+  misunderstood contract.
+- **Task 2's cost model is N+1 decodes, not N.** Minor, but it belongs in Q3's timing
+  arithmetic.
+
+One caveat, and it is a real one: this is verified at `layers: 2` only, on two runs of a
+single source. Whether index 0 stays the composite at 3, 4 and 6 layers is folded into Q2's
+run list below and must be confirmed before task 3 relies on it.
+
+Worth noting the alpha values on the opaque layers sit at 251-254 rather than a clean 255.
+That is VAE quantisation, it is visually opaque, and it needs no handling -- but a future
+equality check against 255 would fail, so nothing downstream should write one.
+
+---
+
+## Open questions
+
+Six remain. The run list below is the agreed plan for them; nothing in it has been run yet.
+
+`D` = whatever layer-count default Q2 lands on; 3 until it has one. All runs 640px / fp8
+unless the row says otherwise, and the same seed within a group.
+
+| ID | Q | Source | px | Layers | Role |
+| --- | --- | --- | --- | --- | --- |
+| R1 | all | SP (spike source) | 640 | 2 | **Control** -- reproduce the spike, or stop and fix the environment |
+| R2 | Q3 | SP | 1024 | 4 | **Corner probe.** Completes or OOMs; changes everything downstream |
+| R3 | Q3 | SP | 1024 | 2 | Resolution axis |
+| R4 | Q3/Q2 | SP | 640 | 4 | Layer-count axis; completes the 2x2 with R1-R3 |
+| R5 | Q2 | SP | 640 | 3 | |
+| R6 | Q2 | SP | 640 | 6 | Do extra layers find structure or invent it? |
+| R7 | Q1 | P1 photo, clean separation | 640 | D | |
+| R8 | Q1 | G1 generated, matched to P1 | 640 | D | Control for R7 |
+| R9 | Q1/Q4 | P2 photo, contact and occlusion, subject ~40% of frame | 640 | D | Also Q4's 40% point |
+| R10 | Q1 | G2 generated, matched to P2 | 640 | D | Control for R9 |
+| R11 | Q1 | P3 photo, fine matte (hair / fur / foliage) | 640 | D | |
+| R12 | Q1 | G3 generated, matched to P3 | 640 | D | Control for R11 |
+| R13 | Q1 | P4 monochrome or heavily graded photo | 640 | D | v0.19 found this family silently colourises monochrome |
+| R14-15 | Q1 | Worst pair from R7-R12, second seed | 640 | D | Nothing is "reproducible" on one seed |
+| R16 | Q4 | P2 cropped, subject ~15% | 640 | D | |
+| R17 | Q4 | P2 cropped, subject ~70% | 640 | D | Same picture, three crops -- isolates occlusion fraction |
+| R18 | Q4 | Worst of R9/R16/R17 | 1024 | D | Is the smear the model's limit or a 640 artifact? |
+| R19-21 | Q7 | G2 | 640 | 3 | Three further seeds; four total with R5 |
+| R22-24 | Q6 | **Conditional -- only on a go** | | | Q4_K_M against R1, against the hardest passing source, and at the corner |
+
+**Recorded per run:** source, provenance, resolution, layers, seed, quant; wall time and
+whether cold or warm; peak VRAM; verbatim error text on failure; what each output contains
+in batch order; whether index 0 is still the composite; matte quality on the hardest edge
+in frame (hold / soft halo / hard cut / failed); background layer state (clean / smear /
+hole) and the move test below; colour shift against the source; and anything invented that
+was not in the source.
+
+**Stop and review after R1, after R2, and after R7-R13.** That third one is the gate's
+actual verdict and it gets read before anything else runs, however the earlier runs looked.
+
+### Q1 -- Does the matte hold on a real photograph?
+
+Open. Designed as **matched pairs** rather than the plan's "three photographs against three
+generated images of comparable content", because provenance and compositional separability
+would otherwise vary together: three busy photographs against three clean generations
+measures clutter and reports it as provenance. Each pair holds composition as near constant
+as the tools allow, across three archetypes -- clean separation, contact and occlusion, and
+fine matte -- plus one unpaired adversarial monochrome source.
+
+The v0.19 finding this inherits is that this model family reproduces its own output far
+more faithfully than it reproduces a photograph. The spike's success used an OpenLayer
+generation, so it is the flattering corner.
+
+### Q2 -- How does it behave as layer count rises?
+
+Open. 2, 3, 4 and 6 on one source and seed (R1, R5, R4, R6). Also carries the Q8
+re-confirmation: index 0 must still be the composite at every layer count.
+
+### Q3 -- How does the 59 s scale?
+
+Open, and deliberately given almost no runs of its own -- every run produces a timing, so
+this is a column rather than a question with a budget. The two runs it does need are the
+corner (R2) and the resolution control (R3), and the corner goes early because a 20.5 GB
+fp8 weight on 12 GB is already offloading at 640; if it will not run at all, the settings
+space shrinks and half of Q2 becomes moot.
+
+Every timing is recorded as **warm** -- the second run of that configuration -- with the
+cold number noted separately. On this card the first run after a model change pays the
+load, and mixing the two would make the curve meaningless.
+
+### Q4 -- Is the background layer usable, or merely present?
+
+Open, with the bar declared in advance so it cannot be moved after the results are in:
+
+> The background layer is **usable** if the subject layer can be moved by roughly 10% of the
+> frame width and the revealed region does not read as damage at 100% zoom.
+
+That is the actual reason to want a layer stack. Anything short of it is "present, repaint
+before use" -- a legitimate answer that belongs in the subtitle rather than in a support
+thread.
+
+Tested as three crops of one photograph rather than three different photographs, so
+occlusion fraction is the only variable.
+
+### Q6 -- Is the shippable quant good enough?
+
+Open and **conditional**: it runs only after Q1, Q2 and Q4 say go. It costs another 13.2 GB
+and it cannot change the go/no-go decision -- it changes the download size.
+
+Its own trap, which the plan does not name: quantisation shifts the sample, so fp8 and
+Q4_K_M at the same seed produce two *different pictures*, and "compare the alpha edge"
+degenerates into judging which is prettier. The comparison has to be made on the layer that
+stayed most nearly identical between the two, and the write-up has to say explicitly when
+they diverged too far for any comparison to be meaningful.
+
+### Q7 -- Is the decomposition stable across seeds?
+
+Open, and added to the gate. Not "is it good" but "is it the same": if one seed splits a
+picture into subject and background while another splits it into subject-plus-shadow and
+background, the layer *semantics* are unstable. The tool then cannot name its layers,
+cannot promise that a re-run improves anything, and the re-roll affordance every other tool
+has means something different here.
+
+One generated source, `layers: 3`, four seeds.
+
+---
+
+## What has changed in the plan so far
+
+- **Task 3 gains a scale-to-target-bounds step** (Q5). Only the enlarging direction.
+- **Task 3 must skip output index 0** and task 2's "N images" is N+1 (Q8).
+- **Q5 is answered and needs no further GPU time**, beyond one remaining seam: the same
+  four PNGs through `importGeneratedImageAsLayer` rather than through Photoshop's own Place.
+- **Artboard documents are an untested import case**, unrelated to this feature but found
+  by it.

--- a/docs/unflatten-v0.20.0.md
+++ b/docs/unflatten-v0.20.0.md
@@ -1,0 +1,239 @@
+# Unflatten - v0.20.0 plan
+
+Written 2026-08-30, after the feasibility spike. This is the shared written plan
+for v0.20.0 in the sense of `ORCHESTRATION.md` section 5a: the numbered task list
+with per-task acceptance criteria that Codex and the reviewing assistant both
+work from.
+
+## The feature
+
+**Unflatten.** Hand the panel a flat Photoshop layer, get the picture back
+decomposed into separate layers with real transparency, imported into the open
+document in stacking order.
+
+Card subtitle: "Split a flat layer into separate layers with transparency."
+Status on arrival: experimental. It groups with the tools that act on a layer you
+already have - Prompt from Layer, Upscale - not with Generate, because it makes
+nothing new.
+
+The model is Qwen-Image-Layered, run locally through ComfyUI. Every node in the
+graph is core ComfyUI; there is no new node package. Nothing else in this space
+puts a decomposed layer stack into a host application - the ecosystem's current
+answer to "what do I do with the output" is a `.psd` save node, which is a
+confession that the technique has nowhere to go. That is the opportunity, and it
+is a Photoshop-plugin opportunity specifically: a layered result is worth very
+little in a web UI and nearly nothing in a canvas app.
+
+## What the spike established
+
+One run, 2026-08-30, on the verified machine.
+
+| | |
+|---|---|
+| Settings | fp8mixed, 640px, `layers: 2` |
+| Time | **58.98 s** |
+| Alpha edge on hair | Held. Individual strands survive against the checker, no halo, no hard cut line. |
+| Background layer | A smeared patch where the subject occluded the road. Clean elsewhere. |
+| Source | One of OpenLayer's own Krea-2 generations - the flattering case, not a photograph. |
+
+The timing matters more than it looks. Klein is 11.6 s and Krea-2 Turbo is
+38-48 s, so at 59 s Unflatten is the slowest tool in the panel but in the same
+family. It is an ordinary button. It does not need a warning, a walk-away
+treatment, or a different progress design.
+
+The two untested things are why phase one exists.
+
+## Models
+
+Three files, roughly 30 GB, none shared with any existing preset. Two different
+Comfy-Org repositories, all ungated, no licence click-through.
+
+| File | Size | Folder | Repo |
+|---|---|---|---|
+| `qwen_image_layered_fp8mixed.safetensors` | 20.5 GB | `diffusion_models` | `Comfy-Org/Qwen-Image-Layered_ComfyUI` |
+| `qwen_2.5_vl_7b_fp8_scaled.safetensors` | 9.4 GB | `text_encoders` | `Comfy-Org/Qwen-Image_ComfyUI` |
+| `qwen_image_layered_vae.safetensors` | 242 MB | `vae` | `Comfy-Org/Qwen-Image-Layered_ComfyUI` |
+
+Two traps worth a comment in the registry when these are added:
+
+- The layered VAE is **not** `qwen_image_vae.safetensors`, which is already on
+  disk for Krea-2. The names differ by one word and the wrong one loads far
+  enough to produce a confusing failure rather than an obvious one.
+- The text encoder is not in the layered repository. That repository has no
+  `text_encoders` folder at all, which is what sends people to the wrong file.
+
+The bf16 weight in that repo is 40.9 GB and will not run on 12 GB. Q4_K_M GGUF at
+13.2 GB is the candidate for reducing the download; see Q6.
+
+## Environment note
+
+The verified machine runs **PyTorch 2.13.0+cu130**, ComfyUI 0.30.0, Python
+3.10.11, RTX 4070 Ti 12 GB. `.claude/agents/WFL.md` states 2.6.0 as a verified
+fact; that is stale and should be corrected, because it is load-bearing for every
+recommendation that agent makes about what will run.
+
+All three layered-specific node classes are present on 0.30.0:
+`EmptyQwenImageLayeredLatentImage` (width, height, layers, batch_size),
+`LatentCutToBatch`, `ImageScaleToMaxDimension`. No ComfyUI upgrade is required.
+
+## Phase one: the gate
+
+No UI code until this is written up. Output is
+`docs/unflatten-gate-findings.md`, in the shape of
+`docs/multi-reference-gate-findings.md`: control/variant pairs, the same seed
+within a pair, and every negative result recorded rather than dropped.
+
+The reason for the discipline is the same as it was in v0.19. Three of that
+release's four gate answers shrank the feature that got built, and the fourth
+became the limitation stated in three places. The spike result above is real, but
+it is the optimistic corner of the space.
+
+**Q1. Does the matte hold on a real photograph?**
+Three photographs against three generated images of comparable content. The v0.19
+finding predicts the generated sources will look markedly better. If the
+photographs fall apart, the honest tool is "decompose your generated layers", not
+"decompose your client's photo" - a much smaller product, and better known now.
+
+**Q2. How does it behave as layer count rises?**
+2, 3, 4, 6 on one source and seed. Two things to watch: whether extra layers find
+real structure or begin inventing it, and whether the background smear seen at 2
+improves or worsens. The answer sets the panel's default and its cap.
+
+**Q3. How does the 59 s scale?**
+Measured: 640px, 2 layers, 58.98 s. Unknown: cost per added layer, and the jump to
+1024. Multi-reference cost a flat +4 s per reference; if layer count behaves the
+same way, this stays an ordinary button at every setting. If it multiplies, the
+panel needs a cap and the screen has to say why.
+
+**Q4. Is the background layer usable, or merely present?**
+The smear is the one visible defect so far. Test whether it scales with how much
+of the frame the subject occupies, and whether it is the model's limit or an
+artifact of 640. A background layer that needs repainting anyway is worth saying
+out loud rather than shipping quietly.
+
+**Q5. Does the alpha survive the trip into Photoshop?**
+Not a ComfyUI question, and the riskiest item here. Nothing in this codebase has
+ever moved an alpha channel: captures run `applyAlpha: false` and every import to
+date has been opaque RGB. Spike this on a hand-made RGBA PNG through the real
+import path before trusting a model output through it.
+
+**Q6. Is the shippable quant good enough?**
+fp8mixed (20.5 GB, offloads hard) against Q4_K_M (13.2 GB), same source. Compare
+the alpha edge specifically, since that is where quantisation damage shows. This
+model is documented as unusually quantisation-sensitive - the 3-bit builds came
+back as noise before being re-cut. If Q4_K_M holds, the download drops by 7 GB
+and the setup story gets materially easier.
+
+**A failed gate is an acceptable outcome for this release.** If photographs come
+back as mush and four layers at 1024 takes nine minutes, the write-up is the
+deliverable and v0.20.0 becomes something else. That is still worth more than
+another checkpoint preset.
+
+## Phase two: the build
+
+Ordered by dependency.
+
+### 1. The preset and the workflow pair
+
+Source-format and API-format workflows under `src/workflows/`, plus a registry
+entry naming models, node classes and injection points. One injection is new to
+the project: **layer count**, on `EmptyQwenImageLayeredLatentImage.layers`.
+
+Acceptance: `workflowSourceEquivalence` passes for the new pair; the preset
+appears in the Workflow Presets catalogue with its three models listed;
+`npm run setup-pack` output includes them.
+
+Delegable under section 5a.
+
+### 2. Retrieve more than one image from a run
+
+`comfyClient` reads `outputs[node].images?.[0]` in two places, and everything
+downstream - `runPipeline`, the preview panel, the result contract - assumes one
+image per generation. This is the first tool that returns several, and the change
+propagates upward.
+
+Acceptance: a run returning N images yields N results in order; every existing
+single-image tool behaves identically; the single-run contract (A4) and run-id
+gating are untouched.
+
+Not delegable.
+
+### 3. Import N layers, in order, with alpha, in one transaction
+
+The heart of the feature and the highest-risk change in the release. N placements
+in stacking order inside a layer group named for the source, each aligned to the
+captured bounds, all inside a single transaction bound to the originating
+document (A1) and cleaning up completely on failure (A3). Plus alpha, which this
+codebase has never carried through an import.
+
+Acceptance: a failure at layer 3 of 5 leaves the document exactly as it was
+found; the group lands above the source layer; transparency is real transparency
+rather than white; the PR carries a literal click-path smoke checklist.
+
+**Not delegable** - this is import-class host code under section 5a.
+
+### 4. The tool card and screen
+
+`id: "unflatten"`, experimental, capture source, a layer-count control, and
+whatever progress treatment Q3 concludes is warranted.
+
+Acceptance: card inventory tests updated; the screen respects both themes; the
+four compact-theme CSS traps in `ORCHESTRATION.md` section 3 are checked before
+any new rule is written.
+
+Delegable.
+
+### 5. Setup entries for the three models
+
+With the VAE naming trap called out in the entry itself.
+
+Acceptance: Setup lists all three with correct folders and sizes; "What will run
+well" rates the preset honestly against 12 GB rather than optimistically.
+
+Delegable.
+
+### 6. `unflatten` joins the MCP bridge
+
+Tenth bridged tool, same boundary as the other nine: an agent can set parameters
+and press the button, and cannot capture a source. Whatever Q1 concludes about
+photographs goes in the tool description, the way the likeness limit did for
+`multi_reference`.
+
+Acceptance: the capability is published through the existing `syncBusy` snapshot
+rather than a second gate in the handler.
+
+Delegable.
+
+### 7. The write-up, and the honest subtitle
+
+`docs/unflatten-gate-findings.md` ships with the feature, and whatever the gate
+found that constrains the tool is stated in three places: the subtitle, the
+in-panel info note, and the MCP tool description. That triple is the house
+pattern now, and it is the reason anyone believes the good half.
+
+Acceptance: no claim in the README, the CHANGELOG or the panel that the gate
+findings do not support.
+
+Not delegable.
+
+### 8. One recording, thirty seconds, uncut
+
+Layers panel visible throughout. A flat photograph goes in; a group of named
+layers arrives; one is dragged aside on camera to show the transparency is real.
+
+This is the asset the release is judged on and the only thing here that nobody
+else can currently film. It also clears the standing asset gap: the newest
+screenshot of this product is still v0.6 UI from 2026-07-17.
+
+## What is still open
+
+- **The timing curve.** The base case is answered. How it scales to four layers
+  at 1024 - the setting a real document would use - is not.
+- **Alpha through UXP.** Unverifiable outside Photoshop, unprecedented in this
+  codebase, and load-bearing for the whole feature. Spike it early rather than
+  discovering it at task 3.
+- **The 30 GB.** Unflatten shares nothing with the existing stacks. It is the
+  largest single addition the setup manifest has taken, and the Setup screen's
+  framing has to carry it.
+- **Reach.** 86 release-asset downloads across 21 releases, zero issues ever
+  opened. Nothing in this plan fixes that except task 8.


### PR DESCRIPTION
Two of the eight gate questions in `docs/unflatten-v0.20.0.md` are answered, and both
change the build plan. Documentation only -- no source changes, nothing to smoke-test in
Photoshop for this PR.

## Q5 -- alpha survives, but Photoshop resizes the layer

Ran first because it needed no model and no download, and because its failure would have
been unconditional: every other question grades how good the decomposition is, this one
decides whether the product can exist.

**Pass.** A mostly-transparent PNG keeps its full canvas bounds (no trimming to visible
pixels), gradient alpha and feathered edges survive, the background shows through, and
16-bit behaves identically to 8-bit.

**The finding underneath it.** Placing a 1024px file into a 1000px-tall document read
`W: 97.66%` -- exactly 1000/1024. `placeEvent` auto-fits an oversized image down to the
canvas, and placing into 2000x2000 read `W: 100.00%`, so it never enlarges.
`alignActiveLayerToBounds` only calls `moveActiveLayerBy`; it translates and never scales.
`ImageScaleToMaxDimension` caps the graph's output at 640px on the long side, so layers
from a large document come back at a fraction of the size they must occupy.

**Task 3 gains an explicit scale-to-target-bounds step.** Only the enlarging direction.

## Q8 -- a new question, and the reason it was needed

Not in the plan. Task 2's acceptance says "a run returning N images yields N results in
order" and task 3's says "in stacking order"; both assumed a mapping nobody had checked.

`layers: 2` returns **three** images. Index 0 is the flattened composite, not a layer.
Compositing index 2 over index 1 reproduces index 0 to a mean absolute error of 2.87/255,
which is VAE round-trip noise and is what confirms the reading.

**Task 3 must skip index 0**, or it stacks a flat copy of the whole picture over the group.
Verified at `layers: 2` only; re-confirmation at 3, 4 and 6 is folded into Q2's run list.

## Also here

- The run list for the six open questions, with Q1 redesigned as matched photo/generated
  pairs so provenance and compositional separability do not vary together, Q4's usability
  bar declared in advance, and Q6 made conditional.
- `.claude/agents/WFL.md` said PyTorch 2.6.0+cu124 as verified fact; the machine runs
  2.13.0+cu130. Separate commit. That line is load-bearing for every model WFL rules in or
  out.

## What is still open

- Six gate questions, none run.
- One seam Q5 did not cover: the four test PNGs through `importGeneratedImageAsLayer`
  rather than through Photoshop's own Place.
- Artboard documents are an untested import case -- unrelated to this feature, found by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
