### PR TITLE
Tasks 5 and 6: Setup coverage and the tenth bridged tool

### DIFF
--- a/bridge/smoke.mjs
+++ b/bridge/smoke.mjs
@@ -22,6 +22,7 @@
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
+import { MCP_TOOLS } from "./src/tools.mjs";
 
 // Deliberately not the default 8199: this must not fight a hub the developer
 // already has running for a real Photoshop session.
@@ -125,18 +126,13 @@ send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
 const list = await waitFor(2, "tools/list");
 const toolNames = (list.result?.tools ?? []).map((tool) => tool.name).sort();
 check(
-  "exposes get_panel_state and all seven generation tools",
+  // Sorted, and derived from MCP_TOOLS rather than retyped. The hand-written
+  // list this replaces went stale when style_reference landed in v0.18 and
+  // again when multi_reference landed in v0.19, so this check sat red for two
+  // releases while still reading as a meaningful assertion.
+  `exposes get_panel_state and all ${MCP_TOOLS.length} generation tools`,
   toolNames.join(",") ===
-    [
-      "get_panel_state",
-      "image_to_image",
-      "inpaint",
-      "outpaint",
-      "prompt_from_layer",
-      "sketch_to_image",
-      "text_to_image",
-      "upscale"
-    ].join(","),
+    ["get_panel_state", ...MCP_TOOLS.map((tool) => tool.name)].sort().join(","),
   toolNames.join(",")
 );
 

--- a/bridge/src/protocol.mjs
+++ b/bridge/src/protocol.mjs
@@ -49,7 +49,8 @@ export const AGENT_TOOLS = [
   "upscale",
   "prompt_from_layer",
   "style_reference",
-  "multi_reference"
+  "multi_reference",
+  "unflatten"
 ];
 
 const FRAME_TYPES = new Set(["hello", "welcome", "command", "result", "event", "state", "ask"]);

--- a/bridge/src/tools.mjs
+++ b/bridge/src/tools.mjs
@@ -163,6 +163,30 @@ export const STYLE_REFERENCE_SCHEMA = {
  * denoise is fixed at 1, so offering either would let an agent set a value the
  * workflow then ignores.
  */
+/**
+ * No cfg, width, height or denoise. The latent is sized from the captured
+ * source and the graph takes an existing picture apart rather than re-sampling
+ * it, so those parameters have nothing to set; cfg is fixed at 2.5 as part of
+ * the technique. layerCount is capped at the range the gate measured.
+ */
+export const UNFLATTEN_SCHEMA = {
+  prompt,
+  workflow,
+  checkpoint,
+  layerCount: z
+    .number()
+    .int()
+    .min(2)
+    .max(4)
+    .optional()
+    .describe(
+      "How many layers to separate into. Four is the measured best setting; two fuses distinct " +
+      "objects into one layer and more than four returns empty ones."
+    ),
+  steps,
+  seed
+};
+
 export const MULTI_REFERENCE_SCHEMA = {
   prompt,
   negativePrompt,
@@ -273,6 +297,23 @@ export const MCP_TOOLS = [
       "a specific person in a picture. The first reference sets the output size. Only the " +
       "parameters you pass are changed. Returns the panel's own status message.",
     schema: MULTI_REFERENCE_SCHEMA,
+    timeoutMs: GENERATION_TIMEOUT_MS
+  },
+  {
+    name: "unflatten",
+    title: "Unflatten",
+    description:
+      "Split the flat layer already captured in the OpenLayer panel into separate layers with " +
+      "real transparency, and import them into the open Photoshop document in stacking order. " +
+      "Requires that layer captured in the panel first \u2014 this tool cannot capture it. " +
+      "It needs a picture with something standing in front of something else: a close-up that " +
+      "fills the frame has no front and back to find and comes back unseparated, whether it is " +
+      "a photograph or a generated image. The number of layers requested is a ceiling rather " +
+      "than a promise, so some may come back empty. Results are re-rendered at 640px on the " +
+      "long side, so layers are softer than the original on a large document. Takes about two " +
+      "minutes. Only the parameters you pass are changed. Returns the panel's own status " +
+      "message.",
+    schema: UNFLATTEN_SCHEMA,
     timeoutMs: GENERATION_TIMEOUT_MS
   }
 ];

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -664,7 +664,8 @@ export function renderApp(rootElement: HTMLElement) {
       "upscale",
       "prompt_from_layer",
       "style_reference",
-      "multi_reference"
+      "multi_reference",
+      "unflatten"
     ] as const) {
       agentBridge.publishCapability(toolId, { canRun: !isBusy, reason });
     }
@@ -1009,6 +1010,28 @@ export function renderApp(rootElement: HTMLElement) {
           : ""
     });
 
+    agentBridge.register("unflatten", {
+      run: handleGenerateUnflatten,
+      fields: {
+        prompt: elements.unflattenPrompt,
+        workflow: elements.unflattenWorkflow,
+        checkpoint: elements.unflattenCheckpoint,
+        layerCount: elements.unflattenLayerCount,
+        steps: elements.unflattenSteps,
+        seed: elements.unflattenSeed
+      },
+      leadingParams: ["workflow"],
+      statusText: elements.unflattenStatusText,
+      statusPill: elements.unflattenStatusPill,
+      errorText: elements.unflattenErrorMessage,
+      // The status line reports how many layers came back, which is the one
+      // number an agent needs and cannot see. Whether they are populated is not
+      // knowable here -- see docs/unflatten-gate-findings.md, Q7 -- so this
+      // does not claim it.
+      describeResult: () =>
+        unflattenResult ? `Returned ${Math.max(unflattenResult.images.length - 1, 0)} layers.` : ""
+    });
+
     agentBridge.register("style_reference", {
       run: handleGenerateStyleReference,
       fields: {
@@ -1232,6 +1255,10 @@ export function renderApp(rootElement: HTMLElement) {
     });
     importBridge.publishCapability("multi-reference", {
       canImport: canImport(multiReferenceResult),
+      auto: null
+    });
+    importBridge.publishCapability("unflatten", {
+      canImport: Boolean(unflattenResult),
       auto: null
     });
     // Live Painting's import button is gated on liveLastResult by hand rather

--- a/src/ui/agentProtocol.ts
+++ b/src/ui/agentProtocol.ts
@@ -33,7 +33,8 @@ export const AGENT_TOOL_IDS = [
   "upscale",
   "prompt_from_layer",
   "style_reference",
-  "multi_reference"
+  "multi_reference",
+  "unflatten"
 ] as const;
 
 export type AgentToolId = (typeof AGENT_TOOL_IDS)[number];

--- a/tests/comfy/unflattenSetup.test.ts
+++ b/tests/comfy/unflattenSetup.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { evaluateSetupRequirements } from "../../src/comfy/setupRequirements";
+import { rankPresetsByVramOutlook } from "../../src/comfy/presetFootprint";
+import { getWorkflowPreset } from "../../src/comfy/presetRegistry";
+
+const PLUGIN_VERSION = "0.20.0";
+const TWELVE_GB = 12 * 1024 ** 3;
+
+function unflattenModels() {
+  const report = evaluateSetupRequirements({ pluginVersion: PLUGIN_VERSION });
+
+  return report.models.filter((model) => model.usedByPresets.includes("unflatten-qwen-layered"));
+}
+
+describe("Unflatten setup requirements", () => {
+  it("lists all three models in the folders their loaders actually read", () => {
+    const byName = new Map(unflattenModels().map((model) => [model.modelName, model]));
+
+    expect(byName.size).toBe(3);
+    // The wrong-folder mistake is this project's most common setup failure and
+    // it fails silently, as "model not found".
+    expect(byName.get("qwen_image_layered_fp8mixed.safetensors")?.targetFolder).toBe("diffusion_models");
+    expect(byName.get("qwen_2.5_vl_7b_fp8_scaled.safetensors")?.targetFolder).toBe("text_encoders");
+    expect(byName.get("qwen_image_layered_vae.safetensors")?.targetFolder).toBe("vae");
+  });
+
+  it("carries real sizes, so the download total is not a guess", () => {
+    const byName = new Map(unflattenModels().map((model) => [model.modelName, model.sizeBytes]));
+
+    // Content-Length observed against the live URLs; a missing size would let
+    // the preset be rated "Comfortable" on a technicality.
+    expect(byName.get("qwen_image_layered_fp8mixed.safetensors")).toBe(20533591821);
+    expect(byName.get("qwen_2.5_vl_7b_fp8_scaled.safetensors")).toBe(9384670680);
+    expect(byName.get("qwen_image_layered_vae.safetensors")).toBe(253816616);
+  });
+
+  it("warns about the layered VAE in the entry itself", () => {
+    const vae = unflattenModels().find((model) => model.modelName === "qwen_image_layered_vae.safetensors");
+
+    // qwen_image_vae.safetensors is Krea-2's and sits in the same folder. The
+    // names differ by one word and the wrong one loads far enough to fail
+    // confusingly rather than obviously, so the hint has to say so where
+    // someone is actually reading it.
+    expect(vae?.setupHint).toContain("not qwen_image_vae.safetensors");
+  });
+
+  it("does not send anyone to the layered repo for the text encoder", () => {
+    const encoder = unflattenModels().find((model) => model.modelName === "qwen_2.5_vl_7b_fp8_scaled.safetensors");
+
+    // The layered repository has no text_encoders folder at all, which is what
+    // sends people looking in the wrong place.
+    expect(encoder?.downloadUrl).toContain("Qwen-Image_ComfyUI");
+    expect(encoder?.downloadUrl).not.toContain("Qwen-Image-Layered");
+  });
+
+  it("rates the preset honestly against 12 GB rather than optimistically", () => {
+    const outlook = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      vramTotalBytes: TWELVE_GB
+    }).find((entry) => entry.presetId === "unflatten-qwen-layered");
+
+    // 19.1 GB resident against 12 GB of VRAM. "Will offload" is the honest
+    // answer and it means slower, not broken -- which is what the note says.
+    expect(outlook?.expectation).toBe("offloads");
+    expect(outlook?.expectationLabel).toBe("Will offload");
+    expect(outlook?.confidence).toBe("complete");
+    expect(outlook?.unknownSizeCount).toBe(0);
+  });
+
+  it("shares no file with any other preset, which is what makes it a 28.1 GB addition", () => {
+    const outlook = rankPresetsByVramOutlook({
+      pluginVersion: PLUGIN_VERSION,
+      vramTotalBytes: TWELVE_GB
+    }).find((entry) => entry.presetId === "unflatten-qwen-layered");
+
+    // Not the largest preset TOTAL -- the Flux Fill stack is heavier at 38.4 GB
+    // -- but the largest addition, because every byte of that stack is already
+    // shared with other presets and none of these three are. Someone who has
+    // everything else installed still downloads all 28.1 GB for this one.
+    expect(outlook?.formattedTotal).toBe("28.1 GB");
+
+    for (const model of unflattenModels()) {
+      expect(model.usedByPresets).toEqual(["unflatten-qwen-layered"]);
+    }
+  });
+
+  it("keeps the preset's own models and its registry stack in step", () => {
+    const preset = getWorkflowPreset("unflatten-qwen-layered");
+
+    expect(preset.requiredModels?.map((model) => model.modelName).sort()).toEqual(
+      preset.modelStack?.map((model) => model.modelName).sort()
+    );
+  });
+});


### PR DESCRIPTION
Tasks 5 and 6 from `docs/unflatten-v0.20.0.md`. Validation green: typecheck, 1003 tests
(+7), build, eslint, and the bridge smoke suite at **8/8**.

## Task 5 was already done by task 1

Setup is derived from the preset registry rather than maintained beside it, so task 1's
entries flowed straight through. Verified rather than assumed:

| Model | Folder | Size |
|---|---|---|
| `qwen_image_layered_fp8mixed.safetensors` | `diffusion_models` | 19.1 GB |
| `qwen_2.5_vl_7b_fp8_scaled.safetensors` | `text_encoders` | 8.7 GB |
| `qwen_image_layered_vae.safetensors` | `vae` | 242 MB |

The layered-VAE warning is in the entry itself, and "What will run well" reports
**Will offload** — 19.1 GB resident against 12 GB of VRAM, with `confidence: complete` and
no unpublished sizes, so it can't be rated Comfortable on a technicality.

What was missing was anything holding that still, so this adds the test. **One of its
assertions was wrong and the test caught it**: 28.1 GB is not the largest preset total —
Flux Fill is heavier at 38.4 GB. It's the largest *addition*, because every byte of those
three files is unshared. The test now asserts the true claim, including that each model is
used by exactly one preset.

## Task 6: tenth bridged tool

Same boundary as the other nine — an agent can set parameters and press the button, and
cannot capture the source. **Acceptance met:** the capability rides the existing
`syncAgentBridge` snapshot rather than a second gate in the handler.

The tool description carries what the gate found, the way `multi_reference` carries its
likeness limit: a close-up comes back unseparated whatever it was made by; the layer count
is a ceiling rather than a promise, so some layers may be empty; results are re-rendered at
640px and are softer than the original on a large document. That's the only warning an agent
gets, for the same reason the panel has only copy — the failure cannot be detected.

Schema is `prompt, workflow, checkpoint, layerCount (2–4), steps, seed`. No cfg, width,
height or denoise, matching the panel.

## A pre-existing red check, fixed

The bridge smoke test froze its tool list **by hand**, and it went stale when
`style_reference` landed in v0.18 and again when `multi_reference` landed in v0.19. It has
been failing for two releases while still reading as a meaningful assertion — I only noticed
because my change made it fail differently.

It now derives from `MCP_TOOLS`, so it cannot go stale again. **8/8 passing.**

## Smoke checklist

No new Photoshop surface — the panel screen is unchanged from #100. Worth a look if you want:

1. Setup screen → all three Qwen models listed, correct folders, sizes as above.
2. The layered VAE row warns it is not `qwen_image_vae.safetensors`.
3. "What will run well" → Unflatten reads **Will offload**.
4. With the hub running and Agent Bridge on, an agent's `tools/list` shows `unflatten`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
