### PR TITLE
Task 1: the Unflatten preset and its workflow pair

### DIFF
--- a/src/comfy/presetRegistry.ts
+++ b/src/comfy/presetRegistry.ts
@@ -50,6 +50,8 @@ const COMFY_ORG_Z_IMAGE_TURBO_REPO = "https://huggingface.co/Comfy-Org/z_image_t
 // point straight at the file with no click-through.
 const BFL_FLUX2_KLEIN_4B_FP8_REPO = "https://huggingface.co/black-forest-labs/FLUX.2-klein-4b-fp8";
 const COMFY_ORG_KREA2_REPO = "https://huggingface.co/Comfy-Org/Krea-2";
+const COMFY_ORG_QWEN_IMAGE_LAYERED_REPO = "https://huggingface.co/Comfy-Org/Qwen-Image-Layered_ComfyUI";
+const COMFY_ORG_QWEN_IMAGE_REPO = "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI";
 const FLUX_TEXT_ENCODERS_REPO = "https://huggingface.co/comfyanonymous/flux_text_encoders";
 const ALIBABA_PAI_ZIMAGE_FUN_CONTROLNET_REPO =
   "https://huggingface.co/alibaba-pai/Z-Image-Turbo-Fun-Controlnet-Union-2.1";
@@ -133,6 +135,48 @@ const FLUX2_KLEIN_4B_STACK = [
     downloadUrl: `${COMFY_ORG_FLUX2_DEV_REPO}/resolve/main/split_files/vae/flux2-vae.safetensors`,
     sourcePageUrl: COMFY_ORG_FLUX2_DEV_REPO,
     downloadSizeBytes: 336211292
+  }
+] as const;
+
+const QWEN_IMAGE_LAYERED_STACK = [
+  {
+    kind: "diffusion-model-stack",
+    objectInfoNode: "UNETLoader",
+    inputName: "unet_name",
+    label: "Qwen-Image-Layered diffusion model",
+    modelName: "qwen_image_layered_fp8mixed.safetensors",
+    setupHint: "Install qwen_image_layered_fp8mixed.safetensors where ComfyUI's UNETLoader can find it.",
+    downloadUrl: `${COMFY_ORG_QWEN_IMAGE_LAYERED_REPO}/resolve/main/split_files/diffusion_models/qwen_image_layered_fp8mixed.safetensors`,
+    sourcePageUrl: COMFY_ORG_QWEN_IMAGE_LAYERED_REPO,
+    downloadSizeBytes: 20533591821
+  },
+  {
+    // NOT in the layered repository. That repo has no text_encoders folder at
+    // all, which is what sends people to the wrong file; the encoder lives with
+    // the base Qwen-Image release instead.
+    kind: "clip",
+    objectInfoNode: "CLIPLoader",
+    inputName: "clip_name",
+    label: "Qwen2.5-VL 7B text encoder",
+    modelName: "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+    setupHint: "Install qwen_2.5_vl_7b_fp8_scaled.safetensors where ComfyUI's CLIPLoader can find it.",
+    downloadUrl: `${COMFY_ORG_QWEN_IMAGE_REPO}/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors`,
+    sourcePageUrl: COMFY_ORG_QWEN_IMAGE_REPO,
+    downloadSizeBytes: 9384670680
+  },
+  {
+    // Not qwen_image_vae.safetensors, which is Krea-2's and sits in the same
+    // folder. The names differ by one word and the wrong one loads far enough
+    // to fail confusingly rather than obviously.
+    kind: "vae",
+    objectInfoNode: "VAELoader",
+    inputName: "vae_name",
+    label: "Qwen-Image-Layered VAE",
+    modelName: "qwen_image_layered_vae.safetensors",
+    setupHint: "Install qwen_image_layered_vae.safetensors in ComfyUI models/vae. This is the layered VAE, not qwen_image_vae.safetensors.",
+    downloadUrl: `${COMFY_ORG_QWEN_IMAGE_LAYERED_REPO}/resolve/main/split_files/vae/qwen_image_layered_vae.safetensors`,
+    sourcePageUrl: COMFY_ORG_QWEN_IMAGE_LAYERED_REPO,
+    downloadSizeBytes: 253816616
   }
 ] as const;
 
@@ -611,6 +655,26 @@ const FLUX2_KLEIN_MULTI_REFERENCE_NODES = {
   saveImage: "9"
 } as const;
 
+const UNFLATTEN_QWEN_LAYERED_NODES = {
+  loadImage: "1",
+  sourceScale: "2",
+  canvasSize: "3",
+  diffusionModelLoader: "4",
+  clipLoader: "5",
+  vaeLoader: "6",
+  modelSampling: "7",
+  positivePrompt: "8",
+  negativePrompt: "9",
+  vaeEncode: "10",
+  referenceIntoPositive: "11",
+  referenceIntoNegative: "12",
+  layeredLatent: "13",
+  sampler: "14",
+  cutToBatch: "15",
+  decode: "16",
+  saveImage: "17"
+} as const;
+
 const FLUX2_KLEIN_EDIT_NODES = {
   diffusionModelLoader: "20",
   clipLoader: "21",
@@ -1060,6 +1124,22 @@ const FLUX2_KLEIN_MULTI_REFERENCE_INJECTIONS = {
   cfg: target(FLUX2_KLEIN_MULTI_REFERENCE_NODES.sampler, "cfg")
   // No denoise and no width/height, for the same reason as edit-flux2-klein:
   // denoise 1 is the technique, and the canvas comes from reference 1.
+} as const;
+
+const UNFLATTEN_QWEN_LAYERED_INJECTIONS = {
+  checkpoint: target(UNFLATTEN_QWEN_LAYERED_NODES.diffusionModelLoader, "unet_name"),
+  sourceImage: target(UNFLATTEN_QWEN_LAYERED_NODES.loadImage, "image"),
+  positivePrompt: target(UNFLATTEN_QWEN_LAYERED_NODES.positivePrompt, "text"),
+  negativePrompt: target(UNFLATTEN_QWEN_LAYERED_NODES.negativePrompt, "text"),
+  seed: target(UNFLATTEN_QWEN_LAYERED_NODES.sampler, "seed"),
+  steps: target(UNFLATTEN_QWEN_LAYERED_NODES.sampler, "steps"),
+  cfg: target(UNFLATTEN_QWEN_LAYERED_NODES.sampler, "cfg"),
+  // New to this project. Everything else here injects into a node class that
+  // already had a home; this one drives how many plates come back.
+  layerCount: target(UNFLATTEN_QWEN_LAYERED_NODES.layeredLatent, "layers")
+  // No width/height: the latent is sized from GetImageSize on the scaled
+  // source, so the output always matches what was captured. No denoise: the
+  // graph decomposes an existing picture rather than re-sampling it.
 } as const;
 
 const FLUX2_KLEIN_EDIT_INJECTIONS = {
@@ -1627,6 +1707,28 @@ const FLUX2_KLEIN_MULTI_REFERENCE_CAPABILITY: WorkflowCapability = {
     hiddenControls: ["denoise", "width", "height"],
     experimentalNote:
       "Composes one picture out of several layers. Clothing, props, setting and lighting all carry across; faces do not -- a person in a reference comes back as a plausible stranger rather than themselves, so this cannot place a specific person. Reference 1 sets the output size. Order matters: if an object behind the subjects comes out duplicated or stretched, move it earlier in the list."
+  }
+};
+
+const UNFLATTEN_QWEN_LAYERED_CAPABILITY: WorkflowCapability = {
+  toolType: "unflatten",
+  loaderType: "diffusion-model-stack",
+  artistLabel: "Unflatten",
+  technicalLabel: "unflatten-qwen-layered",
+  requiredPhotoshopInputs: [{ anyOf: ["active-layer", "canvas"], label: "an active layer or captured canvas" }],
+  controls: ["prompt", "layerCount", "steps", "cfg", "seed"],
+  output: {
+    kind: "source-sized-image",
+    size: "source",
+    importBehavior: "new-layer"
+  },
+  uiHints: {
+    showModelSelector: true,
+    modelSelectorLabel: "Layered model",
+    primaryActionLabel: "Unflatten",
+    hiddenControls: ["denoise", "width", "height", "negativePrompt"],
+    experimentalNote:
+      "Splits a flat layer into separate layers with transparency. It needs a picture with something standing in front of something else -- a subject on visible ground. A close-up that fills the frame has no front and back to find, and comes back unseparated. Four layers is the measured best setting: two fuses distinct objects into one plate, and more than four returns blank layers. Resolution is fixed at 640 because 1024 separates worse and takes three times as long."
   }
 };
 
@@ -3786,6 +3888,114 @@ export const WORKFLOW_PRESETS: WorkflowPresetDefinition[] = [
       },
       {
         id: STYLE_REFERENCE_SD15_NODES.saveImage,
+        classType: "SaveImage",
+        requiredInputs: ["images", "filename_prefix"]
+      }
+    ]
+  },
+  {
+    id: "unflatten-qwen-layered",
+    label: "unflatten-qwen-layered",
+    displayName: "Qwen-Image-Layered",
+    mode: "unflatten",
+    description:
+      "Splits a flat captured layer into separate layers with real transparency, in stacking order. Needs a subject standing on visible ground; a frame-filling close-up comes back unseparated.",
+    workflowFile: "workflows/api/unflatten-qwen-layered.json",
+    sourceWorkflowFile: "workflows/source/unflatten-qwen-layered.workflow.json",
+    status: "experimental",
+    recommendedSettings: { steps: 20, cfg: 2.5 },
+    supportedModelFamilies: ["unknown"],
+    experimentalModelFamilies: ["sd1", "sdxl", "sd3", "flux", "flux2", "zImage"],
+    modelSource: DIFFUSION_MODEL_SOURCE,
+    capability: UNFLATTEN_QWEN_LAYERED_CAPABILITY,
+    modelStack: [...QWEN_IMAGE_LAYERED_STACK],
+    requiredModels: [...QWEN_IMAGE_LAYERED_STACK],
+    injections: UNFLATTEN_QWEN_LAYERED_INJECTIONS,
+    compatibilityNote:
+      "unflatten-qwen-layered returns layers + 1 images: index 0 is the flattened composite, and the layers run back-to-front from index 1. Measured on a live ComfyUI over 20 runs -- see docs/unflatten-gate-findings.md. 640px with 4 layers is the measured optimum; 1024 separates roughly half as well and costs 3.5x the time, which is why the graph fixes largest_size at 640.",
+    requiredNodes: [
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.loadImage,
+        classType: "LoadImage",
+        requiredInputs: ["image"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.sourceScale,
+        classType: "ImageScaleToMaxDimension",
+        requiredInputs: ["image", "upscale_method", "largest_size"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.canvasSize,
+        classType: "GetImageSize",
+        requiredInputs: ["image"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.diffusionModelLoader,
+        classType: "UNETLoader",
+        requiredInputs: ["unet_name", "weight_dtype"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.clipLoader,
+        classType: "CLIPLoader",
+        requiredInputs: ["clip_name", "type"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.vaeLoader,
+        classType: "VAELoader",
+        requiredInputs: ["vae_name"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.modelSampling,
+        classType: "ModelSamplingAuraFlow",
+        requiredInputs: ["model", "shift"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.positivePrompt,
+        classType: "CLIPTextEncode",
+        requiredInputs: ["text", "clip"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.negativePrompt,
+        classType: "CLIPTextEncode",
+        requiredInputs: ["text", "clip"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.vaeEncode,
+        classType: "VAEEncode",
+        requiredInputs: ["pixels", "vae"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.referenceIntoPositive,
+        classType: "ReferenceLatent",
+        requiredInputs: ["conditioning", "latent"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.referenceIntoNegative,
+        classType: "ReferenceLatent",
+        requiredInputs: ["conditioning", "latent"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.layeredLatent,
+        classType: "EmptyQwenImageLayeredLatentImage",
+        requiredInputs: ["width", "height", "layers", "batch_size"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.sampler,
+        classType: "KSampler",
+        requiredInputs: ["model", "seed", "steps", "cfg", "positive", "negative", "latent_image", "denoise"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.cutToBatch,
+        classType: "LatentCutToBatch",
+        requiredInputs: ["samples", "dim", "slice_size"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.decode,
+        classType: "VAEDecode",
+        requiredInputs: ["samples", "vae"]
+      },
+      {
+        id: UNFLATTEN_QWEN_LAYERED_NODES.saveImage,
         classType: "SaveImage",
         requiredInputs: ["images", "filename_prefix"]
       }

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -23,7 +23,8 @@ export type WorkflowPreset =
   | "outpaint-flux-fill-basic"
   | "upscale-basic"
   | "style-reference-sd15"
-  | "multi-reference-flux2-klein";
+  | "multi-reference-flux2-klein"
+  | "unflatten-qwen-layered";
 export type WorkflowMode =
   | "txt2img"
   | "img2img"
@@ -33,7 +34,8 @@ export type WorkflowMode =
   | "prompt"
   | "upscale"
   | "style-reference"
-  | "multi-reference";
+  | "multi-reference"
+  | "unflatten";
 export type ModelFamily = "sd1" | "sdxl" | "sd3" | "flux" | "flux2" | "zImage" | "unknown";
 export type WorkflowToolType = WorkflowMode | "realtime";
 export type WorkflowLoaderType = "checkpoint" | "diffusion-model-stack" | "vision-language" | "upscale";
@@ -51,6 +53,7 @@ export type WorkflowControlId =
   | "numBeams"
   | "controlStrength"
   | "maskBlur"
+  | "layerCount"
   | "contextPadding"
   | "outpaintLeft"
   | "outpaintTop"
@@ -239,6 +242,36 @@ export type BuildMultiReferenceWorkflowOptions = {
 };
 
 /**
+ * No width/height: the layered latent is sized from the captured source, so the
+ * decomposition always comes back at the size that went in. No denoise: this
+ * takes an existing picture apart rather than re-sampling it.
+ */
+export type BuildUnflattenWorkflowOptions = {
+  presetId?: string;
+  /**
+   * A plain description of the picture. The graph conditions the decomposition
+   * on it, so it describes what is already there rather than asking for
+   * something new.
+   */
+  prompt: string;
+  negativePrompt?: string;
+  checkpointName?: string;
+  sourceImageName: string;
+  /**
+   * How many plates to ask for. The run returns this many PLUS ONE image: index
+   * 0 is the flattened composite. Layers past what the picture actually
+   * contains come back blank rather than invented, so this is a ceiling and not
+   * a promise -- see docs/unflatten-gate-findings.md, Q7.
+   */
+  layerCount: number;
+  steps: number;
+  cfg: number;
+  seed: number;
+  requiredModelSelections?: Record<string, string>;
+  lora?: WorkflowLoraSelection;
+};
+
+/**
  * No width/height: the first reference sets the canvas. No denoise: it is fixed
  * at 1, which is the technique rather than a default.
  */
@@ -317,7 +350,13 @@ export type WorkflowInjectionName =
   | "outpaintTop"
   | "outpaintRight"
   | "outpaintBottom"
-  | "outpaintFeathering";
+  | "outpaintFeathering"
+  /**
+   * How many plates the layered decomposition returns. The graph gives back
+   * layerCount + 1 images: index 0 is the flattened composite, and the layers
+   * run back-to-front from index 1.
+   */
+  | "layerCount";
 
 export type WorkflowInjectionTargetList = WorkflowInputTarget | readonly WorkflowInputTarget[];
 

--- a/src/comfy/workflowBuilder.ts
+++ b/src/comfy/workflowBuilder.ts
@@ -31,6 +31,7 @@ import {
   BuildPromptFromLayerWorkflowOptions,
   BuildSketchToImageWorkflowOptions,
   BuildStyleReferenceWorkflowOptions,
+  BuildUnflattenWorkflowOptions,
   BuildUpscaleWorkflowOptions,
   BuildWorkflowOptions,
   BuildWorkflowResult,
@@ -263,6 +264,44 @@ export async function buildMultiReferenceWorkflow(
   // rewires the sampler's conditioning inputs, and a later injection into them
   // would silently drop every reference past the first.
   applyReferenceChain(workflow, preset, options.referenceImageNames);
+  applyLoraSelection(workflow, preset, options.lora);
+
+  validateWorkflowForPreset(workflow, preset);
+
+  return {
+    workflow,
+    seed,
+    preset
+  };
+}
+
+export async function buildUnflattenWorkflow(
+  options: BuildUnflattenWorkflowOptions
+): Promise<BuildWorkflowResult> {
+  const preset = getWorkflowPreset(options.presetId ?? "unflatten-qwen-layered");
+  assertPresetMode(preset, "unflatten");
+  assertPresetRunnable(preset);
+  const workflow = await cloneWorkflowTemplate(preset);
+  const seed = options.seed;
+
+  validateWorkflowForPreset(workflow, preset);
+  applyRequiredModelSelections(workflow, preset, options.requiredModelSelections);
+
+  if (options.checkpointName) {
+    setPresetInput(workflow, preset, "checkpoint", options.checkpointName, true);
+  }
+
+  setPresetInput(workflow, preset, "sourceImage", options.sourceImageName, true);
+  setPresetInput(workflow, preset, "positivePrompt", options.prompt, true);
+  setPresetInput(workflow, preset, "negativePrompt", options.negativePrompt ?? "");
+  setPresetInput(workflow, preset, "seed", seed, true);
+  setPresetInput(workflow, preset, "steps", options.steps, true);
+  setPresetInput(workflow, preset, "cfg", options.cfg, true);
+  // Required, unlike most injections: a graph that silently kept the template's
+  // layer count would return a different number of plates than the panel asked
+  // for, and the import maps results to layers positionally.
+  setPresetInput(workflow, preset, "layerCount", options.layerCount, true);
+
   applyLoraSelection(workflow, preset, options.lora);
 
   validateWorkflowForPreset(workflow, preset);

--- a/src/comfy/workflowCapabilities.ts
+++ b/src/comfy/workflowCapabilities.ts
@@ -14,7 +14,8 @@ const MODE_LABELS: Record<WorkflowPresetDefinition["mode"], string> = {
   prompt: "Prompt from Layer",
   upscale: "Upscale",
   "style-reference": "Style Reference",
-  "multi-reference": "Multi-Reference Composition"
+  "multi-reference": "Multi-Reference Composition",
+  unflatten: "Unflatten"
 };
 
 const DEFAULT_CONTROLS: Record<WorkflowPresetDefinition["mode"], readonly WorkflowControlId[]> = {
@@ -38,7 +39,10 @@ const DEFAULT_CONTROLS: Record<WorkflowPresetDefinition["mode"], readonly Workfl
   upscale: [],
   "style-reference": ["prompt", "negativePrompt", "width", "height", "steps", "cfg", "seed", "controlStrength"],
   // No width/height: reference 1 sets the canvas. No denoise: it is fixed at 1.
-  "multi-reference": ["prompt", "negativePrompt", "steps", "cfg", "seed"]
+  "multi-reference": ["prompt", "negativePrompt", "steps", "cfg", "seed"],
+  // No width/height: the latent is sized from the captured source. No denoise:
+  // this decomposes an existing picture rather than re-sampling it.
+  unflatten: ["prompt", "layerCount", "steps", "cfg", "seed"]
 };
 
 export function getWorkflowCapability(preset: WorkflowPresetDefinition): WorkflowCapability {

--- a/src/workflows/api/unflatten-qwen-layered.json
+++ b/src/workflows/api/unflatten-qwen-layered.json
@@ -1,0 +1,131 @@
+{
+  "1": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "openlayer-unflatten-source.png"
+    }
+  },
+  "2": {
+    "class_type": "ImageScaleToMaxDimension",
+    "inputs": {
+      "upscale_method": "lanczos",
+      "largest_size": 640,
+      "image": ["1", 0]
+    }
+  },
+  "3": {
+    "class_type": "GetImageSize",
+    "inputs": {
+      "image": ["2", 0]
+    }
+  },
+  "4": {
+    "class_type": "UNETLoader",
+    "inputs": {
+      "unet_name": "qwen_image_layered_fp8mixed.safetensors",
+      "weight_dtype": "default"
+    }
+  },
+  "5": {
+    "class_type": "CLIPLoader",
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    }
+  },
+  "6": {
+    "class_type": "VAELoader",
+    "inputs": {
+      "vae_name": "qwen_image_layered_vae.safetensors"
+    }
+  },
+  "7": {
+    "class_type": "ModelSamplingAuraFlow",
+    "inputs": {
+      "shift": 1.0,
+      "model": ["4", 0]
+    }
+  },
+  "8": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "a photograph",
+      "clip": ["5", 0]
+    }
+  },
+  "9": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "",
+      "clip": ["5", 0]
+    }
+  },
+  "10": {
+    "class_type": "VAEEncode",
+    "inputs": {
+      "pixels": ["2", 0],
+      "vae": ["6", 0]
+    }
+  },
+  "11": {
+    "class_type": "ReferenceLatent",
+    "inputs": {
+      "conditioning": ["8", 0],
+      "latent": ["10", 0]
+    }
+  },
+  "12": {
+    "class_type": "ReferenceLatent",
+    "inputs": {
+      "conditioning": ["9", 0],
+      "latent": ["10", 0]
+    }
+  },
+  "13": {
+    "class_type": "EmptyQwenImageLayeredLatentImage",
+    "inputs": {
+      "width": ["3", 0],
+      "height": ["3", 1],
+      "layers": 4,
+      "batch_size": 1
+    }
+  },
+  "14": {
+    "class_type": "KSampler",
+    "inputs": {
+      "seed": 0,
+      "steps": 20,
+      "cfg": 2.5,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1.0,
+      "model": ["7", 0],
+      "positive": ["11", 0],
+      "negative": ["12", 0],
+      "latent_image": ["13", 0]
+    }
+  },
+  "15": {
+    "class_type": "LatentCutToBatch",
+    "inputs": {
+      "dim": "t",
+      "slice_size": 1,
+      "samples": ["14", 0]
+    }
+  },
+  "16": {
+    "class_type": "VAEDecode",
+    "inputs": {
+      "samples": ["15", 0],
+      "vae": ["6", 0]
+    }
+  },
+  "17": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "filename_prefix": "OpenLayer_Unflatten",
+      "images": ["16", 0]
+    }
+  }
+}

--- a/src/workflows/source/README.md
+++ b/src/workflows/source/README.md
@@ -98,3 +98,26 @@ import misplaces it.
 `outpaint-flux-fill-basic.workflow.json` is the GUI-editable reference workflow for the experimental Outpaint tool.
 
 The runnable API version is in `src/workflows/api/outpaint-flux-fill-basic.json`. It uses ImagePadForOutpaint to expand the captured source before Flux Fill sampling. If this source workflow is edited in ComfyUI, export a matching API workflow and update `src/comfy/presetRegistry.ts` node mappings before relying on it.
+
+## Unflatten Notes
+
+`unflatten-qwen-layered.workflow.json` is the GUI-editable graph for the Unflatten tool, and
+its node ids match `src/workflows/api/unflatten-qwen-layered.json` one for one.
+
+Three things in it are load-bearing and measured rather than chosen. All three come from
+`docs/unflatten-gate-findings.md`.
+
+- **`ImageScaleToMaxDimension.largest_size` is fixed at 640, and should stay there.** At 1024
+  the decomposition separates roughly half as well, leaves more layers blank, and takes 3.5x
+  as long -- confirmed on two seeds. This is not the usual quality/time trade-off, so the
+  larger setting is not offered rather than being offered with a warning.
+- **`EmptyQwenImageLayeredLatentImage.layers` defaults to 4.** Two fuses distinct objects
+  into one plate, three separates less than four, and six returns blank layers. Four is the
+  measured optimum.
+- **`VAELoader` must load `qwen_image_layered_vae.safetensors`**, not `qwen_image_vae.safetensors`,
+  which is Krea-2's and sits in the same folder. The names differ by one word and the wrong
+  one loads far enough to fail confusingly rather than obviously.
+
+The graph returns **`layers` + 1 images**. Index 0 is the flattened composite, not a layer;
+the layers run back-to-front from index 1. Anything consuming this workflow has to skip
+index 0, and has to tolerate blank layers, because the populated count varies with seed.

--- a/src/workflows/source/unflatten-qwen-layered.workflow.json
+++ b/src/workflows/source/unflatten-qwen-layered.workflow.json
@@ -1,0 +1,862 @@
+{
+  "id": "openlayer-unflatten-qwen-layered",
+  "revision": 0,
+  "last_node_id": 17,
+  "last_link_id": 21,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "LoadImage",
+      "pos": [
+        -1180,
+        40
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "openlayer-unflatten-source.png"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "ImageScaleToMaxDimension",
+      "pos": [
+        -880,
+        40
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1
+        },
+        {
+          "name": "upscale_method",
+          "type": "COMBO",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            2,
+            6
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ImageScaleToMaxDimension"
+      },
+      "widgets_values": [
+        640
+      ]
+    },
+    {
+      "id": 3,
+      "type": "GetImageSize",
+      "pos": [
+        -600,
+        40
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 2
+        }
+      ],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            12
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            13
+          ]
+        },
+        {
+          "name": "batch_size",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetImageSize"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 4,
+      "type": "UNETLoader",
+      "pos": [
+        -1180,
+        320
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            3
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "qwen_image_layered_fp8mixed.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "CLIPLoader",
+      "pos": [
+        -1180,
+        470
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            4,
+            5
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+        "qwen_image",
+        "default"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "VAELoader",
+      "pos": [
+        -1180,
+        640
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            7,
+            20
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "qwen_image_layered_vae.safetensors"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "ModelSamplingAuraFlow",
+      "pos": [
+        -880,
+        320
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 3
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            14
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ModelSamplingAuraFlow"
+      },
+      "widgets_values": [
+        1.0
+      ]
+    },
+    {
+      "id": 8,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -880,
+        620
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 4
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            8
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "a photograph"
+      ]
+    },
+    {
+      "id": 9,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -880,
+        800
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 5
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            10
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        ""
+      ]
+    },
+    {
+      "id": 10,
+      "type": "VAEEncode",
+      "pos": [
+        -600,
+        200
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 6
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            9,
+            11
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEEncode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 11,
+      "type": "ReferenceLatent",
+      "pos": [
+        -340,
+        620
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 8
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "link": 9
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            15
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ReferenceLatent"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 12,
+      "type": "ReferenceLatent",
+      "pos": [
+        -340,
+        800
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 10
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "link": 11
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            16
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ReferenceLatent"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 13,
+      "type": "EmptyQwenImageLayeredLatentImage",
+      "pos": [
+        -340,
+        300
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "link": 12,
+          "widget": {
+            "name": "width"
+          }
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "link": 13,
+          "widget": {
+            "name": "height"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            17
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "EmptyQwenImageLayeredLatentImage"
+      },
+      "widgets_values": [
+        4,
+        1
+      ]
+    },
+    {
+      "id": 14,
+      "type": "KSampler",
+      "pos": [
+        -40,
+        400
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 14
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 15
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 16
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 17
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            18
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        0,
+        "fixed",
+        20,
+        2.5,
+        "euler",
+        "simple",
+        1.0
+      ]
+    },
+    {
+      "id": 15,
+      "type": "LatentCutToBatch",
+      "pos": [
+        280,
+        400
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 18
+        },
+        {
+          "name": "dim",
+          "type": "COMBO",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            19
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LatentCutToBatch"
+      },
+      "widgets_values": [
+        1
+      ]
+    },
+    {
+      "id": 16,
+      "type": "VAEDecode",
+      "pos": [
+        520,
+        400
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 19
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 20
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            21
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 17,
+      "type": "SaveImage",
+      "pos": [
+        760,
+        400
+      ],
+      "size": [
+        300,
+        120
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 21
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "OpenLayer_Unflatten"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      2,
+      0,
+      "IMAGE"
+    ],
+    [
+      2,
+      2,
+      0,
+      3,
+      0,
+      "IMAGE"
+    ],
+    [
+      3,
+      4,
+      0,
+      7,
+      0,
+      "MODEL"
+    ],
+    [
+      4,
+      5,
+      0,
+      8,
+      0,
+      "CLIP"
+    ],
+    [
+      5,
+      5,
+      0,
+      9,
+      0,
+      "CLIP"
+    ],
+    [
+      6,
+      2,
+      0,
+      10,
+      0,
+      "IMAGE"
+    ],
+    [
+      7,
+      6,
+      0,
+      10,
+      1,
+      "VAE"
+    ],
+    [
+      8,
+      8,
+      0,
+      11,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      9,
+      10,
+      0,
+      11,
+      1,
+      "LATENT"
+    ],
+    [
+      10,
+      9,
+      0,
+      12,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      11,
+      10,
+      0,
+      12,
+      1,
+      "LATENT"
+    ],
+    [
+      12,
+      3,
+      0,
+      13,
+      0,
+      "INT"
+    ],
+    [
+      13,
+      3,
+      1,
+      13,
+      1,
+      "INT"
+    ],
+    [
+      14,
+      7,
+      0,
+      14,
+      0,
+      "MODEL"
+    ],
+    [
+      15,
+      11,
+      0,
+      14,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      16,
+      12,
+      0,
+      14,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      17,
+      13,
+      0,
+      14,
+      3,
+      "LATENT"
+    ],
+    [
+      18,
+      14,
+      0,
+      15,
+      0,
+      "LATENT"
+    ],
+    [
+      19,
+      15,
+      0,
+      16,
+      0,
+      "LATENT"
+    ],
+    [
+      20,
+      6,
+      0,
+      16,
+      1,
+      "VAE"
+    ],
+    [
+      21,
+      16,
+      0,
+      17,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/tests/comfy/modelFolders.test.ts
+++ b/tests/comfy/modelFolders.test.ts
@@ -135,6 +135,7 @@ describe("required model inventory", () => {
         "diffusion_models/flux-2-klein-4b-fp8.safetensors",
         "diffusion_models/flux2-dev-Q4_K_M.gguf",
         "diffusion_models/krea2_turbo_fp8_scaled.safetensors",
+        "diffusion_models/qwen_image_layered_fp8mixed.safetensors",
         "diffusion_models/z_image_turbo_bf16.safetensors",
         "clip_vision/CLIP-ViT-H-14-laion2B-s32B-b79K.safetensors",
         "ipadapter/ip-adapter-plus_sd15.safetensors",
@@ -143,12 +144,14 @@ describe("required model inventory", () => {
         "text_encoders/clip_l.safetensors",
         "text_encoders/mistral_3_small_flux2_fp8.safetensors",
         "text_encoders/qwen3vl_4b_fp8_scaled.safetensors",
+        "text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
         "text_encoders/qwen_3_4b.safetensors",
         "text_encoders/t5xxl_fp16.safetensors",
         "upscale_models/4x-UltraSharp.pth",
         "vae/ae.safetensors",
         "vae/flux2-vae.safetensors",
         "vae/full_encoder_small_decoder.safetensors",
+        "vae/qwen_image_layered_vae.safetensors",
         "vae/qwen_image_vae.safetensors"
       ].sort()
     );


### PR DESCRIPTION
Task 1 from `docs/unflatten-v0.20.0.md`. No Photoshop surface yet -- this adds the preset,
the workflow pair and the registry mapping. Nothing in the panel calls it, so there is
**nothing to smoke-test in Photoshop for this PR**; the verification that matters is below.

## What is here

- `src/workflows/api/unflatten-qwen-layered.json` -- the graph the gate ran twenty times,
  with the same node ids the harness used. The registry maps against a mapping that has
  already produced correct output on this machine.
- `src/workflows/source/unflatten-qwen-layered.workflow.json` -- generated from the API file
  against the live `/object_info`, so slot names, types and wiring describe the same graph
  rather than a plausible-looking one. 17 nodes, 21 links, none unresolved.
- Registry entry: three models with exact byte sizes and verified download paths, seventeen
  node requirements, and the injection map.
- `layerCount`, the new injection, on `EmptyQwenImageLayeredLatentImage.layers`.
- `buildUnflattenWorkflow` plus the `unflatten` mode.

## Verification beyond the suite

The shipped API file was submitted to a running ComfyUI with **only the registry's declared
injection targets set** -- if the mapping were wrong, this would fail rather than silently
use template values:

```
shipped workflow -> success in 134.6 s | 5 images for layers=4 (expect 5)
```

That is the N+1 contract from Q8 and the expected 640/4 timing from Q3.

## Acceptance criteria

- [x] `workflowSourceEquivalence` passes for the new pair -- 967 tests green.
- [x] Preset appears in the catalogue with its three models listed.
- [x] `npm run setup-pack` includes them: 26 presets, 27 models, both workflow files in the
      zip, all three models with correct folders. The pack advertises the editable source,
      which it only does when the equivalence check passes.

## Measured settings, recorded where someone would otherwise tidy them

- **`largest_size` fixed at 640.** 1024 separates about half as well, leaves more layers
  blank, and costs 3.5x the time. Absent rather than warned about, because it is not a
  quality/time trade-off.
- **`layers` defaults to 4.** Two fuses distinct objects into one plate; six returns blanks.
- **The layered VAE, not Krea-2's.** Same folder, one word apart, fails confusingly.

`layerCount` is injected as **required**: a graph that silently kept the template's layer
count would return a different number of plates than the panel asked for, and the import
maps results to layers positionally.

## Note on delegation

The plan marks task 1 delegable. Codex is unavailable, and the economics had already changed
-- the gate work produced the verified graph, so a brief would have contained most of the
task. Tasks 4, 5 and 6 come to me as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
