### PR TITLE
Task 3: import a decomposed stack as N layers in one transaction

### DIFF
--- a/docs/unflatten-gate-findings.md
+++ b/docs/unflatten-gate-findings.md
@@ -343,9 +343,36 @@ and seed 778 filled two, leaving layer 2 blank (0.0%, 21.4%, 23.6%). Both are go
 decompositions and both put the same kinds of thing on the same kinds of layer, back to
 front. But you cannot promise an artist four layers of content from `layers: 4`.
 
-**Consequence for task 3: blank layers must be skipped on import**, alongside the composite
-at index 0. Otherwise a run lands empty layers in the artist's document with no explanation,
-and it will read as a bug in the import rather than a property of the model.
+**Consequence for task 3: the composite at index 0 must be skipped.** Skipping *blank* layers
+was also stated here as a task 3 requirement, and that has since been qualified -- see below.
+
+### Skipping blank layers: wanted, deferred, and not by the obvious route
+
+Detecting a blank plate needs its alpha channel, and nothing in this codebase can decode a
+PNG. Captures run the other way, from Photoshop's pixels outward, and UXP has no canvas.
+
+The obvious cheap proxy is file size, on the reasoning that a blank plate compresses to
+nothing. **Measured across the 63 layers these runs produced, it does not:**
+
+| | Count | PNG size |
+| --- | --- | --- |
+| Blank (coverage under 1%) | 8 | 201 KB - 845 KB |
+| Populated | 55 | 243 KB - 2.3 MB |
+
+The ranges overlap almost completely, and the largest blank plate is bigger than most real
+ones. A blank layer is not uniform transparency: it carries ordinary RGB noise underneath a
+near-zero alpha, and that noise does not compress away. Any threshold that caught the blanks
+would also discard real layers.
+
+So task 3 imports every plate except the composite, and the failure it protects against is
+the asymmetric one: an unwanted empty layer is visible in the Layers panel and takes one
+click to delete, while a wrongly discarded faint layer is silent data loss. The layers are
+named by stacking position so an empty one is obvious rather than mysterious.
+
+Doing it properly needs a downsampled alpha read of each placed layer through the imaging
+API. That is a real option and not a large one, but it puts a pixel read inside the
+transaction that mutates the artist's document, and it is not worth that risk to save a
+click. Worth revisiting once the tool has been used on real work.
 
 ## Q8 -- addendum
 
@@ -389,7 +416,8 @@ problem the spike blamed on the model.
 - **Defaults: 640px, 4 layers.** Both are measured optima rather than round numbers.
 - **Do not offer 1024** (Q3). Worse separation, more blank layers, 3.5x the time.
 - **Cap layer count at 4** (Q2). Six pads with blanks.
-- **Task 3 must skip blank layers** as well as index 0 (Q7, Q8).
+- **Task 3 must skip the composite at index 0** (Q8). Skipping blank layers is deferred with
+  a measured reason -- file size cannot identify them and nothing here can decode a PNG (Q7).
 - **Task 3 needs the scale-to-target-bounds step** (Q5), enlarging direction only.
 - **Task 4 should detect and report the close-up failure** (Q1) rather than importing an
   empty layer. Comparing the background layer against the source is enough to catch it.

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -4,6 +4,7 @@ import { encodeRgbaPng } from "../utils/png";
 import { calculatePlacementOffset, createOpaqueGrayscaleMaskPng, PixelDimensions } from "./exactInpaintMask";
 import { OutpaintExpansionPlan } from "./outpaintExpansion";
 import { UpscaleResizePlan } from "./upscaleResize";
+import { planLayerScale, planUnflattenLayerStack, LayerScalePlan } from "./unflattenLayerStack";
 import {
   calculateCenteredOrigin,
   createPaddedSelectionBounds,
@@ -1313,6 +1314,306 @@ async function resizeCanvas(
       vertical: { _enum: "verticalLocation", _value: verticalAnchor },
       _options: { dialogOptions: "dontDisplay" }
     }],
+    {}
+  );
+}
+
+export type UnflattenLayerStackImportOptions = {
+  /**
+   * Every image the run returned, in ComfyUI's order. Index 0 is the flattened
+   * composite and is not imported; see planUnflattenLayerStack.
+   */
+  images: readonly { blob: Blob }[];
+  originatingDocument: PhotoshopDocumentIdentity | null;
+  /**
+   * Where the source layer sat. Every plate is scaled and aligned to this, so
+   * the stack lands back over the region it was decomposed from. Absent means
+   * the capture could not report bounds, and the stack centres instead.
+   */
+  targetBounds?: NormalizedSelectionBounds;
+  /** The captured layer's name; the group is named after it. */
+  sourceName?: string;
+  onProgress?: ImportProgress;
+};
+
+export type UnflattenLayerStackImportResult = {
+  groupName: string;
+  layerNames: string[];
+};
+
+/**
+ * Imports a decomposed layer stack into the artist's document: N plates, back
+ * to front, each scaled and aligned to the region the source was captured
+ * from, all inside one layer group named after that source.
+ *
+ * Three things here are not shared with any other import in this file.
+ *
+ * **It is the only import that places more than once.** Every placement mutates
+ * the document, so the failure this has to survive is a partial one -- three
+ * plates down of five when something goes wrong. The whole sequence runs inside
+ * a single suspended history state, so `resumeHistory(id, false)` undoes every
+ * placement, rename, transform and the group in one step (A3). The deletions
+ * before it are belt and braces for a host that cannot suspend history at all.
+ *
+ * **It is the only import that scales.** `placeEvent` shrinks an oversized
+ * image to fit the canvas and never enlarges a small one, and
+ * `alignActiveLayerToBounds` beside it only translates -- so a 640px plate
+ * would otherwise sit at a fraction of its size in the corner of the region it
+ * came from. Measured rather than assumed: docs/unflatten-gate-findings.md, Q5.
+ *
+ * **It is the only import that carries alpha.** Nothing here had moved an alpha
+ * channel before; captures run `applyAlpha: false` and every import to date was
+ * opaque RGB. The bytes are never decoded on the way through -- ComfyUI's PNG
+ * reaches `placeEvent` untouched -- and Place preserves transparency, both
+ * verified before this was written.
+ */
+export async function importUnflattenLayerStack(
+  options: UnflattenLayerStackImportOptions
+): Promise<UnflattenLayerStackImportResult> {
+  const photoshop = getPhotoshop();
+  const files: UxpFile[] = [];
+
+  try {
+    assertActiveDocumentMatchesOrigin(photoshop, options.originatingDocument);
+
+    const plan = planUnflattenLayerStack({
+      imageCount: options.images.length,
+      sourceName: options.sourceName
+    });
+
+    for (const placement of plan.placements) {
+      const image = options.images[placement.imageIndex];
+
+      if (!image?.blob || image.blob.size === 0) {
+        throw new Error(`The decomposed image for ${placement.layerName} is empty.`);
+      }
+    }
+
+    // Every temporary file and token is created before the modal scope opens,
+    // matching the single-image imports: a failure while writing files must not
+    // happen with the artist's document already half-mutated.
+    const uxp = getUxp();
+    const tokens: string[] = [];
+    const stamp = Date.now();
+
+    for (const placement of plan.placements) {
+      options.onProgress?.(`Saving ${placement.layerName} to a temporary PNG...`);
+      const file = await saveBlobToTemporaryFile(
+        options.images[placement.imageIndex].blob,
+        `OpenLayer_Unflatten_${stamp}_${placement.depth}.png`
+      );
+      files.push(file);
+      tokens.push(await uxp.storage.localFileSystem.createSessionToken(file));
+    }
+
+    const layerNames: string[] = [];
+
+    await photoshop.core.executeAsModal(
+      async (executionContext) => {
+        assertActiveDocumentMatchesOrigin(photoshop, options.originatingDocument);
+        const transactionDocument = getActiveDocument();
+        const previousLayerId = transactionDocument.activeLayers?.[0]?.id;
+
+        const hostControl = executionContext?.hostControl;
+        const canSuspendHistory = typeof transactionDocument.id === "number" &&
+          typeof hostControl?.suspendHistory === "function" &&
+          typeof hostControl?.resumeHistory === "function";
+        const suspensionId = canSuspendHistory
+          ? await hostControl!.suspendHistory!({
+            documentID: transactionDocument.id!,
+            name: "OpenLayer Unflatten Import"
+          })
+          : null;
+
+        const placedLayerIds: number[] = [];
+        let operationError: unknown;
+
+        try {
+          for (const placement of plan.placements) {
+            // Re-checked every iteration rather than once at the end. This loop
+            // mutates the document repeatedly, and a document switched
+            // underneath it halfway would otherwise scatter plates across two
+            // documents before anything noticed (A1).
+            assertActiveDocumentMatchesOrigin(photoshop, options.originatingDocument);
+
+            options.onProgress?.(`Placing ${placement.layerName}...`);
+            await placeFileAsLayer(photoshop, tokens[placement.depth - 1]);
+
+            const placedLayerId = getActiveDocument().activeLayers?.[0]?.id;
+            if (placedLayerId === undefined) {
+              throw new Error(`Photoshop did not expose a layer ID for ${placement.layerName}.`);
+            }
+            placedLayerIds.push(placedLayerId);
+
+            await renameActiveLayer(photoshop, placement.layerName);
+            await fitActiveLayerToBounds(photoshop, options.targetBounds);
+            layerNames.push(placement.layerName);
+          }
+
+          assertActiveDocumentMatchesOrigin(photoshop, options.originatingDocument);
+          options.onProgress?.(`Grouping ${plan.placements.length} layers into ${plan.groupName}...`);
+          await selectLayersByIds(photoshop, placedLayerIds);
+          await groupSelectedLayers(photoshop, plan.groupName);
+        } catch (caughtError) {
+          operationError = caughtError;
+        }
+
+        if (operationError) {
+          // Reverse order so each delete targets a layer nothing else sits on.
+          for (const layerId of [...placedLayerIds].reverse()) {
+            await deleteLayerById(photoshop, layerId, true);
+          }
+
+          if (previousLayerId !== undefined) {
+            await selectLayerById(photoshop, previousLayerId, true);
+          }
+        }
+
+        if (suspensionId !== null) {
+          await hostControl!.resumeHistory!(suspensionId, !operationError);
+        }
+
+        if (operationError) {
+          const revertNote = suspensionId !== null
+            ? " The document was returned to its state before the import."
+            : " Undo (Ctrl+Z) removes any layers that were already placed.";
+          throw new Error(`${getErrorMessage(operationError)}${revertNote}`);
+        }
+      },
+      { commandName: "Import OpenLayer Unflatten Layers" }
+    );
+
+    options.onProgress?.(`Imported ${layerNames.length} layers into ${plan.groupName}.`);
+    return { groupName: plan.groupName, layerNames };
+  } catch (caughtError) {
+    throw createOpenLayerError(
+      "PHOTOSHOP_IMPORT_FAILED",
+      `Could not import the decomposed layers. ${getErrorMessage(caughtError)}`
+    );
+  } finally {
+    for (const file of files) {
+      await deleteTemporaryFileBestEffort(file);
+    }
+  }
+}
+
+/**
+ * Scales the active layer to the captured region and then moves it there.
+ *
+ * Scale before align, always: the transform is anchored on the layer's own
+ * centre, so it moves the layer as a side effect, and aligning first would be
+ * undone by it.
+ */
+async function fitActiveLayerToBounds(
+  photoshop: PhotoshopModule,
+  targetBounds?: NormalizedSelectionBounds
+) {
+  if (!targetBounds) {
+    await centerActiveLayerOnCanvas(photoshop);
+    return;
+  }
+
+  const placedBounds = await readActiveLayerBounds(photoshop);
+  const scale = planLayerScale(placedBounds, targetBounds);
+
+  if (scale) {
+    await scaleActiveLayer(photoshop, scale);
+  }
+
+  await alignActiveLayerToBounds(photoshop, targetBounds);
+}
+
+async function scaleActiveLayer(photoshop: PhotoshopModule, scale: LayerScalePlan) {
+  await photoshop.action.batchPlay(
+    [
+      {
+        _obj: "transform",
+        _target: [
+          {
+            _ref: "layer",
+            _enum: "ordinal",
+            _value: "targetEnum"
+          }
+        ],
+        freeTransformCenterState: {
+          _enum: "quadCenterState",
+          _value: "QCSAverage"
+        },
+        offset: {
+          _obj: "offset",
+          horizontal: { _unit: "pixelsUnit", _value: 0 },
+          vertical: { _unit: "pixelsUnit", _value: 0 }
+        },
+        width: { _unit: "percentUnit", _value: scale.horizontalPercent },
+        height: { _unit: "percentUnit", _value: scale.verticalPercent },
+        interfaceIconFrameDimmed: {
+          _enum: "interpolationType",
+          _value: "bicubic"
+        },
+        _options: {
+          dialogOptions: "dontDisplay"
+        }
+      }
+    ],
+    {}
+  );
+}
+
+async function selectLayersByIds(photoshop: PhotoshopModule, layerIds: readonly number[]) {
+  if (layerIds.length === 0) throw new Error("No placed layers to group.");
+
+  await selectLayerById(photoshop, layerIds[0], false);
+
+  for (const layerId of layerIds.slice(1)) {
+    await photoshop.action.batchPlay(
+      [
+        {
+          _obj: "select",
+          _target: [
+            {
+              _ref: "layer",
+              _id: layerId
+            }
+          ],
+          selectionModifier: {
+            _enum: "selectionModifierType",
+            _value: "addToSelection"
+          },
+          makeVisible: false,
+          _options: {
+            dialogOptions: "dontDisplay"
+          }
+        }
+      ],
+      {}
+    );
+  }
+}
+
+async function groupSelectedLayers(photoshop: PhotoshopModule, groupName: string) {
+  await photoshop.action.batchPlay(
+    [
+      {
+        _obj: "make",
+        _target: [
+          {
+            _ref: "layerSection"
+          }
+        ],
+        from: {
+          _ref: "layer",
+          _enum: "ordinal",
+          _value: "targetEnum"
+        },
+        using: {
+          _obj: "layerSection",
+          name: groupName
+        },
+        _options: {
+          dialogOptions: "dontDisplay"
+        }
+      }
+    ],
     {}
   );
 }

--- a/src/photoshop/unflattenLayerStack.ts
+++ b/src/photoshop/unflattenLayerStack.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure planning for the Unflatten import: which of a run's images become
+ * Photoshop layers, in what order, under what names, and how much each has to
+ * be scaled to sit back over the region it came from.
+ *
+ * All of this is host-free on purpose. The adapter half cannot be tested
+ * outside Photoshop, so everything that can be decided without Photoshop is
+ * decided here instead.
+ */
+
+export type UnflattenLayerPlacement = Readonly<{
+  /** Index into the run's images, in ComfyUI's output order. */
+  imageIndex: number;
+  /** 1 is the backmost layer. Placement happens in this order. */
+  depth: number;
+  layerName: string;
+}>;
+
+export type UnflattenStackPlan = Readonly<{
+  groupName: string;
+  /** Back to front. Placing in this order leaves the frontmost layer on top. */
+  placements: readonly UnflattenLayerPlacement[];
+}>;
+
+export type UnflattenStackPlanInput = Readonly<{
+  /** How many images the run returned, composite included. */
+  imageCount: number;
+  /** The captured layer's name, used to name the group after its source. */
+  sourceName?: string;
+}>;
+
+/**
+ * The graph returns `layers + 1` images. Index 0 is the flattened composite --
+ * the whole picture, opaque -- and the layers run back-to-front from index 1.
+ * Measured over twenty runs; see docs/unflatten-gate-findings.md, Q8.
+ *
+ * Importing index 0 would stack a flat copy of the entire picture over the
+ * group and read as an import bug rather than a misunderstood contract, so it
+ * is dropped here, once, where a test can hold it still.
+ */
+export const UNFLATTEN_COMPOSITE_INDEX = 0;
+
+export function planUnflattenLayerStack(input: UnflattenStackPlanInput): UnflattenStackPlan {
+  const layerCount = input.imageCount - 1;
+
+  if (!Number.isInteger(input.imageCount) || layerCount < 1) {
+    throw new Error(
+      `An Unflatten run must return a composite plus at least one layer; it returned ${input.imageCount} image(s).`
+    );
+  }
+
+  const placements: UnflattenLayerPlacement[] = [];
+
+  for (let depth = 1; depth <= layerCount; depth += 1) {
+    placements.push({
+      imageIndex: UNFLATTEN_COMPOSITE_INDEX + depth,
+      depth,
+      layerName: formatLayerName(depth, layerCount)
+    });
+  }
+
+  return {
+    groupName: formatGroupName(input.sourceName),
+    placements
+  };
+}
+
+function formatLayerName(depth: number, layerCount: number) {
+  if (layerCount === 1) return "Layer 1";
+  if (depth === 1) return "Layer 1 (back)";
+  if (depth === layerCount) return `Layer ${depth} (front)`;
+  return `Layer ${depth}`;
+}
+
+function formatGroupName(sourceName?: string) {
+  const trimmed = sourceName?.trim();
+
+  return trimmed ? `Unflatten ${trimmed}` : "Unflatten";
+}
+
+export type LayerScalePlan = Readonly<{
+  horizontalPercent: number;
+  verticalPercent: number;
+}>;
+
+/**
+ * How much a placed layer has to grow to cover the region it was captured from.
+ *
+ * This exists because of a measured Photoshop behaviour rather than a
+ * preference. `placeEvent` shrinks an oversized image to fit the canvas and
+ * **never enlarges a small one**, and the aligner beside it only translates.
+ * The graph caps its output at 640px on the long side, so a layer captured from
+ * a large document comes back a fraction of the size it has to occupy and
+ * nothing on the existing import path would grow it. See
+ * docs/unflatten-gate-findings.md, Q5.
+ *
+ * Returns null when no transform is warranted: identical size, or a degenerate
+ * measurement that would produce a nonsense scale. Callers skip the transform
+ * rather than applying 100%, because a no-op transform is still a history step
+ * and still resamples.
+ */
+export function planLayerScale(
+  placed: { width: number; height: number },
+  target: { width: number; height: number }
+): LayerScalePlan | null {
+  if (!isPositiveFinite(placed.width) || !isPositiveFinite(placed.height)) return null;
+  if (!isPositiveFinite(target.width) || !isPositiveFinite(target.height)) return null;
+
+  const horizontalPercent = (target.width / placed.width) * 100;
+  const verticalPercent = (target.height / placed.height) * 100;
+
+  // Sub-pixel differences are the VAE's rounding, not a scale anyone asked for.
+  if (isEffectivelyUnscaled(horizontalPercent) && isEffectivelyUnscaled(verticalPercent)) {
+    return null;
+  }
+
+  return { horizontalPercent, verticalPercent };
+}
+
+function isEffectivelyUnscaled(percent: number) {
+  return Math.abs(percent - 100) < 0.1;
+}
+
+function isPositiveFinite(value: number) {
+  return Number.isFinite(value) && value > 0;
+}

--- a/tests/photoshop/unflattenLayerStack.test.ts
+++ b/tests/photoshop/unflattenLayerStack.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  planLayerScale,
+  planUnflattenLayerStack,
+  UNFLATTEN_COMPOSITE_INDEX
+} from "../../src/photoshop/unflattenLayerStack";
+
+describe("planUnflattenLayerStack", () => {
+  it("drops the composite and keeps every layer after it", () => {
+    // A layers: 4 run returns five images.
+    const plan = planUnflattenLayerStack({ imageCount: 5, sourceName: "Photo" });
+
+    expect(plan.placements.map((placement) => placement.imageIndex)).toEqual([1, 2, 3, 4]);
+    expect(plan.placements.some((placement) => placement.imageIndex === UNFLATTEN_COMPOSITE_INDEX)).toBe(false);
+  });
+
+  it("places back to front, so the frontmost layer ends up on top", () => {
+    const plan = planUnflattenLayerStack({ imageCount: 4 });
+
+    expect(plan.placements.map((placement) => placement.depth)).toEqual([1, 2, 3]);
+    // Placement order is the array order; depth 1 goes down first.
+    expect(plan.placements[0].imageIndex).toBe(1);
+    expect(plan.placements[plan.placements.length - 1].imageIndex).toBe(3);
+  });
+
+  it("names the ends of the stack so the order is legible in the Layers panel", () => {
+    const plan = planUnflattenLayerStack({ imageCount: 5 });
+
+    expect(plan.placements.map((placement) => placement.layerName)).toEqual([
+      "Layer 1 (back)",
+      "Layer 2",
+      "Layer 3",
+      "Layer 4 (front)"
+    ]);
+  });
+
+  it("does not label a single layer as back or front", () => {
+    const plan = planUnflattenLayerStack({ imageCount: 2 });
+
+    expect(plan.placements.map((placement) => placement.layerName)).toEqual(["Layer 1"]);
+  });
+
+  it("names the group after the captured layer, and falls back when there is no name", () => {
+    expect(planUnflattenLayerStack({ imageCount: 3, sourceName: "Background copy" }).groupName).toBe(
+      "Unflatten Background copy"
+    );
+    expect(planUnflattenLayerStack({ imageCount: 3, sourceName: "   " }).groupName).toBe("Unflatten");
+    expect(planUnflattenLayerStack({ imageCount: 3 }).groupName).toBe("Unflatten");
+  });
+
+  it("refuses a run that returned nothing to import", () => {
+    // One image is the composite alone: nothing was separated.
+    expect(() => planUnflattenLayerStack({ imageCount: 1 })).toThrow(/composite plus at least one layer/);
+    expect(() => planUnflattenLayerStack({ imageCount: 0 })).toThrow(/composite plus at least one layer/);
+  });
+});
+
+describe("planLayerScale", () => {
+  it("grows a 640px result back onto the region it was captured from", () => {
+    // The case Q5 found: placeEvent never enlarges, and the aligner only moves.
+    const plan = planLayerScale({ width: 640, height: 424 }, { width: 3840, height: 2544 });
+
+    expect(plan?.horizontalPercent).toBeCloseTo(600, 5);
+    expect(plan?.verticalPercent).toBeCloseTo(600, 5);
+  });
+
+  it("scales each axis independently when the aspect ratio drifted", () => {
+    const plan = planLayerScale({ width: 640, height: 400 }, { width: 1280, height: 1200 });
+
+    expect(plan?.horizontalPercent).toBeCloseTo(200, 5);
+    expect(plan?.verticalPercent).toBeCloseTo(300, 5);
+  });
+
+  it("returns null when the layer is already the right size", () => {
+    expect(planLayerScale({ width: 1024, height: 768 }, { width: 1024, height: 768 })).toBeNull();
+  });
+
+  it("ignores sub-pixel rounding rather than resampling for nothing", () => {
+    expect(planLayerScale({ width: 1000, height: 1000 }, { width: 1000.4, height: 999.6 })).toBeNull();
+  });
+
+  it("returns null for degenerate measurements instead of a nonsense scale", () => {
+    expect(planLayerScale({ width: 0, height: 100 }, { width: 500, height: 500 })).toBeNull();
+    expect(planLayerScale({ width: 100, height: 100 }, { width: 0, height: 500 })).toBeNull();
+    expect(planLayerScale({ width: Number.NaN, height: 100 }, { width: 500, height: 500 })).toBeNull();
+    expect(planLayerScale({ width: 100, height: 100 }, { width: Number.POSITIVE_INFINITY, height: 5 })).toBeNull();
+  });
+
+  it("shrinks as well, so a result larger than its target is not left oversized", () => {
+    const plan = planLayerScale({ width: 2000, height: 2000 }, { width: 1000, height: 1000 });
+
+    expect(plan?.horizontalPercent).toBeCloseTo(50, 5);
+  });
+});


### PR DESCRIPTION
Task 3 from `docs/unflatten-v0.20.0.md`. Host-touching, carries A1 and A3.

## ⚠️ This cannot be smoke-tested yet, and I don't think it should be merged yet

Nothing calls `importUnflattenLayerStack` — task 4 builds the button. So the click-path below
is **written and ready but not runnable today**, and merging this now would mean merging
host-touching code before your check, which is the one thing the protocol says never to do.

**My recommendation: leave this open until task 4 is ready, then smoke-test both together
and merge in order.** The alternative is merging on the strength of the pure tests alone,
which I'd rather not do for the function that mutates your document. Your call.

## What it does

N plates, back to front, each scaled and aligned to the region the source was captured from,
all inside one group named after that source.

Three things are unique to this import:

- **It places more than once**, so the failure it must survive is partial — three plates down
  of five. The whole sequence runs inside one suspended history state (the outpaint import's
  mechanism), so `resumeHistory(id, false)` undoes every placement, rename, transform and the
  group in one step. Explicit layer deletions run first as belt and braces for a host that
  cannot suspend history at all.
- **It scales**, which no other import does. `placeEvent` never enlarges and the aligner only
  translates, so a 640px plate would otherwise sit at a fraction of its size in the corner of
  its own region (Q5). Scale runs *before* align because the transform is centre-anchored and
  moves the layer as a side effect.
- **It carries alpha**, which nothing here had done before.

**A1:** document identity is re-asserted **every iteration**, not once at the end — a loop
that mutates repeatedly can have the document switched underneath it halfway, and checking
only at the end notices after plates are already scattered across two documents.

Everything decidable without Photoshop lives in `unflattenLayerStack.ts` with 12 tests:
which images become layers, in what order, under what names, and the scale each needs.

## Blank-layer skipping: deferred, with the measurement that changed my mind

I told you task 3 would skip blank layers. It doesn't, and the findings doc now records why.

File size cannot identify a blank plate. Across the 63 layers the gate produced:

| | Count | PNG size |
|---|---|---|
| Blank (coverage <1%) | 8 | 201 KB – 845 KB |
| Populated | 55 | 243 KB – 2.3 MB |

The ranges overlap almost entirely and the largest blank is bigger than most real layers — a
blank plate isn't uniform transparency, it carries RGB noise under near-zero alpha that
doesn't compress away. Nothing in this codebase can decode a PNG to check properly (no canvas
in UXP). The asymmetry decides it: an unwanted empty layer is visible and one click to
delete; a wrongly discarded faint layer is silent data loss.

## Smoke checklist — for after task 4 lands

Setup: open a photo with a clear subject on visible ground (a person on a bench, not a
close-up). Note the layer's name. **Window > History** open so you can watch the transaction.

1. Select the photo layer. Unflatten with **4 layers**. Wait ~2 min.
2. **Layers panel:** one new group named `Unflatten <your layer name>`, sitting **above** the
   source layer. Inside it: `Layer 1 (back)`, `Layer 2`, `Layer 3`, `Layer 4 (front)`.
3. **History panel:** exactly **one** entry, `OpenLayer Unflatten Import` — not four
   placements. That's the transaction.
4. Click `Layer 4 (front)`. Its thumbnail shows a **checkerboard**, not white.
5. Hide every layer except `Layer 4 (front)`. The canvas shows the subject on the document
   background showing through — transparency is real.
6. Show all again. Pick `Layer 4 (front)` and drag it ~10% of the frame to the right. What's
   revealed underneath should be background, not a hole and not a second copy of the subject.
7. Each layer covers the **same area as the original photo layer** — not a small copy in a
   corner. This is the scaling step; if it failed you'll see it immediately.
8. `Ctrl+Z` **once**. The entire group disappears in one undo, document back as it was.

Failure path (the one that matters): with the panel busy importing, **switch to another
document** mid-import. Expected: the import fails with a message, and your original document
has **no** partial group and no stray layers.

## Validation

`npm run typecheck`, `npm test` (990, +12), `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
