### PR TITLE
Fix: leave out a layer the stack already holds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,33 @@ anything at all.
   system calls it that — rendering it as "12.9 GB" would be arithmetically defensible and read as a
   bug.
 
+- **Unflatten imported the same subject two and three times over.** A four-layer run on a photograph
+  came back as three near-identical masks of one person: `Layer 4` sat 87.5% inside `Layer 3`. No
+  existing rule could have caught it, because every rule up to now judged a plate on its own — how
+  much of it is solid, how flat it is, how much of the frame it covers — and three layers all showing
+  the same person pass every one of those individually. Redundancy is a relationship *between*
+  layers.
+
+  A plate is now compared against the cut-outs already placed and left out if it is mostly inside one
+  of them. Worst containment within a run, measured across five sources: bench 5.7%, balloon 23.0%,
+  large-subject 53.0%, cat 99.8%, poster 100%. A clean decomposition puts different things on
+  different layers so its plates barely touch; a failed one hands the same content back twice. The
+  ceiling sits at 75%, above every good run measured and below every bad one.
+
+  The first version of the rule compared against *everything* already placed, including the
+  background — which covers the whole frame, so every later plate is 100% "inside" it. Replaying it
+  over nine recorded runs before touching Photoshop found it dropping all three layers of the
+  cleanest decomposition on file. Backgrounds are excluded, and that trap has its own test.
+
+- **A masking fall-back that would not say why it fell back.** When no layer can be built from the
+  artist's own pixels the import drops to the model's plates, which is the right behaviour — a host
+  that refuses one descriptor should not cost someone a decomposition they waited two minutes for.
+  But it did so through a bare `catch` that discarded the error, so a real report of "Built from the
+  model's pixels" had two possible causes with opposite fixes and no way to tell them apart. Three
+  outcomes that were indistinguishable from outside are now distinct: a background legitimately
+  keeping the model's pixels, a cut-out with nothing captured to mask against, and a masking step the
+  host refused, which now carries the error it caught into the diagnostics line.
+
 ## v0.20.0-alpha - 2026-08-30
 
 This release adds Unflatten: hand the panel a flat layer and get the picture back as separate layers with real transparency, imported into the open document in stacking order. Nothing else in this space puts a decomposed layer stack into a host application, and that is the whole point of building it here rather than anywhere else.

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -1374,6 +1374,17 @@ export type UnflattenLayerStackImportResult = {
   skippedBlankLayerCount: number;
   /** Plates left out because a layer already placed already held them. */
   skippedRedundantLayerCount: number;
+  /**
+   * Why no layer could be built from the artist's own pixels, when none was.
+   *
+   * The masking path is written to fail soft: a host that refuses one of its
+   * steps drops to the model's own plates rather than losing a decomposition
+   * someone waited two minutes for. Failing soft was right and failing
+   * *silently* was not -- it turned one real report into an investigation with
+   * two candidate causes and no way to tell them apart. The reason now travels
+   * back with the result.
+   */
+  fallbackReason?: string;
 };
 
 /**
@@ -1457,6 +1468,7 @@ export async function importUnflattenLayerStack(
     let sourcePixelLayerCount = 0;
     let skippedBlankLayerCount = 0;
     let skippedRedundantLayerCount = 0;
+    let fallbackReason: string | undefined;
 
     await photoshop.core.executeAsModal(
       async (executionContext) => {
@@ -1492,12 +1504,16 @@ export async function importUnflattenLayerStack(
 
             options.onProgress?.(`Placing ${placement.layerName}...`);
 
-            const { outcome, solidMask } = await placeDecomposedPlate(photoshop, {
+            const { outcome, solidMask, reason } = await placeDecomposedPlate(photoshop, {
               modelToken: tokens[placement.depth - 1],
               sourceToken,
               targetBounds: options.targetBounds,
               placedMasks
             });
+
+            // The first one is enough. Every plate in a run hits the same wall,
+            // so repeating it once per layer would bury the message it explains.
+            fallbackReason ??= reason;
 
             if (outcome === "skipped") {
               // A plate holding nothing, or holding a flat fill and no picture.
@@ -1593,7 +1609,8 @@ export async function importUnflattenLayerStack(
       layerNames,
       sourcePixelLayerCount,
       skippedBlankLayerCount,
-      skippedRedundantLayerCount
+      skippedRedundantLayerCount,
+      fallbackReason
     };
   } catch (caughtError) {
     throw createOpenLayerError(
@@ -1663,6 +1680,7 @@ async function placeDecomposedPlate(
 ): Promise<{
   outcome: "masked" | "model" | "skipped" | "redundant" | "unavailable";
   solidMask?: Uint8Array;
+  reason?: string;
 }> {
   let plateLayerId: number | undefined;
   let sourceLayerId: number | undefined;
@@ -1695,14 +1713,25 @@ async function placeDecomposedPlate(
       return { outcome: "redundant" };
     }
 
-    // A background, or a run with no source to mask against. Either way the
-    // plate as placed already is the layer.
-    if (kind === "full-frame" || options.sourceToken === undefined) {
-      // A background is deliberately not offered for comparison. It covers the
-      // whole frame, so every later plate is entirely "inside" it and the
-      // redundancy check would drop the whole stack -- which is exactly what
-      // the first version of this did before it was replayed over real runs.
-      return { outcome: "model", solidMask: kind === "cutout" ? solidMask : undefined };
+    // A background keeps the model's pixels because it holds what was invented
+    // behind the subject, which the source does not have. It is also
+    // deliberately not offered for comparison: it covers the whole frame, so
+    // every later plate would count as entirely "inside" it and the redundancy
+    // check would drop the whole stack -- which is what the first version of
+    // that rule did before it was replayed over recorded runs.
+    if (kind === "full-frame") {
+      return { outcome: "model" };
+    }
+
+    // A cut-out that cannot be masked because nothing was captured to mask
+    // with. Reported rather than silently downgraded: it looks identical to a
+    // refused descriptor from the outside and has a completely different fix.
+    if (options.sourceToken === undefined) {
+      return {
+        outcome: "model",
+        solidMask,
+        reason: "the captured source never reached the import, so there was nothing to mask with"
+      };
     }
 
     // Placed above the plate, and placed now, because after the selection
@@ -1726,7 +1755,7 @@ async function placeDecomposedPlate(
     await deselectActiveSelection(photoshop);
 
     return { outcome: "masked", solidMask };
-  } catch {
+  } catch (caughtError) {
     // Leave nothing behind: the caller is about to place this plate plainly.
     if (sourceLayerId !== undefined) {
       await deleteLayerById(photoshop, sourceLayerId, true);
@@ -1742,7 +1771,7 @@ async function placeDecomposedPlate(
       // A selection that will not clear is not worth failing the import over.
     }
 
-    return { outcome: "unavailable" };
+    return { outcome: "unavailable", reason: `Photoshop refused a masking step: ${getErrorMessage(caughtError)}` };
   }
 }
 

--- a/src/photoshop/photoshopAdapter.ts
+++ b/src/photoshop/photoshopAdapter.ts
@@ -6,6 +6,8 @@ import { OutpaintExpansionPlan } from "./outpaintExpansion";
 import { UpscaleResizePlan } from "./upscaleResize";
 import {
   classifyPlateSample,
+  isPlateRedundant,
+  PlateKind,
   planLayerScale,
   planUnflattenLayerStack,
   stackLayerNames,
@@ -1370,6 +1372,8 @@ export type UnflattenLayerStackImportResult = {
   sourcePixelLayerCount: number;
   /** Plates that carried no matte at all and were left out. */
   skippedBlankLayerCount: number;
+  /** Plates left out because a layer already placed already held them. */
+  skippedRedundantLayerCount: number;
 };
 
 /**
@@ -1452,6 +1456,7 @@ export async function importUnflattenLayerStack(
     const layerNames: string[] = [];
     let sourcePixelLayerCount = 0;
     let skippedBlankLayerCount = 0;
+    let skippedRedundantLayerCount = 0;
 
     await photoshop.core.executeAsModal(
       async (executionContext) => {
@@ -1471,6 +1476,10 @@ export async function importUnflattenLayerStack(
           : null;
 
         const placedLayerIds: number[] = [];
+        // The sampled shape of every layer already down, so the next plate can
+        // be asked whether it adds anything. Redundancy is a relationship
+        // between layers and cannot be seen one plate at a time.
+        const placedMasks: Uint8Array[] = [];
         let operationError: unknown;
 
         try {
@@ -1483,10 +1492,11 @@ export async function importUnflattenLayerStack(
 
             options.onProgress?.(`Placing ${placement.layerName}...`);
 
-            const outcome = await placeDecomposedPlate(photoshop, {
+            const { outcome, solidMask } = await placeDecomposedPlate(photoshop, {
               modelToken: tokens[placement.depth - 1],
               sourceToken,
-              targetBounds: options.targetBounds
+              targetBounds: options.targetBounds,
+              placedMasks
             });
 
             if (outcome === "skipped") {
@@ -1494,6 +1504,19 @@ export async function importUnflattenLayerStack(
               // Either way there is no layer in it.
               skippedBlankLayerCount += 1;
               continue;
+            }
+
+            if (outcome === "redundant") {
+              // Everything in it is already on a layer below. Importing it
+              // gives the artist the same content twice.
+              skippedRedundantLayerCount += 1;
+              continue;
+            }
+
+            // Only cut-outs are worth comparing against; see the note in
+            // placeDecomposedPlate about why a background must never join this.
+            if (solidMask) {
+              placedMasks.push(solidMask);
             }
 
             if (outcome === "unavailable") {
@@ -1565,7 +1588,13 @@ export async function importUnflattenLayerStack(
     );
 
     options.onProgress?.(`Imported ${layerNames.length} layers into ${plan.groupName}.`);
-    return { groupName: plan.groupName, layerNames, sourcePixelLayerCount, skippedBlankLayerCount };
+    return {
+      groupName: plan.groupName,
+      layerNames,
+      sourcePixelLayerCount,
+      skippedBlankLayerCount,
+      skippedRedundantLayerCount
+    };
   } catch (caughtError) {
     throw createOpenLayerError(
       "PHOTOSHOP_IMPORT_FAILED",
@@ -1629,8 +1658,12 @@ async function placeDecomposedPlate(
     modelToken: string;
     sourceToken?: string;
     targetBounds?: NormalizedSelectionBounds;
+    placedMasks: readonly Uint8Array[];
   }
-): Promise<"masked" | "model" | "skipped" | "unavailable"> {
+): Promise<{
+  outcome: "masked" | "model" | "skipped" | "redundant" | "unavailable";
+  solidMask?: Uint8Array;
+}> {
   let plateLayerId: number | undefined;
   let sourceLayerId: number | undefined;
 
@@ -1644,18 +1677,32 @@ async function placeDecomposedPlate(
 
     await fitActiveLayerToBounds(photoshop, options.targetBounds);
 
-    const kind = await classifyPlacedPlate(photoshop, plateLayerId);
+    const { kind, solidMask } = await classifyPlacedPlate(photoshop, plateLayerId);
 
     if (kind === "blank" || kind === "flat-fill") {
       await deleteLayerById(photoshop, plateLayerId, true);
 
-      return "skipped";
+      return { outcome: "skipped" };
+    }
+
+    // Checked before anything is built from it. A plate whose content is
+    // already on a layer below is not a layer, it is the same layer again --
+    // which is what a stack of three near-identical masks of one subject
+    // actually was.
+    if (solidMask && isPlateRedundant(solidMask, options.placedMasks)) {
+      await deleteLayerById(photoshop, plateLayerId, true);
+
+      return { outcome: "redundant" };
     }
 
     // A background, or a run with no source to mask against. Either way the
     // plate as placed already is the layer.
     if (kind === "full-frame" || options.sourceToken === undefined) {
-      return "model";
+      // A background is deliberately not offered for comparison. It covers the
+      // whole frame, so every later plate is entirely "inside" it and the
+      // redundancy check would drop the whole stack -- which is exactly what
+      // the first version of this did before it was replayed over real runs.
+      return { outcome: "model", solidMask: kind === "cutout" ? solidMask : undefined };
     }
 
     // Placed above the plate, and placed now, because after the selection
@@ -1678,7 +1725,7 @@ async function placeDecomposedPlate(
     await addLayerMaskFromSelection(photoshop);
     await deselectActiveSelection(photoshop);
 
-    return "masked";
+    return { outcome: "masked", solidMask };
   } catch {
     // Leave nothing behind: the caller is about to place this plate plainly.
     if (sourceLayerId !== undefined) {
@@ -1695,7 +1742,7 @@ async function placeDecomposedPlate(
       // A selection that will not clear is not worth failing the import over.
     }
 
-    return "unavailable";
+    return { outcome: "unavailable" };
   }
 }
 
@@ -1708,12 +1755,15 @@ async function placeDecomposedPlate(
  * layer -- because importing something empty is a visible nuisance while
  * dropping something real is silent data loss.
  */
-async function classifyPlacedPlate(photoshop: PhotoshopModule, plateLayerId: number) {
+async function classifyPlacedPlate(
+  photoshop: PhotoshopModule,
+  plateLayerId: number
+): Promise<{ kind: PlateKind; solidMask?: Uint8Array }> {
   const imaging = photoshop.imaging;
   const documentId = getActiveDocument().id;
 
   if (!imaging?.getPixels || typeof documentId !== "number") {
-    return "cutout" as const;
+    return { kind: "cutout" };
   }
 
   let imageData: PhotoshopImageData | undefined;
@@ -1731,14 +1781,17 @@ async function classifyPlacedPlate(photoshop: PhotoshopModule, plateLayerId: num
     });
     imageData = pixels.imageData;
 
-    if (!imageData) return "cutout" as const;
+    if (!imageData) return { kind: "cutout" };
 
     const components = Number(imageData.components ?? 4);
     const raw = toUint8Array(await readImageDataBytes(imageData));
 
-    return classifyPlateSample(measurePlateSample(raw, components));
+    return {
+      kind: classifyPlateSample(measurePlateSample(raw, components)),
+      solidMask: extractSolidMask(raw, components)
+    };
   } catch {
-    return "cutout" as const;
+    return { kind: "cutout" };
   } finally {
     imageData?.dispose?.();
   }
@@ -1751,6 +1804,25 @@ async function classifyPlacedPlate(photoshop: PhotoshopModule, plateLayerId: num
  * whether a layer reaches the artist's document, and it is the one part of the
  * read that can be checked without Photoshop.
  */
+/**
+ * One byte per sampled pixel, non-zero where the plate is at least half opaque.
+ *
+ * The same floor `measurePlateSample` counts with, so "how much of this plate
+ * is solid" and "which parts of it are solid" can never disagree.
+ */
+export function extractSolidMask(raw: Uint8Array, components: number): Uint8Array {
+  const hasAlpha = components >= 4;
+  const pixelCount = components > 0 ? Math.floor(raw.length / components) : 0;
+  const mask = new Uint8Array(pixelCount);
+
+  for (let pixel = 0; pixel < pixelCount; pixel += 1) {
+    const alpha = hasAlpha ? raw[pixel * components + components - 1] : 255;
+    mask[pixel] = alpha >= PLATE_SOLID_ALPHA_FLOOR ? 1 : 0;
+  }
+
+  return mask;
+}
+
 export function measurePlateSample(raw: Uint8Array, components: number) {
   const hasAlpha = components >= 4;
   const pixelCount = components > 0 ? Math.floor(raw.length / components) : 0;

--- a/src/photoshop/unflattenLayerStack.ts
+++ b/src/photoshop/unflattenLayerStack.ts
@@ -171,6 +171,54 @@ export function classifyPlateSample(sample: PlateSample): PlateKind {
   return "cutout";
 }
 
+/**
+ * How much of one plate sits inside another, as a fraction of the first, 0-1.
+ *
+ * Both masks are the same downsampled grid, one byte per pixel, non-zero where
+ * the plate is at least half opaque. Comparing them is the cheapest question
+ * that can be asked about two layers and it turns out to be the sharpest.
+ */
+export function containmentFraction(candidate: Uint8Array, placed: Uint8Array): number {
+  const length = Math.min(candidate.length, placed.length);
+  let candidateSolid = 0;
+  let shared = 0;
+
+  for (let index = 0; index < length; index += 1) {
+    if (!candidate[index]) continue;
+    candidateSolid += 1;
+    if (placed[index]) shared += 1;
+  }
+
+  return candidateSolid === 0 ? 0 : shared / candidateSolid;
+}
+
+/**
+ * A plate mostly inside one already placed adds nothing but confusion.
+ *
+ * This is the rule that explains what "bad results" actually looked like.
+ * Every earlier rule judged a plate on its own -- how much of it was solid, how
+ * flat, how much of the frame it covered -- and a stack of three layers all
+ * showing the same person passes every one of those individually. Redundancy is
+ * a relationship between layers, so it cannot be seen one plate at a time.
+ *
+ * Measured across five sources, worst containment within a run:
+ *
+ *   bench 5.7%   balloon 23.0%   large-subject 53.0%   cat 99.8%   poster 100%
+ *
+ * A clean decomposition puts different things on different layers, so its
+ * plates barely touch. A failed one hands back the same content twice. The
+ * ceiling sits above every good run measured and far below every bad one.
+ */
+export const PLATE_REDUNDANT_CONTAINMENT_CEILING = 0.75;
+
+export function isPlateRedundant(
+  candidate: Uint8Array,
+  placed: readonly Uint8Array[],
+  ceiling: number = PLATE_REDUNDANT_CONTAINMENT_CEILING
+): boolean {
+  return placed.some((mask) => containmentFraction(candidate, mask) > ceiling);
+}
+
 export type LayerScalePlan = Readonly<{
   horizontalPercent: number;
   verticalPercent: number;

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -5120,6 +5120,9 @@ export function renderApp(rootElement: HTMLElement) {
             : " Built from the model's pixels.") +
           (imported.skippedBlankLayerCount > 0
             ? ` ${imported.skippedBlankLayerCount} came back empty and were left out.`
+            : "") +
+          (imported.skippedRedundantLayerCount > 0
+            ? ` ${imported.skippedRedundantLayerCount} repeated a layer below and were left out.`
             : "")
       );
     } catch (caughtError) {

--- a/src/ui/App.ts
+++ b/src/ui/App.ts
@@ -5117,7 +5117,7 @@ export function renderApp(rootElement: HTMLElement) {
         `Group created: ${imported.groupName}. Layers, back to front: ${imported.layerNames.join(", ")}.` +
           (imported.sourcePixelLayerCount > 0
             ? ` ${imported.sourcePixelLayerCount} built from your own pixels, masked.`
-            : " Built from the model's pixels.") +
+            : ` Built from the model's pixels${imported.fallbackReason ? ` -- ${imported.fallbackReason}` : ""}.`) +
           (imported.skippedBlankLayerCount > 0
             ? ` ${imported.skippedBlankLayerCount} came back empty and were left out.`
             : "") +

--- a/tests/photoshop/measurePlateSample.test.ts
+++ b/tests/photoshop/measurePlateSample.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { measurePlateSample } from "../../src/photoshop/photoshopAdapter";
-import { classifyPlateSample } from "../../src/photoshop/unflattenLayerStack";
+import { extractSolidMask, measurePlateSample } from "../../src/photoshop/photoshopAdapter";
+import {
+  classifyPlateSample,
+  containmentFraction,
+  isPlateRedundant,
+  PLATE_REDUNDANT_CONTAINMENT_CEILING
+} from "../../src/photoshop/unflattenLayerStack";
 
 /** Builds interleaved RGBA bytes the way the imaging API hands them over. */
 function rgba(pixels: readonly [number, number, number, number][]) {
@@ -106,5 +111,74 @@ describe("measurePlateSample", () => {
     expect(classifyPlateSample(flatFill)).toBe("flat-fill");
     expect(classifyPlateSample(background)).toBe("full-frame");
     expect(classifyPlateSample(cutout)).toBe("cutout");
+  });
+});
+
+describe("extractSolidMask and containment", () => {
+  it("marks exactly the pixels measurePlateSample counts as solid", () => {
+    const raw = rgba([
+      [0, 0, 0, 0],
+      [9, 9, 9, 127],
+      [9, 9, 9, 128],
+      [9, 9, 9, 255]
+    ]);
+
+    // The two functions share a floor, so "how much is solid" and "which parts
+    // are solid" can never disagree.
+    expect([...extractSolidMask(raw, 4)]).toEqual([0, 0, 1, 1]);
+    expect(measurePlateSample(raw, 4).solidFraction).toBeCloseTo(0.5, 5);
+  });
+
+  it("reports how much of a plate sits inside another", () => {
+    const candidate = Uint8Array.from([1, 1, 1, 1, 0, 0]);
+    const half = Uint8Array.from([1, 1, 0, 0, 1, 1]);
+    const all = Uint8Array.from([1, 1, 1, 1, 1, 1]);
+
+    expect(containmentFraction(candidate, half)).toBeCloseTo(0.5, 5);
+    expect(containmentFraction(candidate, all)).toBe(1);
+    expect(containmentFraction(Uint8Array.from([0, 0]), all)).toBe(0);
+  });
+
+  it("drops a plate the stack already holds, and keeps one that adds something", () => {
+    const placed = [Uint8Array.from([1, 1, 1, 1, 1, 1, 1, 1, 0, 0])];
+    // 90% inside what is already down: the shape of the layer that arrived as a
+    // third near-identical mask of the same person.
+    const repeat = Uint8Array.from([1, 1, 1, 1, 1, 1, 1, 1, 1, 0]);
+    // Half of it is new, which is what a real second layer looks like.
+    const distinct = Uint8Array.from([1, 1, 0, 0, 0, 0, 0, 0, 1, 1]);
+
+    expect(isPlateRedundant(repeat, placed)).toBe(true);
+    expect(isPlateRedundant(distinct, placed)).toBe(false);
+  });
+
+  it("sits above every good run measured and below every bad one", () => {
+    // Worst containment within a run, measured across five sources:
+    //   bench 5.7%  balloon 23.0%  large-subject 53.0%  cat 99.8%  poster 100%
+    const good = [0.057, 0.23, 0.53];
+    const bad = [0.875, 0.998, 1];
+
+    for (const value of good) expect(value).toBeLessThan(PLATE_REDUNDANT_CONTAINMENT_CEILING);
+    for (const value of bad) expect(value).toBeGreaterThan(PLATE_REDUNDANT_CONTAINMENT_CEILING);
+  });
+});
+
+describe("the background must never join the comparison set", () => {
+  it("would swallow every later plate, because it covers the whole frame", () => {
+    const background = Uint8Array.from([1, 1, 1, 1, 1, 1, 1, 1]);
+    const subject = Uint8Array.from([0, 0, 1, 1, 0, 0, 0, 0]);
+    const bench = Uint8Array.from([1, 1, 0, 0, 0, 0, 0, 0]);
+
+    // Everything is inside a full-frame plate by definition, so comparing
+    // against one reports every real layer as redundant. Replaying the rule
+    // over nine recorded runs is what caught this: it dropped all three layers
+    // of the cleanest decomposition measured.
+    expect(containmentFraction(subject, background)).toBe(1);
+    expect(containmentFraction(bench, background)).toBe(1);
+    expect(isPlateRedundant(subject, [background])).toBe(true);
+
+    // Against each other, which is the comparison that means something, they
+    // are plainly different layers.
+    expect(isPlateRedundant(subject, [bench])).toBe(false);
+    expect(isPlateRedundant(bench, [subject])).toBe(false);
   });
 });


### PR DESCRIPTION
Import-class, so **this needs your smoke test.** 1027 tests, typecheck, build, eslint green.

## What "bad results" actually was

Your 4-layer bench run imported **three masks of the same person**. `Layer 4` sat **87.5% inside** `Layer 3`.

Nothing was wrong with any single layer — every plate measured between 7% and 43% coverage, comfortably legitimate. That's why no existing rule caught it: **every rule so far judges a plate in isolation, and redundancy is a relationship between layers.**

## The rule

Before a plate is built, it's compared against the cut-outs already placed. If it's mostly inside one of them, it adds nothing and is left out.

Worst containment within a run, measured across five sources:

| bench | balloon | large-subject | your run | cat | poster |
|---|---|---|---|---|---|
| **5.7%** | **23.0%** | 53.0% | **87.5%** | **99.8%** | **100%** |

A clean decomposition puts different things on different layers, so its plates barely touch. A failed one hands the same content back twice. Ceiling at 75%, above every good run and below every bad one — a far wider gap than any of the three rules retired here previously had.

## The bug the replay caught

The first version compared against **everything** placed, including the background. A background covers the whole frame, so every later plate is 100% "inside" it.

I replayed the rule over all nine recorded runs before touching Photoshop, and it **dropped all three layers of the cleanest decomposition on file.** The background is now excluded, and that trap has its own test.

That replay is the reason this isn't the fourth rule to be retired here.

## One limit left standing

This drops a plate that repeats one **already placed**, not one later swallowed by a plate **above** it. The close-up failure has that shape — its small plate is 100% inside the larger one that follows. Catching it would mean deleting a layer already in your document mid-import; close-ups are already documented as unsupported, so that trade isn't worth the extra mutation.

## Simulated effect on your runs

| Run | Before | After |
|---|---|---|
| GOOD-bench | 3 | **3** unchanged |
| GOOD-balloon | 4 | **4** unchanged |
| RISK large subject | 4 | **4** unchanged |
| Snowden poster | 4 | **3** — drops the duplicate |
| Poster scans | 3, 4 | **2, 3** — drops the duplicate |

## Second commit: the fallback now says why

Your last successful run reported **"Built from the model's pixels"** — meaning not one layer was masked from your own. There are exactly two ways that happens: the captured source never reached the import, or Photoshop refused one of the masking steps. Opposite fixes, and **the code threw the evidence away** — a bare `catch` that returned "unavailable" and discarded the error.

Failing soft there was right: a refused descriptor shouldn't cost you a decomposition you waited two minutes for. Failing *silently* was not.

Three outcomes that were indistinguishable from outside are now distinct:

| | Reported as |
|---|---|
| A background legitimately keeping the model's pixels | nothing — this is correct and expected |
| A cut-out with nothing captured to mask against | "the captured source never reached the import…" |
| A masking step the host refused | "Photoshop refused a masking step: `<the actual error>`" |

The first reason found travels back with the result and into the diagnostics line — first only, because every plate in a run hits the same wall and repeating it per layer would bury it.

## Smoke checklist

1. Capture `output/gate-sources/P2-crop-large.jpg`, Unflatten at **4 layers, seed 777** — the exact run you imported yesterday.
2. **Import to Layers.**
3. Expect **3 layers, not 4.** The redundant near-copy of the person should be gone.
4. Diagnostics should end with **"1 repeated a layer below and were left out."**
5. Re-run the balloon at 4 layers — it should be **unchanged**, since nothing in it is redundant. That's the regression check that matters.
6. `Ctrl+Z` once still removes the whole group.
7. If any run again says **"Built from the model's pixels"**, read what follows the `--`. That sentence is the answer to yesterday's question, and it's the one thing I still can't determine from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

