### PR TITLE
Task 7: the write-up, the honest limits, and the version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.20.0-alpha - 2026-08-30
+
+This release adds Unflatten: hand the panel a flat layer and get the picture back as separate layers with real transparency, imported into the open document in stacking order. Nothing else in this space puts a decomposed layer stack into a host application, and that is the whole point of building it here rather than anywhere else.
+
+Before any of the screen existed, eight questions about how the technique actually behaves were answered with live ComfyUI generations — full results in `docs/unflatten-gate-findings.md`. Two of the answers overturned assumptions the plan document was built on, one of them about the plan's own account of the original spike.
+
+### Added
+
+- **Unflatten** (experimental). A captured layer is decomposed by `unflatten-qwen-layered` into `layers + 1` images and imported as N Photoshop layers, back to front, each scaled and aligned to the region the source was captured from, all inside one group named after that source. Every node in the graph is core ComfyUI. Three new model files totalling 28.1 GB, which share nothing with any existing preset — the largest single addition the Setup manifest has taken. About two minutes for four layers on a 12 GB card.
+
+  **Composition decides whether it works, not provenance.** The gate expected v0.19's result to repeat, that the model favours its own output over photographs. It does not. Crossing the two axes on matched pairs — the generated members made locally with the shipped Krea-2 stack — a generated close-up failed exactly as a photographed one did, and a photographed contained subject succeeded exactly as a generated one did. What predicts success is whether the picture has something standing in front of something else. The plan's premise needed correcting on the way: it recorded the original spike's source as one of OpenLayer's own generations, and the run history showed a stock photograph, so the spike was already the case the question was invented to test.
+
+  **640px with four layers is a measured optimum.** Two layers fuses distinct objects into a single plate — which is what the spike used, and why its background looked worse than the model deserved. Six pads the result with blank layers. And 1024 is not a quality/time trade-off worth exposing: on two seeds it separated about half as well as 640, left more layers empty, and cost three and a half times the wall time, so the graph fixes the resolution and the panel does not offer it.
+
+- **`unflatten` joins the MCP Agent Bridge** as the tenth bridged tool, on the same boundary as the other nine: an agent can set parameters and press the button, and cannot capture the source. Everything the gate found that constrains the tool is in the description an agent reads before running it.
+
+### Known limits, stated rather than worked around
+
+- **A close-up that fills the frame cannot be separated**, whatever it was made by, and the panel cannot detect it. Deciding whether a picture separated needs its alpha channel; nothing in a UXP panel can decode a PNG. Two cheap proxies were measured and both failed: file size cannot identify a blank plate (across 63 gate layers, blanks ran 201 KB–845 KB and populated ones 243 KB–2.3 MB, overlapping almost completely, because a blank plate carries RGB noise under a near-zero alpha that does not compress away), and the size ratio between the background layer and the composite does not separate the two outcomes either — an unseparated run sat at 0.972 while genuinely separated ones sat at 0.983 and 0.984. So it is stated in copy in three places instead of being guessed at in code.
+
+- **Layers come back at 640px and are softer than the original on a large document.** The decomposition is done at 640 on purpose; the layers are then scaled up to cover the region they came from. The fix is known and not in this release: use the model's alpha as a layer mask over the artist's own full-resolution pixels, which keeps the subject pixel-for-pixel and leaves only the matte edge soft.
+
+- **The layer count is a ceiling, not a promise.** A four-layer run can return two populated layers and two empty ones, varying with the seed. Empty layers are imported rather than skipped, because an unwanted empty layer is visible and one click to delete while a wrongly discarded faint layer is silent data loss.
+
+### Fixed
+
+- **The bridge's own smoke test had been asserting a stale tool list since v0.18.** It froze the eight tools by hand, never gained `style_reference` in v0.18 or `multi_reference` in v0.19, and so reported a failure on every run for two releases while still reading as a meaningful check. It now derives the expected list from `MCP_TOOLS` and cannot go stale again.
+
 ## v0.19.0-alpha - 2026-08-28
 
 This release adds Multi-Reference Composition: give the panel a list of captured layers instead of one, and it builds a single picture out of all of them. Before any of the screen was built, four questions about how the technique actually behaves were answered with 48 live ComfyUI generations, each run as a control/variant pair — full results in `docs/multi-reference-gate-findings.md`. Two of the four answers shrank the feature that got built; the third is the honest limit stated everywhere the tool is described.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ OpenLayer is an open-source Adobe Photoshop UXP plugin that connects Photoshop t
 
 ## Alpha Release
 
-`v0.19.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
+`v0.20.0-alpha` is the current public alpha checkpoint. It is intended for testing the core local workflows in Photoshop UXP, not for production work yet.
 
-New in `v0.19.0-alpha`:
+New in `v0.20.0-alpha`:
+
+- **Unflatten** (experimental). Hand the panel a flat layer and get the picture back as separate layers with real transparency, imported into your open document in stacking order, inside one group named after the source. A photograph of someone on a bench comes back as ground, bench and person, each cut out with its own alpha. Local, through ComfyUI, every node core. Nothing else in this space puts a decomposed layer stack into a host application, which is the point: a layered result is worth very little in a web UI and nearly nothing in a canvas app.
+
+  Runs on Qwen-Image-Layered. Three files, 28.1 GB, sharing nothing with any existing preset — the largest single addition the Setup screen has taken, and it lists all three with their folders. About two minutes for four layers on a 12 GB card.
+
+  Eight questions were answered with live generations before any of the screen was built, recorded in `docs/unflatten-gate-findings.md`, and two of the answers overturned assumptions the plan was built on. **The variable that decides whether this works is composition, not where the picture came from.** A generated close-up fails exactly as a photographed one does; a photographed subject standing clear of its background succeeds exactly as a generated one does. And **640px with four layers is a measured optimum rather than a round number** — 1024 separates roughly half as well, leaves more layers empty, and costs three and a half times the time, so it is not offered at all.
 
 - **Multi-Reference Composition** (experimental). Give the panel a list of captured Photoshop layers instead of one, and it builds a single image out of all of them — a background, a person, an object, however many you add. Add Active Layer or Add Canvas repeatedly to grow the list; each entry gets Up, Down, and Remove. Order is not cosmetic: the first reference sets the output canvas size, and moving an object earlier in the list is the fix if it comes back duplicated or distorted. Built on FLUX.2 Klein's own `ReferenceLatent` conditioning, chained once per reference onto both the positive and negative branches — every node is core ComfyUI, so it shares the Klein 4B stack the other Klein presets already need and downloads nothing extra.
 
@@ -161,9 +167,9 @@ The earlier card-based dashboard established OpenLayer's honest available/experi
 
 </details>
 
-v0.19.0-alpha tester focus:
+v0.20.0-alpha tester focus:
 
-- **Confirm the panel footer reads `v0.19.0`.** It read the wrong version for the whole of v0.14.0-alpha, so this is worth a glance before anything else.
+- **Confirm the panel footer reads `v0.20.0`.** It read the wrong version for the whole of v0.14.0-alpha, so this is worth a glance before anything else.
 - **Open Multi-Reference and add three or four layers**, one at a time, with Add Active Layer or Add Canvas. Confirm each row gets its own correct thumbnail — not a repeat of the previous one — and that the count reads "N of 8".
 - **Press Up or Down twice, fast.** A reference should move exactly one place per press, not two. Same for Remove: one press, one row gone.
 - **Compose from two references at a fixed seed, then reorder them and compose again at the same seed.** The result must change, and the output canvas size must follow whichever reference is now first — that is the one thing reference order is guaranteed to affect. If it comes back identical, the reorder is not reaching ComfyUI.
@@ -240,8 +246,11 @@ Also worth rechecking from v0.9.0-alpha:
 - Run `npm run setup-pack` and confirm it reports no source/API mismatches at all.
 - Recheck the existing local generation, cancel, preview, import, History, and Workflow Health paths for regressions.
 
-Known v0.19.0-alpha boundaries:
+Known v0.20.0-alpha boundaries:
 
+- **Unflatten needs a subject standing in front of a background.** A close-up that fills the frame has no front and back to find: it comes back with the picture unchanged on the background layer and empty layers above it. This is true of photographs and generated images alike — it is about the composition, not the source. The panel cannot detect this and say so, because deciding it needs the image's alpha channel and nothing in a UXP panel can decode a PNG; two cheap proxies were measured and both failed. So the limit is stated on the screen, in the tool description an agent reads, and here.
+- **Unflatten's layers come back at 640px on the long side**, so on a large document they are softer than the original. The decomposition itself is done at 640 because higher resolution measurably separates worse, but the layers are then scaled back up to cover the region they came from. A future version can avoid this by using the model's alpha as a layer mask over your own full-resolution pixels; it is not in this release.
+- **The number of layers you ask Unflatten for is a ceiling, not a promise.** A four-layer run may come back with two populated and two empty, and which is which varies with the seed. Empty layers are imported rather than skipped, deliberately: an unwanted empty layer is visible and one click to delete, while a wrongly discarded faint layer would be silent data loss.
 - **Multi-Reference Composition does not preserve a specific person's likeness.** It carries clothing, props, setting and lighting from a reference; a person's face comes back as a plausible stranger rather than the person photographed, confirmed against four real photographs and dozens of Klein-generated sources. Treat it as scene composition, not as a way to put someone recognisable into a picture.
 - **The reference list is capped at 8**, a sanity bound rather than a measured quality limit — testing found no reference count at which composition degraded, up to 6. Reference order matters more than count: an object that has to sit behind the other subjects is more likely to render cleanly if it comes earlier in the list.
 - **The Agent Bridge is not in the `.ccx`/`.zip` download.** A Photoshop plugin package cannot install or start a Node program, so it lives in the repository — see `bridge/README.md`. It is off by default in the panel either way. "Ask the Agent for a Prompt" additionally depends on your AI client supporting MCP *sampling*, which is optional in the protocol; a client that does not offer it gets a clear, instant refusal rather than the button working.
@@ -417,10 +426,10 @@ npm run package
 This creates a zip package from `dist` in the `packages` folder. For the current alpha, the expected package name is:
 
 ```text
-packages/openlayer-v0.19.0-alpha.zip
+packages/openlayer-v0.20.0-alpha.zip
 ```
 
-`npm run package` also writes `packages/openlayer-v0.19.0-alpha.ccx` beside it, from the same files.
+`npm run package` also writes `packages/openlayer-v0.20.0-alpha.ccx` beside it, from the same files.
 
 ## One-click install (verified 2026-08-03)
 
@@ -585,7 +594,7 @@ Inpaint output quality, mask interpretation, and Photoshop alignment are still b
 
 ## Pre-release Tester Checklist
 
-Use this quick pass before reporting a v0.19.0-alpha test result:
+Use this quick pass before reporting a v0.20.0-alpha test result:
 
 1. Start ComfyUI on `http://127.0.0.1:8190`.
 2. Build OpenLayer and load `dist/manifest.json` in Adobe UXP Developer Tool.

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer-mcp-bridge",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "description": "Lets an MCP client drive the OpenLayer Photoshop panel's existing tools",
   "license": "MIT",

--- a/docs/become-a-tester.html
+++ b/docs/become-a-tester.html
@@ -44,7 +44,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.19.0 &middot; testers wanted</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.20.0 &middot; testers wanted</p>
           <h1 id="hero-title">Five minutes to<br><span class="grad">your first AI layer.</span></h1>
           <p class="hero-lede">
             OpenLayer is an alpha. It works on the author's machine, and that is exactly the problem —
@@ -53,7 +53,7 @@
             and an honest report of where those five minutes went wrong.
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.19.0-alpha">Download v0.19.0-alpha</a>
+            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.20.0-alpha">Download v0.20.0-alpha</a>
             <a class="button button-secondary" href="https://github.com/MehranMarxian/OpenLayer/issues/new?template=tester_report.yml">Send a tester report</a>
           </div>
           <ul class="signal-list" aria-label="What testing costs you">
@@ -93,8 +93,8 @@
             <article class="setup-step">
               <span>1</span>
               <h3>Install OpenLayer</h3>
-              <p>Download <code>openlayer-v0.19.0-alpha.ccx</code> from the release and <strong>double-click it</strong>. Creative Cloud installs the panel — no developer tool, nothing to unzip. Creative Cloud will warn that the plugin is not verified by Adobe, because it is not from Adobe Exchange; that prompt is expected. Keep the file on the same drive as Photoshop. Then open Photoshop: <strong>Plugins &gt; OpenLayer</strong>.</p>
-              <p><strong>If double-clicking does nothing at all</strong> — a known Windows 11 quirk — the release also has <code>openlayer-v0.19.0-alpha.zip</code>, which loads through the <a href="https://developer.adobe.com/photoshop/uxp/2022/guides/devtool/">UXP Developer Tool</a>: <strong>Add Plugin</strong>, select the unzipped <code>manifest.json</code>, then <strong>Load</strong>. And if that is what you had to do, please say so in your report — the one-click path has only ever been verified on Windows 11 with Photoshop 2025.</p>
+              <p>Download <code>openlayer-v0.20.0-alpha.ccx</code> from the release and <strong>double-click it</strong>. Creative Cloud installs the panel — no developer tool, nothing to unzip. Creative Cloud will warn that the plugin is not verified by Adobe, because it is not from Adobe Exchange; that prompt is expected. Keep the file on the same drive as Photoshop. Then open Photoshop: <strong>Plugins &gt; OpenLayer</strong>.</p>
+              <p><strong>If double-clicking does nothing at all</strong> — a known Windows 11 quirk — the release also has <code>openlayer-v0.20.0-alpha.zip</code>, which loads through the <a href="https://developer.adobe.com/photoshop/uxp/2022/guides/devtool/">UXP Developer Tool</a>: <strong>Add Plugin</strong>, select the unzipped <code>manifest.json</code>, then <strong>Load</strong>. And if that is what you had to do, please say so in your report — the one-click path has only ever been verified on Windows 11 with Photoshop 2025.</p>
             </article>
             <article class="setup-step">
               <span>2</span>
@@ -194,7 +194,7 @@
             talk it through than file a report, the discussion board has a Setup Help category.
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.19.0-alpha">Download v0.19.0-alpha</a>
+            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.20.0-alpha">Download v0.20.0-alpha</a>
             <a class="button button-secondary" href="https://github.com/MehranMarxian/OpenLayer/discussions">Open discussions</a>
           </div>
         </div>
@@ -202,7 +202,7 @@
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.19.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.20.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="./">Overview</a> &middot;
         <a href="https://github.com/MehranMarxian/OpenLayer">GitHub</a> &middot;

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,10 +33,10 @@
       "operatingSystem": "Windows, macOS",
       "applicationCategory": "DesignApplication",
       "applicationSubCategory": "Adobe Photoshop plugin",
-      "softwareVersion": "0.19.0-alpha",
+      "softwareVersion": "0.20.0-alpha",
       "description": "Open-source Photoshop UXP plugin that connects to a local ComfyUI server for AI image generation: text to image, image to image, sketch to image, inpaint, outpaint, and upscale with Stable Diffusion, SDXL, and Flux models.",
       "url": "https://mehran-ahmadi.com/OpenLayer/",
-      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.19.0-alpha",
+      "downloadUrl": "https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.20.0-alpha",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Mehran Ahmadi", "url": "https://github.com/MehranMarxian" }
     }
@@ -66,7 +66,7 @@
     <main id="top">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.19.0 · free &amp; open source</p>
+          <p class="hero-badge"><span class="pulse-dot" aria-hidden="true"></span> Alpha v0.20.0 · free &amp; open source</p>
           <h1 id="hero-title">Local AI layers,<br><span class="grad">inside Photoshop.</span></h1>
           <p class="hero-lede">
             OpenLayer connects Photoshop to <strong>your own ComfyUI server</strong>.
@@ -75,7 +75,7 @@
             <strong>No cloud. No credits. No subscription.</strong>
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.19.0-alpha">Download alpha</a>
+            <a class="button button-primary" href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.20.0-alpha">Download alpha</a>
             <a class="button button-secondary" href="https://github.com/MehranMarxian/OpenLayer">Star on GitHub</a>
           </div>
           <ul class="signal-list" aria-label="Project signals">
@@ -329,7 +329,7 @@
             <article class="setup-step">
               <span>1</span>
               <h3>Download and double-click</h3>
-              <p>Grab <code>openlayer-v0.19.0-alpha.ccx</code> from the <a href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.19.0-alpha">latest release</a> and double-click it. Creative Cloud installs the panel — no developer tools, nothing to build.</p>
+              <p>Grab <code>openlayer-v0.20.0-alpha.ccx</code> from the <a href="https://github.com/MehranMarxian/OpenLayer/releases/tag/v0.20.0-alpha">latest release</a> and double-click it. Creative Cloud installs the panel — no developer tools, nothing to build.</p>
             </article>
             <article class="setup-step">
               <span>2</span>
@@ -373,7 +373,7 @@
             </article>
             <article class="status-card">
               <h3>Testing alpha</h3>
-              <p>OpenLayer v0.19.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
+              <p>OpenLayer v0.20.0-alpha is for local testing and feedback. It is not production-ready yet.</p>
             </article>
             <article class="status-card">
               <h3>Multi-Reference composes; it does not preserve likeness</h3>
@@ -381,7 +381,7 @@
             </article>
             <article class="status-card">
               <h3>Inpaint is experimental</h3>
-              <p>v0.19.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
+              <p>v0.20.0 retains the upload and alignment fixes while output quality across checkpoints continues to be validated by testers.</p>
             </article>
             <article class="status-card">
               <h3>Flux Fill is experimental</h3>
@@ -404,7 +404,7 @@
               <li>Inpaint and Outpaint should be tested on duplicate layers first.</li>
               <li>Prompt from Layer requires the local Florence-2 PromptGen model and the comfyui-florence2 nodes. The custom-scripts pack is no longer needed.</li>
               <li>Upscale uses pixel/model upscale only. Generative upscale, tiled diffusion, and creative enhancement are future work.</li>
-              <li>Custom workflow import, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.19.0 keeps the shared metadata foundation and session-history wiring.</li>
+              <li>Custom workflow import, batch variants, and true persistent Photoshop AI layer metadata are future work. v0.20.0 keeps the shared metadata foundation and session-history wiring.</li>
               <li>The LoRA list cannot be filtered by which model a LoRA suits: ComfyUI reports only a name and size. Entries are labelled from their filenames and likely matches sorted first, but a mismatched LoRA loads without error and quietly does nothing.</li>
               <li>CI does not run Photoshop, UXP, or ComfyUI integration tests.</li>
               <li>Live sampler previews require ComfyUI to be started with <code>--preview-method auto</code>.</li>
@@ -498,7 +498,7 @@
     </main>
 
     <footer class="site-footer">
-      <p>OpenLayer v0.19.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
+      <p>OpenLayer v0.20.0-alpha. Developed by Mehran Ahmadi, 2026.</p>
       <p>
         <a href="https://github.com/MehranMarxian">GitHub</a> &middot;
         <a href="./privacy.html">Privacy Policy</a> &middot;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlayer",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlayer",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlayer",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "description": "Local AI layers for Photoshop",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "1e827d3d",
   "name": "OpenLayer",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "main": "index.html",
   "host": [
     {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -4968,7 +4968,7 @@ export function renderApp(rootElement: HTMLElement) {
       setUnflattenStatus(elements, `Returned ${layerCount} layers.`, "ready");
       setUnflattenDiagnostics(
         elements,
-        `${layerCount} layers plus the reassembled picture. If the layers look empty, the source was too close-up to separate. Seed used: ${buildResult.seed}. Workflow: ${buildResult.preset.id}.`
+        `${layerCount} layers plus the reassembled picture. Some may be empty -- the count is a ceiling, and a close-up cannot be separated at all. Seed used: ${buildResult.seed}. Workflow: ${buildResult.preset.id}.`
       );
     } catch (caughtError) {
       if (isGenerationCancelledError(caughtError)) {

--- a/src/ui/appConstants.ts
+++ b/src/ui/appConstants.ts
@@ -1,7 +1,7 @@
 import { OpenLayerTheme } from "../utils/preferences";
 
 export const DEFAULT_SERVER_URL = "http://127.0.0.1:8190";
-export const APP_VERSION = "0.19.0";
+export const APP_VERSION = "0.20.0";
 export const DEVELOPER_GITHUB = "https://github.com/MehranMarxian";
 export const HISTORY_LIMIT = 5;
 export const COMFY_PORT_CANDIDATES = [8190, 8188, 8189, 8191, 8192, 8193, 7860];

--- a/src/ui/appMarkup.ts
+++ b/src/ui/appMarkup.ts
@@ -1281,7 +1281,7 @@ export function createAppMarkup() {
           <div class="field img2img-field">
             <span class="label">Description${createPromptWalletControlsMarkup("unflatten-prompt")}</span>
             <textarea maxlength="10000" class="textarea compact-textarea" id="unflatten-prompt" placeholder="Describe what is already in the picture..."></textarea>
-            <div class="diagnostics-line unflatten-hint" id="unflatten-prompt-hint">Describe what is already there, not what you want changed. Needs a picture with something standing in front of something else -- a close-up that fills the frame comes back unseparated.</div>
+            <div class="diagnostics-line unflatten-hint" id="unflatten-prompt-hint">Describe what is already there, not what you want changed. Needs a picture with something standing in front of something else -- a close-up that fills the frame comes back unseparated. Layers come back at 640px, so they are softer than the original on a large document.</div>
           </div>
           <div class="field img2img-field">
             <span class="label">Workflow</span>


### PR DESCRIPTION
Task 7 from `docs/unflatten-v0.20.0.md`. Validation green: typecheck, 1003 tests, build,
eslint, setup-pack at 0.20.0.

**Acceptance — "no claim in the README, the CHANGELOG or the panel that the gate findings do
not support"** — audited, and one claim failed the audit (below).

## The limits, in the three places the house pattern requires

| | Says |
|---|---|
| **Subtitle** | "Split a flat layer into separate layers" — deliberately does not promise transparency or *any* layer |
| **On screen** | Needs something standing in front of something else; a close-up comes back unseparated; layers return at 640px and are softer on a large document |
| **MCP description** | All of the above, plus that the layer count is a ceiling and some layers may be empty |

The 640px limit is **new to the copy**. It was going to be fixed rather than described; since
we deferred that, a limit that ships has to be visible whether or not it's fixed later.

## One claim that didn't survive its own findings

The post-run message read *"if the layers look empty, the source was too close-up to
separate."* Only half true — Q7 found the layer count is a ceiling on **any** source and
which layers fill varies with the seed, so a perfectly good picture returns empty layers too.
It now says both. Blaming the artist's choice of picture for a property of the model is the
kind of small wrongness that costs someone an hour.

## README and CHANGELOG

Both carry the two findings that overturned the plan — composition rather than provenance
decides whether this works, and 640×4 is a measured optimum — and all three known limits
*with the measurements behind them*, including the two proxies that were tried and failed
(file size for blank plates; the background/composite ratio for no-separation).

The CHANGELOG also records the smoke test that had been red since v0.18.

## Version bump

**The consistency test knows about eight places, not the four in my notes**: both root fields
of `package-lock.json`, `docs/index.html`, `docs/become-a-tester.html`, and README's
checkpoint line and package filenames, besides the four manifests. It caught every one I'd
have missed. Verified in the rendered panel that the footer reads `v0.20.0` — the first item
on the tester checklist, because it was wrong for all of v0.14.

## Smoke checklist

1. Panel footer reads **v0.20.0**.
2. Unflatten screen → the hint under Description reads in full and now ends "...softer than
   the original on a large document." Four to five lines, not truncated.
3. Run one decomposition → the status diagnostics mentions both that some layers may be empty
   *and* that a close-up cannot be separated.
4. Home card subtitle still reads "Split a flat layer into separate layers".

## What's left in the release

Task 8, the recording — yours. The mitigation from earlier stands: shoot on a source near
640px on the long side so the upscale is invisible, and pick a run whose layers all came back
populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
