### PR TITLE
Task 2: let a run return more than one image

### DIFF
--- a/src/comfy/comfyClient.ts
+++ b/src/comfy/comfyClient.ts
@@ -621,20 +621,67 @@ export class ComfyClient {
     throw createOpenLayerError("COMFY_TIMEOUT", "Timed out while waiting for ComfyUI to finish text generation.");
   }
 
+  /**
+   * The single-image path every tool but Unflatten uses. Fetches only the first
+   * image even when a run produced several, so nothing pays for downloads it
+   * will not use.
+   */
   async retrieveFirstOutputImage(
     promptId: string,
     historyItem?: ComfyHistoryItem,
     options: RetrieveOutputOptions = {}
   ): Promise<GeneratedImageResult> {
+    const images = await this.locateOutputImages(promptId, historyItem, options);
+
+    return this.downloadOutputImage(images[0]);
+  }
+
+  /**
+   * Every image a run produced, in the order ComfyUI listed them.
+   *
+   * Unflatten is the first tool that needs this: its graph returns `layers + 1`
+   * images from one SaveImage node, and the import maps them to Photoshop
+   * layers positionally, so order is part of the contract rather than a
+   * convenience.
+   */
+  async retrieveOutputImages(
+    promptId: string,
+    historyItem?: ComfyHistoryItem,
+    options: RetrieveOutputOptions = {}
+  ): Promise<GeneratedImageResult[]> {
+    const images = await this.locateOutputImages(promptId, historyItem, options);
+    const results: GeneratedImageResult[] = [];
+
+    // Sequential on purpose. These are large PNGs off a local server that is
+    // usually still holding a model in VRAM, and a parallel fetch of five
+    // full-size layers buys nothing while making the failure case harder to
+    // attribute to a particular layer.
+    for (const image of images) {
+      results.push(await this.downloadOutputImage(image));
+    }
+
+    return results;
+  }
+
+  /**
+   * Shared validation for both retrieval paths, so the "no history" and "no
+   * image" failures cannot drift apart between them. Always returns at least
+   * one image; it throws rather than returning empty.
+   */
+  private async locateOutputImages(
+    promptId: string,
+    historyItem: ComfyHistoryItem | undefined,
+    options: RetrieveOutputOptions
+  ): Promise<ComfyImageOutput[]> {
     const history = historyItem ?? (await this.getHistory(promptId))[promptId];
 
     if (!history) {
       throw createOpenLayerError("COMFY_NO_IMAGE", `No ComfyUI history was found for prompt ${promptId}.`);
     }
 
-    const image = findImageOutput(history, options.preferredNodeId);
+    const images = findImageOutputs(history, options.preferredNodeId);
 
-    if (!image) {
+    if (images.length === 0) {
       throw createOpenLayerError(
         "COMFY_NO_IMAGE",
         options.preferredNodeId
@@ -643,6 +690,10 @@ export class ComfyClient {
       );
     }
 
+    return images;
+  }
+
+  private async downloadOutputImage(image: ComfyImageOutput): Promise<GeneratedImageResult> {
     const imageUrl = this.createViewUrl(image);
     const response = await fetch(imageUrl);
 
@@ -1012,6 +1063,39 @@ export function findImageOutput(
   }
 
   return null;
+}
+
+/**
+ * Every image from the node that produced images, in ComfyUI's own order.
+ *
+ * "The node that produced images" rather than "all nodes": a graph with two
+ * SaveImage nodes would otherwise interleave two unrelated sets, and for
+ * Unflatten the order across one node's batch *is* the layer stacking order.
+ * Without a preferred node this scans in output order and takes the first node
+ * that has any, which is the same node `findImageOutput` would have picked.
+ *
+ * Images without a filename cannot be fetched, so they are dropped rather than
+ * returned as holes the caller would have to check for.
+ */
+export function findImageOutputs(
+  history: ComfyHistoryItem,
+  preferredNodeId?: string
+): ComfyImageOutput[] {
+  const outputs = history.outputs ?? {};
+
+  if (preferredNodeId) {
+    return (outputs[preferredNodeId]?.images ?? []).filter((image) => Boolean(image?.filename));
+  }
+
+  for (const output of Object.values(outputs)) {
+    const images = (output.images ?? []).filter((image) => Boolean(image?.filename));
+
+    if (images.length > 0) {
+      return images;
+    }
+  }
+
+  return [];
 }
 
 export function findTextOutput(

--- a/src/comfy/types.ts
+++ b/src/comfy/types.ts
@@ -627,6 +627,22 @@ export type GeneratedImageResult = {
   mimeType: string;
 };
 
+/**
+ * The result of a run that produced several images, as a wrapper rather than a
+ * bare array.
+ *
+ * The wrapper is load-bearing, not decoration. `bindDocumentContext` binds a
+ * result to its originating document with `{ ...value, originatingDocument }`,
+ * and spreading an array into an object turns it into `{0: ..., 1: ...}` --
+ * still an object, so it typechecks, but with no `length`, no `map`, and no
+ * order anyone can rely on. Anything committed through the pipeline has to
+ * survive that spread.
+ */
+export type GeneratedImageSet = {
+  /** ComfyUI's own output order. For a layered run this is the stacking order. */
+  images: readonly GeneratedImageResult[];
+};
+
 export type ComfyUploadImageResponse = {
   name?: string;
   subfolder?: string;

--- a/src/ui/generationController.ts
+++ b/src/ui/generationController.ts
@@ -58,7 +58,18 @@ export type GenerationPipelineMessages = {
   livePreview: string;
 };
 
-export type GenerationPipelineOptions<THistory, TImage extends object> = {
+/**
+ * `TImage` is what the client's single-image path returns; `TResult` is what
+ * this run actually commits. They are the same for every tool that produces one
+ * picture, which is why `TResult` defaults to `TImage` and no existing caller
+ * mentions it.
+ *
+ * They come apart for Unflatten, which commits a whole layer stack. Rather than
+ * a second pipeline -- the copy-paste that Phase A existed to undo -- the tool
+ * supplies its own `retrieve`, and everything around it (the run gates, the
+ * cancellation unwind, the document binding) stays one implementation.
+ */
+export type GenerationPipelineOptions<THistory, TImage extends object, TResult extends object = TImage> = {
   toolType: HistoryToolType;
   client: GenerationClient<THistory, TImage> & CancellableGenerationClient;
   workflow: object;
@@ -66,9 +77,24 @@ export type GenerationPipelineOptions<THistory, TImage extends object> = {
   originatingDocument: PhotoshopDocumentIdentity | null;
   ui: GenerationPipelineUi;
   messages: GenerationPipelineMessages;
+  /**
+   * How this run's output is fetched once the poll reports it finished.
+   * Omitted by every single-image tool, which gets the client's own
+   * `retrieveFirstOutputImage`.
+   *
+   * Must resolve to a plain object, never a bare array: the result is bound to
+   * its document by spreading it, and spreading an array yields an object with
+   * index keys and no array methods. Wrap collections -- `GeneratedImageSet` is
+   * the shape multi-image tools use.
+   */
+  retrieve?(
+    promptId: string,
+    history: THistory,
+    options: { preferredNodeId?: string }
+  ): Promise<TResult>;
   // Publish the committed result to tool state and history. Runs only after the
   // commit gate passed; the run is finalized when it returns.
-  commit(result: DocumentContextBound<TImage>): void | Promise<void>;
+  commit(result: DocumentContextBound<TResult>): void | Promise<void>;
 };
 
 export type GenerationRunHandle = {
@@ -192,9 +218,9 @@ export function createGenerationController(hooks: GenerationControllerHooks) {
       activeGeneration.watcher = null;
     },
 
-    async runPipeline<THistory, TImage extends object>(
-      options: GenerationPipelineOptions<THistory, TImage>
-    ): Promise<DocumentContextBound<TImage> | null> {
+    async runPipeline<THistory, TImage extends object, TResult extends object = TImage>(
+      options: GenerationPipelineOptions<THistory, TImage, TResult>
+    ): Promise<DocumentContextBound<TResult> | null> {
       let watcher: GenerationProgressWatcher | null = null;
       let run: GenerationRunHandle | null = null;
 
@@ -246,12 +272,17 @@ export function createGenerationController(hooks: GenerationControllerHooks) {
 
         options.ui.status(options.messages.retrieveStatus, "idle");
         options.ui.progressPreview(options.messages.retrievePreview);
-        const generatedResult = bindDocumentContext(
-          await options.client.retrieveFirstOutputImage(promptId, history, {
-            preferredNodeId: options.preferredNodeId
-          }),
-          options.originatingDocument
-        );
+        const retrieved = options.retrieve
+          ? await options.retrieve(promptId, history, { preferredNodeId: options.preferredNodeId })
+          // The cast carries the `TResult = TImage` default into the body, which
+          // the compiler cannot prove on its own: inside a generic function
+          // TResult is opaque even when its default made it TImage at the call
+          // site. Reachable only when no `retrieve` was supplied, which is
+          // exactly the case where the two are the same type.
+          : ((await options.client.retrieveFirstOutputImage(promptId, history, {
+              preferredNodeId: options.preferredNodeId
+            })) as unknown as TResult);
+        const generatedResult = bindDocumentContext(retrieved, options.originatingDocument);
         run.assertCanCommit();
         await options.commit(generatedResult);
         run.finish();

--- a/tests/comfy/comfyClient.test.ts
+++ b/tests/comfy/comfyClient.test.ts
@@ -3,6 +3,7 @@ import { getWorkflowPreset } from "../../src/comfy/presetRegistry";
 import {
   ComfyClient,
   findImageOutput,
+  findImageOutputs,
   findPromptIndex,
   readComfyModelNameList,
   readComfyProgress
@@ -55,6 +56,126 @@ describe("ComfyClient output selection", () => {
     );
 
     expect(image).toBeNull();
+  });
+});
+
+describe("ComfyClient multi-image output selection", () => {
+  // Unflatten's graph emits layers + 1 images from one SaveImage node, and the
+  // import maps them to Photoshop layers positionally. Order is the contract.
+  const layeredHistory = {
+    outputs: {
+      "17": {
+        images: [
+          { filename: "OpenLayer_Unflatten_00001_.png", type: "output" },
+          { filename: "OpenLayer_Unflatten_00002_.png", type: "output" },
+          { filename: "OpenLayer_Unflatten_00003_.png", type: "output" }
+        ]
+      }
+    }
+  };
+
+  it("returns every image from the preferred node, in order", () => {
+    expect(findImageOutputs(layeredHistory, "17").map((image) => image.filename)).toEqual([
+      "OpenLayer_Unflatten_00001_.png",
+      "OpenLayer_Unflatten_00002_.png",
+      "OpenLayer_Unflatten_00003_.png"
+    ]);
+  });
+
+  it("agrees with the single-image finder on which image comes first", () => {
+    expect(findImageOutputs(layeredHistory, "17")[0]).toEqual(findImageOutput(layeredHistory, "17"));
+    expect(findImageOutputs(layeredHistory)[0]).toEqual(findImageOutput(layeredHistory));
+  });
+
+  it("takes one node's whole batch rather than interleaving two nodes", () => {
+    const images = findImageOutputs({
+      outputs: {
+        "9": { images: [{ filename: "first-node-a.png" }, { filename: "first-node-b.png" }] },
+        "17": { images: [{ filename: "second-node.png" }] }
+      }
+    });
+
+    expect(images.map((image) => image.filename)).toEqual(["first-node-a.png", "first-node-b.png"]);
+  });
+
+  it("drops images with no filename rather than returning holes", () => {
+    const images = findImageOutputs({
+      outputs: { "17": { images: [{ filename: "" }, { filename: "real.png" }] } }
+    });
+
+    expect(images.map((image) => image.filename)).toEqual(["real.png"]);
+  });
+
+  it("returns an empty list when the preferred node produced nothing", () => {
+    expect(findImageOutputs({ outputs: { "12": { images: [{ filename: "other.png" }] } } }, "17")).toEqual([]);
+  });
+});
+
+describe("ComfyClient.retrieveOutputImages", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function stubFetch() {
+    const requested: string[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      requested.push(String(url));
+      return {
+        ok: true,
+        headers: { get: () => "image/png" },
+        blob: async () => new Blob([String(url)], { type: "image/png" })
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return requested;
+  }
+
+  const history = {
+    outputs: {
+      "17": {
+        images: [
+          { filename: "layer-0.png", subfolder: "", type: "output" },
+          { filename: "layer-1.png", subfolder: "", type: "output" },
+          { filename: "layer-2.png", subfolder: "", type: "output" }
+        ]
+      }
+    }
+  };
+
+  it("returns one result per image, in the order ComfyUI listed them", async () => {
+    const requested = stubFetch();
+    const client = new ComfyClient("http://127.0.0.1:8190");
+
+    const results = await client.retrieveOutputImages("prompt-1", history, { preferredNodeId: "17" });
+
+    expect(results.map((result) => result.filename)).toEqual(["layer-0.png", "layer-1.png", "layer-2.png"]);
+    expect(requested).toHaveLength(3);
+    expect(requested[0]).toContain("layer-0.png");
+    expect(requested[2]).toContain("layer-2.png");
+  });
+
+  it("fetches only the first image on the single-image path, even when a run produced several", async () => {
+    const requested = stubFetch();
+    const client = new ComfyClient("http://127.0.0.1:8190");
+
+    const result = await client.retrieveFirstOutputImage("prompt-1", history, { preferredNodeId: "17" });
+
+    expect(result.filename).toBe("layer-0.png");
+    expect(requested).toHaveLength(1);
+  });
+
+  it("reports the same missing-image failure both paths always reported", async () => {
+    stubFetch();
+    const client = new ComfyClient("http://127.0.0.1:8190");
+    const empty = { outputs: {} };
+
+    await expect(client.retrieveOutputImages("prompt-1", empty, { preferredNodeId: "17" })).rejects.toThrow(
+      /No output image was found from the expected SaveImage node 17/
+    );
+    await expect(client.retrieveFirstOutputImage("prompt-1", empty, { preferredNodeId: "17" })).rejects.toThrow(
+      /No output image was found from the expected SaveImage node 17/
+    );
   });
 });
 

--- a/tests/ui/generationController.test.ts
+++ b/tests/ui/generationController.test.ts
@@ -197,6 +197,93 @@ describe("generation controller pipeline", () => {
     expect(hooks.onRunFinished).toHaveBeenCalledWith("sketch-to-image");
   });
 
+  // Unflatten commits a whole layer stack rather than one picture. The point of
+  // routing it through the same pipeline is that A4 keeps applying to it, so
+  // these two tests check the payload AND that the gates did not get a hole
+  // punched in them on the way.
+  it("commits every image in order when the tool supplies its own retrieval", async () => {
+    const { controller, hooks } = createController();
+    const { client } = createFakeClient();
+    const ui = createUi();
+    const commit = vi.fn();
+    const layers = [
+      { blob: new Blob(["composite"]), filename: "layer-0.png" },
+      { blob: new Blob(["background"]), filename: "layer-1.png" },
+      { blob: new Blob(["subject"]), filename: "layer-2.png" }
+    ];
+
+    const result = await controller.runPipeline({
+      toolType: "image-to-image",
+      client,
+      workflow: {},
+      preferredNodeId: "17",
+      originatingDocument: origin,
+      ui,
+      messages: MESSAGES,
+      retrieve: vi.fn(async () => ({ images: layers })),
+      commit
+    });
+
+    expect(result?.images.map((layer) => layer.filename)).toEqual([
+      "layer-0.png",
+      "layer-1.png",
+      "layer-2.png"
+    ]);
+    expect(result?.originatingDocument).toBe(origin);
+    expect(commit).toHaveBeenCalledWith(result);
+    // The single-image path must not also have run.
+    expect(client.retrieveFirstOutputImage).not.toHaveBeenCalled();
+    expect(hooks.onRunFinished).toHaveBeenCalledWith("image-to-image");
+  });
+
+  // Regression guard for a mistake this pipeline invites: a bare array payload
+  // typechecks (arrays are objects) but does not survive the document binding.
+  it("keeps a wrapped collection intact through the document binding", async () => {
+    const { controller } = createController();
+    const { client } = createFakeClient();
+
+    const result = await controller.runPipeline({
+      toolType: "image-to-image",
+      client,
+      workflow: {},
+      originatingDocument: origin,
+      ui: createUi(),
+      messages: MESSAGES,
+      retrieve: async () => ({ images: [{ filename: "a.png" }, { filename: "b.png" }] }),
+      commit: vi.fn()
+    });
+
+    expect(Array.isArray(result?.images)).toBe(true);
+    expect(result?.images).toHaveLength(2);
+    expect(result?.originatingDocument).toBe(origin);
+  });
+
+  it("still refuses to commit a multi-image run that was superseded", async () => {
+    const { controller } = createController();
+    const ui = createUi();
+    const commit = vi.fn();
+    const { client } = createFakeClient({
+      duringPoll: () => {
+        // A newer run takes ownership while this one is still polling.
+        controller.begin("upscale", { cancelPrompt: async () => "interrupted" as const }, "prompt-2");
+      }
+    });
+
+    const result = await controller.runPipeline({
+      toolType: "image-to-image",
+      client,
+      workflow: {},
+      originatingDocument: origin,
+      ui,
+      messages: MESSAGES,
+      retrieve: async () => ({ images: [{ blob: new Blob(["layer"]), filename: "layer-0.png" }] }),
+      commit
+    });
+
+    expect(result).toBeNull();
+    expect(commit).not.toHaveBeenCalled();
+  });
+
   it("gates live preview frames and diagnostics on run currency", async () => {
     const { controller } = createController();
     const ui = createUi();


### PR DESCRIPTION
Task 2 from `docs/unflatten-v0.20.0.md`. Pure logic -- no Photoshop surface, nothing in the
panel calls the multi-image path yet, so **there is nothing to smoke-test in Photoshop for
this PR**. What needs checking is that the existing tools are untouched, which the suite and
the notes below cover.

## Acceptance criteria

- [x] **A run returning N images yields N results in order.** `retrieveOutputImages` returns
      one result per image in ComfyUI's own order; the pipeline commits them intact.
- [x] **Every existing single-image tool behaves identically.** No existing call site changed
      -- not one line in `App.ts`, `livePainting.ts`, or any handler. 978 tests green (was
      967; +11 new). The single-image path still fetches exactly one image even when a run
      produced five.
- [x] **A4 and run-id gating untouched.** The pipeline is not duplicated; multi-image runs go
      through the same gates, and a new test asserts a superseded multi-image run cannot
      commit.

## How it avoids a second pipeline

`TImage` is what the client's single-image path returns; `TResult` is what a run commits.
They are the same for every existing tool, so `TResult` defaults to `TImage` and no existing
caller mentions either. A tool that needs something else supplies its own `retrieve`, and the
run gates, cancellation unwind and document binding stay one implementation. That was the
point -- A4 has to keep applying to multi-image runs, not be reimplemented beside them.

## One trap worth knowing about, found by a test

A bare array payload **typechecks** -- arrays are objects, so `TResult extends object` admits
them -- but does not survive `bindDocumentContext`, which binds by spreading:

```js
{ ...[a, b], originatingDocument }   // -> { 0: a, 1: b, originatingDocument }
```

No `length`, no `map`, and it still satisfies `DocumentContextBound`. So collections are
wrapped in `GeneratedImageSet`, and a regression test asserts the payload is still an array
on the far side of the binding. **This would have surfaced in task 3 as layers arriving in an
unusable shape.** `bindDocumentContext` itself is untouched -- it carries A1 and did not need
changing.

Also deliberate: `findImageOutputs` takes one node's whole batch rather than aggregating
across nodes. A graph with two SaveImage nodes would otherwise interleave two unrelated sets
into what the caller reads as layer order.

## Verified beyond the suite

The real `ComfyClient` was pointed at the running ComfyUI and pulled all five layers of an
actual layered run -- five distinct non-empty PNGs, correct MIME types, with
`retrieveFirstOutputImage` returning exactly the first of them. That check ran from a
temporary file and was deleted rather than committed; CI has no ComfyUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
